### PR TITLE
chore(auth): add Google OAuth env vars to .env.example and README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,10 @@ JWT_SECRET="change-me-in-production"
 NODE_ENV="development"
 
 # ─── Auth (Slice 2) ────────────────────────────────────────────────────────────
-# GOOGLE_CLIENT_ID=
-# GOOGLE_CLIENT_SECRET=
+# Google OAuth — server-side (web client)
+GOOGLE_CLIENT_ID=967542660167-dhm3mjldvtlm6l4igd6ueq2cvft090u8.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=fakesecret
+
+# Google OAuth — mobile public client IDs (no secret; safe to expose in app)
+GOOGLE_IOS_CLIENT_ID=967542660167-ircfnmum03iap9fefa7o6nutgbsubf51.apps.googleusercontent.com
+GOOGLE_ANDROID_CLIENT_ID=TODO

--- a/README.md
+++ b/README.md
@@ -156,7 +156,10 @@ npm install
 
 # Create your local env file from the root template (single file for all apps)
 cp .env.example .env
-# Edit .env and set DATABASE_URL, JWT_SECRET, etc.
+# Edit .env — required: DATABASE_URL, JWT_SECRET
+# For auth (Slice 2+): fill in GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET,
+#   GOOGLE_IOS_CLIENT_ID, GOOGLE_ANDROID_CLIENT_ID
+# See issue #9 for how to create credentials in Google Cloud Console
 
 # Run database migrations
 npm run db:migrate


### PR DESCRIPTION
Resolves #9

## Summary
- Uncommented and expanded the `Auth (Slice 2)` section in root `.env.example` to include all four Google OAuth credential placeholders (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_IOS_CLIENT_ID`, `GOOGLE_ANDROID_CLIENT_ID`) with clarifying comments
- Updated `README.md` Getting Started setup instructions to name the Google OAuth vars and point to issue #9 for credential creation steps

> Note: Issue #9 references `apps/api/.env.example`, but that file is a redirect notice — the project uses a single root `.env` file for all apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)