### PR TITLE
chore(api): add nodemon for auto-restart in development

### DIFF
--- a/apps/api/nodemon.json
+++ b/apps/api/nodemon.json
@@ -1,0 +1,13 @@
+{
+  "exec": "node --env-file=../../.env ../../node_modules/.bin/tsx src/index.ts",
+  "ext": "ts,json",
+  "watch": [
+    "src",
+    "../../packages/db/src",
+    "../../packages/types/src"
+  ],
+  "ignore": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "node --env-file=../../.env ../../node_modules/.bin/tsx watch src/index.ts",
+    "dev": "../../node_modules/.bin/nodemon",
     "build": "tsc",
     "start": "node --env-file=../../.env dist/index.js"
   },
@@ -24,6 +24,7 @@
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^22.13.9",
+    "nodemon": "^3.1.14",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3"
   }


### PR DESCRIPTION
## Summary

- Installs `nodemon@3.1.14` as a dev dependency in `apps/api`
- Adds `apps/api/nodemon.json` to configure watch paths and the exec command
- Updates the `dev` script in `apps/api/package.json` to invoke `nodemon`

## What nodemon watches

| Path | Why |
|---|---|
| `apps/api/src/` | API source files |
| `packages/db/src/` | Shared Prisma client / db types |
| `packages/types/src/` | Shared Zod schemas |

`tsx` is retained as the TypeScript executor inside nodemon's `exec` command — nodemon owns file watching, tsx handles TS compilation. Web (Vite) and Mobile (Expo) have their own built-in watchers and are unaffected.

## Test plan

- [ ] Run `turbo dev` or `npm run dev:api` — confirm API starts via nodemon
- [ ] Edit a file in `apps/api/src/` — confirm server restarts automatically
- [ ] Edit a file in `packages/db/src/` or `packages/types/src/` — confirm server restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)