### PR TITLE
feat(types): Slice 2 — auth Zod schemas

### DIFF
--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+export const LoginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+})
+export const RegisterSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  name: z.string().min(1),
+})
+export const TokenPairSchema = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+})
+
+export type LoginInput = z.infer<typeof LoginSchema>
+export type RegisterInput = z.infer<typeof RegisterSchema>
+export type TokenPair = z.infer<typeof TokenPairSchema>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,2 @@
 export * from './result.js'
+export * from './auth.js'


### PR DESCRIPTION
## Summary
- Adds `LoginSchema`, `RegisterSchema`, `TokenPairSchema` to `packages/types/src/auth.ts`
- Re-exports from `packages/types/src/index.ts`

## Test plan
- [ ] `npx tsc --noEmit -p packages/types/tsconfig.json` → zero errors

Part of Slice 2 — Auth (#11). Depends on nothing. `slice-2/api` will be opened next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)