### PR TITLE
test(mobile): Jest + RNTL acceptance tests for PR #50

### DIFF
--- a/apps/mobile/__tests__/AuthContext.test.tsx
+++ b/apps/mobile/__tests__/AuthContext.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * AuthContext tests
+ *
+ * T1: App opens with no stored session → user is null (LoginScreen would be shown).
+ * T3: App starts with valid stored tokens → session is restored and user is set
+ *     (Feed would be shown — RootNavigator reads user from this context).
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import { Text } from 'react-native'
+import { AuthProvider, useAuth } from '../src/context/AuthContext'
+
+// Mock the api module — AuthContext calls these functions directly.
+jest.mock('../src/lib/api', () => ({
+  api: {
+    auth: { me: jest.fn() },
+  },
+  setAccessToken: jest.fn(),
+  setUnauthorizedHandler: jest.fn(),
+  storeTokens: jest.fn(),
+  getStoredTokens: jest.fn(),
+  clearTokens: jest.fn(),
+}))
+
+import { api, getStoredTokens } from '../src/lib/api'
+
+// A minimal consumer that exposes auth state as text so we can assert on it.
+function AuthConsumer() {
+  const { user, isLoading } = useAuth()
+  if (isLoading) return <Text testID="status">loading</Text>
+  if (!user) return <Text testID="status">not-logged-in</Text>
+  return <Text testID="status">{`logged-in:${user.id}`}</Text>
+}
+
+describe('AuthContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('T1: no stored tokens → user is null after initialisation', async () => {
+    ;(getStoredTokens as jest.Mock).mockResolvedValue({
+      accessToken: null,
+      refreshToken: null,
+    })
+
+    const { findByTestId } = render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    )
+
+    const el = await findByTestId('status')
+    expect(el.props.children).toBe('not-logged-in')
+  })
+
+  test('T3: valid stored tokens → session restored, user populated from api.auth.me', async () => {
+    ;(getStoredTokens as jest.Mock).mockResolvedValue({
+      accessToken: 'valid-access-token',
+      refreshToken: 'valid-refresh-token',
+    })
+    ;(api.auth.me as jest.Mock).mockResolvedValue({
+      id: 'user-123',
+      email: 'member@gym.com',
+      name: 'Jane Doe',
+    })
+
+    const { findByTestId } = render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    )
+
+    const el = await findByTestId('status')
+    expect(el.props.children).toBe('logged-in:user-123')
+  })
+})

--- a/apps/mobile/__tests__/AuthContext.test.tsx
+++ b/apps/mobile/__tests__/AuthContext.test.tsx
@@ -1,9 +1,8 @@
 /**
  * AuthContext tests
  *
- * T1: App opens with no stored session → user is null (LoginScreen would be shown).
- * T3: App starts with valid stored tokens → session is restored and user is set
- *     (Feed would be shown — RootNavigator reads user from this context).
+ * Tests the two startup paths: cold start with no session, and warm start with
+ * stored tokens that restore the authenticated user without requiring login.
  */
 
 import React from 'react'
@@ -38,7 +37,7 @@ describe('AuthContext', () => {
     jest.clearAllMocks()
   })
 
-  test('T1: no stored tokens → user is null after initialisation', async () => {
+  test('no stored tokens → user is null after initialisation', async () => {
     ;(getStoredTokens as jest.Mock).mockResolvedValue({
       accessToken: null,
       refreshToken: null,
@@ -54,7 +53,7 @@ describe('AuthContext', () => {
     expect(el.props.children).toBe('not-logged-in')
   })
 
-  test('T3: valid stored tokens → session restored, user populated from api.auth.me', async () => {
+  test('valid stored tokens → session restored, user populated from api.auth.me', async () => {
     ;(getStoredTokens as jest.Mock).mockResolvedValue({
       accessToken: 'valid-access-token',
       refreshToken: 'valid-refresh-token',

--- a/apps/mobile/__tests__/FeedScreen.test.tsx
+++ b/apps/mobile/__tests__/FeedScreen.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * FeedScreen tests
+ *
+ * T4: Feed groups workouts into TODAY / TOMORROW / future date headers.
+ * T5: Multiple workouts on the same day appear as separate cards under one header.
+ * T6: Tapping a workout card calls navigation.navigate('WodDetail', { workoutId }).
+ * T9: Pull-to-refresh triggers a second api.gyms.workouts call.
+ */
+
+import React from 'react'
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native'
+import { FlatList, RefreshControl } from 'react-native'
+import FeedScreen from '../src/screens/FeedScreen'
+
+// Replace useFocusEffect with a plain useEffect so screens focus immediately in tests.
+jest.mock('@react-navigation/native', () => {
+  const React = require('react')
+  return {
+    useFocusEffect: (cb: () => void) => React.useEffect(cb, []),
+  }
+})
+
+jest.mock('../src/context/GymContext', () => ({
+  useGym: jest.fn(),
+}))
+
+jest.mock('../src/lib/api', () => ({
+  api: {
+    gyms: { workouts: jest.fn() },
+  },
+}))
+
+import { useGym } from '../src/context/GymContext'
+import { api } from '../src/lib/api'
+
+const ACTIVE_GYM = { id: 'gym-1', name: 'Test Gym', slug: 'test-gym', timezone: 'UTC', userRole: 'MEMBER' }
+
+function makeNavigation() {
+  return { navigate: jest.fn(), setOptions: jest.fn(), goBack: jest.fn() } as any
+}
+
+function workout(
+  id: string,
+  title: string,
+  scheduledAt: Date,
+  type = 'AMRAP',
+) {
+  return { id, title, type, status: 'PUBLISHED', scheduledAt: scheduledAt.toISOString(), programId: 'prog-1', description: '' }
+}
+
+function daysFromNow(n: number) {
+  const d = new Date()
+  d.setDate(d.getDate() + n)
+  return d
+}
+
+describe('FeedScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useGym as jest.Mock).mockReturnValue({ activeGym: ACTIVE_GYM, isLoading: false, selectGym: jest.fn() })
+  })
+
+  test('T4: workouts grouped into TODAY, TOMORROW, and future date headers', async () => {
+    ;(api.gyms.workouts as jest.Mock).mockResolvedValue([
+      workout('w1', 'Morning WOD', daysFromNow(0)),
+      workout('w2', 'Tomorrow WOD', daysFromNow(1)),
+      workout('w3', 'Future WOD', daysFromNow(2)),
+    ])
+
+    const { findByText } = render(<FeedScreen navigation={makeNavigation()} route={{} as any} />)
+
+    await findByText(/^TODAY/)
+    await findByText(/^TOMORROW/)
+    // The day-after header is a localised date string in uppercase — just assert the workout renders
+    await findByText('Future WOD')
+  })
+
+  test('T5: multiple workouts on the same day appear as separate cards under one header', async () => {
+    const today = daysFromNow(0)
+    ;(api.gyms.workouts as jest.Mock).mockResolvedValue([
+      workout('w1', 'Morning WOD', today, 'WARMUP'),
+      workout('w2', 'Afternoon WOD', today, 'AMRAP'),
+    ])
+
+    const { findByText, getAllByText } = render(
+      <FeedScreen navigation={makeNavigation()} route={{} as any} />,
+    )
+
+    await findByText('Morning WOD')
+    await findByText('Afternoon WOD')
+
+    // Only one TODAY header — both cards are under the same day block
+    const todayHeaders = getAllByText(/^TODAY/)
+    expect(todayHeaders).toHaveLength(1)
+  })
+
+  test('T6: tapping a workout card calls navigate with the correct workoutId', async () => {
+    const nav = makeNavigation()
+    ;(api.gyms.workouts as jest.Mock).mockResolvedValue([
+      workout('workout-abc', 'Tap Me WOD', daysFromNow(0)),
+    ])
+
+    const { findByText } = render(<FeedScreen navigation={nav} route={{} as any} />)
+
+    fireEvent.press(await findByText('Tap Me WOD'))
+
+    expect(nav.navigate).toHaveBeenCalledWith('WodDetail', { workoutId: 'workout-abc' })
+  })
+
+  test('T9: pull-to-refresh triggers a second api call', async () => {
+    ;(api.gyms.workouts as jest.Mock).mockResolvedValue([
+      workout('w1', 'Daily WOD', daysFromNow(0)),
+    ])
+
+    const { UNSAFE_getByType, findByText } = render(
+      <FeedScreen navigation={makeNavigation()} route={{} as any} />,
+    )
+
+    // Wait for initial load
+    await findByText('Daily WOD')
+    expect(api.gyms.workouts).toHaveBeenCalledTimes(1)
+
+    // Trigger pull-to-refresh by calling onRefresh on the RefreshControl directly
+    const rc = UNSAFE_getByType(RefreshControl)
+    act(() => rc.props.onRefresh())
+
+    await waitFor(() => {
+      expect(api.gyms.workouts).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/apps/mobile/__tests__/FeedScreen.test.tsx
+++ b/apps/mobile/__tests__/FeedScreen.test.tsx
@@ -1,10 +1,8 @@
 /**
  * FeedScreen tests
  *
- * T4: Feed groups workouts into TODAY / TOMORROW / future date headers.
- * T5: Multiple workouts on the same day appear as separate cards under one header.
- * T6: Tapping a workout card calls navigation.navigate('WodDetail', { workoutId }).
- * T9: Pull-to-refresh triggers a second api.gyms.workouts call.
+ * Covers feed data presentation: day-block grouping labels, multi-workout days,
+ * card tap navigation to WodDetail, and pull-to-refresh reloading.
  */
 
 import React from 'react'
@@ -60,7 +58,7 @@ describe('FeedScreen', () => {
     ;(useGym as jest.Mock).mockReturnValue({ activeGym: ACTIVE_GYM, isLoading: false, selectGym: jest.fn() })
   })
 
-  test('T4: workouts grouped into TODAY, TOMORROW, and future date headers', async () => {
+  test('workouts grouped into TODAY, TOMORROW, and future date headers', async () => {
     ;(api.gyms.workouts as jest.Mock).mockResolvedValue([
       workout('w1', 'Morning WOD', daysFromNow(0)),
       workout('w2', 'Tomorrow WOD', daysFromNow(1)),
@@ -75,7 +73,7 @@ describe('FeedScreen', () => {
     await findByText('Future WOD')
   })
 
-  test('T5: multiple workouts on the same day appear as separate cards under one header', async () => {
+  test('multiple workouts on the same day appear as separate cards under one header', async () => {
     const today = daysFromNow(0)
     ;(api.gyms.workouts as jest.Mock).mockResolvedValue([
       workout('w1', 'Morning WOD', today, 'WARMUP'),
@@ -94,7 +92,7 @@ describe('FeedScreen', () => {
     expect(todayHeaders).toHaveLength(1)
   })
 
-  test('T6: tapping a workout card calls navigate with the correct workoutId', async () => {
+  test('tapping a workout card calls navigate with the correct workoutId', async () => {
     const nav = makeNavigation()
     ;(api.gyms.workouts as jest.Mock).mockResolvedValue([
       workout('workout-abc', 'Tap Me WOD', daysFromNow(0)),
@@ -107,7 +105,7 @@ describe('FeedScreen', () => {
     expect(nav.navigate).toHaveBeenCalledWith('WodDetail', { workoutId: 'workout-abc' })
   })
 
-  test('T9: pull-to-refresh triggers a second api call', async () => {
+  test('pull-to-refresh triggers a second api call', async () => {
     ;(api.gyms.workouts as jest.Mock).mockResolvedValue([
       workout('w1', 'Daily WOD', daysFromNow(0)),
     ])

--- a/apps/mobile/__tests__/LoginScreen.test.tsx
+++ b/apps/mobile/__tests__/LoginScreen.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * LoginScreen tests
+ *
+ * T2:  Valid credentials call login() — navigation is handled by RootNavigator
+ *      reacting to the user state change, not by the screen itself.
+ * T10: Bad credentials surface "Invalid email or password." error text.
+ */
+
+import React from 'react'
+import { render, fireEvent, waitFor } from '@testing-library/react-native'
+import LoginScreen from '../src/screens/LoginScreen'
+
+jest.mock('../src/context/AuthContext', () => ({
+  useAuth: jest.fn(),
+}))
+
+import { useAuth } from '../src/context/AuthContext'
+
+describe('LoginScreen', () => {
+  const mockLogin = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useAuth as jest.Mock).mockReturnValue({
+      user: null,
+      isLoading: false,
+      login: mockLogin,
+      logout: jest.fn(),
+    })
+  })
+
+  test('T2: valid credentials call login() with the correct email and password', async () => {
+    mockLogin.mockResolvedValue(undefined)
+
+    const { getByPlaceholderText, getByText } = render(<LoginScreen />)
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'coach@gym.com')
+    fireEvent.changeText(getByPlaceholderText('Password'), 'SecurePass1!')
+    fireEvent.press(getByText('Sign In'))
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith('coach@gym.com', 'SecurePass1!')
+    })
+  })
+
+  test('T2b: submitting empty fields shows required-field error without calling login()', async () => {
+    const { getByText } = render(<LoginScreen />)
+
+    fireEvent.press(getByText('Sign In'))
+
+    await waitFor(() => {
+      expect(getByText('Email and password are required.')).toBeTruthy()
+    })
+    expect(mockLogin).not.toHaveBeenCalled()
+  })
+
+  test('T10: failed login shows "Invalid email or password." error message', async () => {
+    mockLogin.mockRejectedValue(new Error('Unauthorized'))
+
+    const { getByPlaceholderText, getByText, findByText } = render(<LoginScreen />)
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'bad@email.com')
+    fireEvent.changeText(getByPlaceholderText('Password'), 'wrongpassword')
+    fireEvent.press(getByText('Sign In'))
+
+    await findByText('Invalid email or password.')
+  })
+})

--- a/apps/mobile/__tests__/LoginScreen.test.tsx
+++ b/apps/mobile/__tests__/LoginScreen.test.tsx
@@ -1,9 +1,9 @@
 /**
  * LoginScreen tests
  *
- * T2:  Valid credentials call login() — navigation is handled by RootNavigator
- *      reacting to the user state change, not by the screen itself.
- * T10: Bad credentials surface "Invalid email or password." error text.
+ * Covers the login form: successful submit, empty-field guard, and bad-credentials
+ * error handling. Navigation after login is handled by RootNavigator reacting to
+ * the auth context user state change, not by the screen itself.
  */
 
 import React from 'react'
@@ -29,7 +29,7 @@ describe('LoginScreen', () => {
     })
   })
 
-  test('T2: valid credentials call login() with the correct email and password', async () => {
+  test('valid credentials call login() with the correct email and password', async () => {
     mockLogin.mockResolvedValue(undefined)
 
     const { getByPlaceholderText, getByText } = render(<LoginScreen />)
@@ -43,7 +43,7 @@ describe('LoginScreen', () => {
     })
   })
 
-  test('T2b: submitting empty fields shows required-field error without calling login()', async () => {
+  test('submitting empty fields shows required-field error without calling login()', async () => {
     const { getByText } = render(<LoginScreen />)
 
     fireEvent.press(getByText('Sign In'))
@@ -54,7 +54,7 @@ describe('LoginScreen', () => {
     expect(mockLogin).not.toHaveBeenCalled()
   })
 
-  test('T10: failed login shows "Invalid email or password." error message', async () => {
+  test('failed login shows "Invalid email or password." error message', async () => {
     mockLogin.mockRejectedValue(new Error('Unauthorized'))
 
     const { getByPlaceholderText, getByText, findByText } = render(<LoginScreen />)

--- a/apps/mobile/__tests__/WodDetailScreen.test.tsx
+++ b/apps/mobile/__tests__/WodDetailScreen.test.tsx
@@ -1,9 +1,8 @@
 /**
  * WodDetailScreen tests
  *
- * T6-display: Workout title and description rendered from the API response.
- * T7: Tapping a level filter chip re-fetches the leaderboard with that level filter.
- * T8: The current user's leaderboard row has the highlight background style applied.
+ * Covers WOD detail rendering, leaderboard level filter chips, and the current
+ * user's row highlight styling.
  */
 
 import React from 'react'
@@ -70,7 +69,7 @@ describe('WodDetailScreen', () => {
     ;(api.workouts.results as jest.Mock).mockResolvedValue([])
   })
 
-  test('T6-display: shows workout title and description from API', async () => {
+  test('shows workout title and description from API', async () => {
     const { findByText } = render(
       <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
     )
@@ -79,7 +78,7 @@ describe('WodDetailScreen', () => {
     await findByText('21-15-9 Thrusters and Pull-ups')
   })
 
-  test('T7: tapping the "RX" filter chip re-fetches leaderboard with level=RX', async () => {
+  test('tapping the "RX" filter chip re-fetches leaderboard with level=RX', async () => {
     const { findByText } = render(
       <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
     )
@@ -95,7 +94,7 @@ describe('WodDetailScreen', () => {
     })
   })
 
-  test('T7b: tapping "All" after a level filter clears the filter', async () => {
+  test('tapping "All" after a level filter clears the filter', async () => {
     const { findByText } = render(
       <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
     )
@@ -111,7 +110,7 @@ describe('WodDetailScreen', () => {
     await waitFor(() => expect(api.workouts.results).toHaveBeenCalledWith('workout-1', undefined))
   })
 
-  test('T8: current user\'s leaderboard row has highlight background color applied', async () => {
+  test("current user's leaderboard row has highlight background color applied", async () => {
     ;(api.workouts.results as jest.Mock).mockResolvedValue([
       makeEntry('e1', 'other-user', 'Alice'),
       makeEntry('e2', 'me', 'Me'),

--- a/apps/mobile/__tests__/WodDetailScreen.test.tsx
+++ b/apps/mobile/__tests__/WodDetailScreen.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * WodDetailScreen tests
+ *
+ * T6-display: Workout title and description rendered from the API response.
+ * T7: Tapping a level filter chip re-fetches the leaderboard with that level filter.
+ * T8: The current user's leaderboard row has the highlight background style applied.
+ */
+
+import React from 'react'
+import { render, fireEvent, waitFor } from '@testing-library/react-native'
+import { StyleSheet } from 'react-native'
+import WodDetailScreen from '../src/screens/WodDetailScreen'
+
+jest.mock('../src/context/AuthContext', () => ({
+  useAuth: jest.fn(),
+}))
+
+jest.mock('../src/lib/api', () => ({
+  api: {
+    workouts: {
+      get: jest.fn(),
+      results: jest.fn(),
+    },
+  },
+}))
+
+import { useAuth } from '../src/context/AuthContext'
+import { api } from '../src/lib/api'
+
+const WORKOUT = {
+  id: 'workout-1',
+  title: 'Fran',
+  description: '21-15-9 Thrusters and Pull-ups',
+  type: 'FOR_TIME' as const,
+  status: 'PUBLISHED' as const,
+  scheduledAt: '2026-06-15T12:00:00.000Z',
+  programId: 'prog-1',
+}
+
+function makeEntry(id: string, userId: string, userName: string) {
+  return {
+    id,
+    user: { id: userId, name: userName },
+    level: 'RX' as const,
+    workoutGender: 'OPEN' as const,
+    value: { type: 'FOR_TIME' as const, seconds: 210 },
+    notes: null,
+    createdAt: '2026-06-15T14:00:00.000Z',
+  }
+}
+
+function makeNavigation() {
+  return { navigate: jest.fn(), setOptions: jest.fn(), goBack: jest.fn() } as any
+}
+
+function makeRoute(workoutId = 'workout-1') {
+  return { params: { workoutId } } as any
+}
+
+describe('WodDetailScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useAuth as jest.Mock).mockReturnValue({
+      user: { id: 'me', email: 'me@gym.com', name: 'Me' },
+      isLoading: false,
+      login: jest.fn(),
+      logout: jest.fn(),
+    })
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(WORKOUT)
+    ;(api.workouts.results as jest.Mock).mockResolvedValue([])
+  })
+
+  test('T6-display: shows workout title and description from API', async () => {
+    const { findByText } = render(
+      <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
+    )
+
+    await findByText('Fran')
+    await findByText('21-15-9 Thrusters and Pull-ups')
+  })
+
+  test('T7: tapping the "RX" filter chip re-fetches leaderboard with level=RX', async () => {
+    const { findByText } = render(
+      <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
+    )
+
+    // Wait for initial load (called with no level filter = undefined)
+    await findByText('Fran')
+    expect(api.workouts.results).toHaveBeenCalledWith('workout-1', undefined)
+
+    fireEvent.press(await findByText('RX'))
+
+    await waitFor(() => {
+      expect(api.workouts.results).toHaveBeenCalledWith('workout-1', 'RX')
+    })
+  })
+
+  test('T7b: tapping "All" after a level filter clears the filter', async () => {
+    const { findByText } = render(
+      <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
+    )
+
+    await findByText('Fran')
+
+    // Set a filter first
+    fireEvent.press(await findByText('Scaled'))
+    await waitFor(() => expect(api.workouts.results).toHaveBeenCalledWith('workout-1', 'SCALED'))
+
+    // Clear it
+    fireEvent.press(await findByText('All'))
+    await waitFor(() => expect(api.workouts.results).toHaveBeenCalledWith('workout-1', undefined))
+  })
+
+  test('T8: current user\'s leaderboard row has highlight background color applied', async () => {
+    ;(api.workouts.results as jest.Mock).mockResolvedValue([
+      makeEntry('e1', 'other-user', 'Alice'),
+      makeEntry('e2', 'me', 'Me'),
+    ])
+
+    const { findByText, UNSAFE_getAllByType } = render(
+      <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
+    )
+
+    // The highlight style adds backgroundColor: '#1e1b4b' to the current user's row.
+    const meText = await findByText('Me')
+
+    // Walk up the tree until we find a node with the highlight backgroundColor.
+    // Fixed-depth traversal is fragile because RN host/composite split adds extra levels.
+    function findAncestorWithBg(node: any, color: string): any {
+      let cur = node
+      while (cur) {
+        const flat = StyleSheet.flatten(cur.props?.style ?? []) as Record<string, unknown>
+        if (flat?.backgroundColor === color) return cur
+        cur = cur.parent
+      }
+      return null
+    }
+
+    const highlight = '#1e1b4b'
+    expect(findAncestorWithBg(meText, highlight)).not.toBeNull()
+    expect(findAncestorWithBg(await findByText('Alice'), highlight)).toBeNull()
+  })
+})

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -1,0 +1,11 @@
+const path = require('path')
+
+module.exports = {
+  preset: 'jest-expo',
+  // Force React to resolve to the single copy in this workspace.
+  // react-native is hoisted to the root and must NOT be remapped here.
+  moduleNameMapper: {
+    '^react$': path.resolve(__dirname, 'node_modules/react'),
+    '^react/(.*)$': path.resolve(__dirname, 'node_modules/react/$1'),
+  },
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -6,7 +6,8 @@
     "dev": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@react-navigation/bottom-tabs": "^7.15.8",
@@ -21,7 +22,11 @@
     "react-native-screens": "^4.24.0"
   },
   "devDependencies": {
+    "@testing-library/react-native": "^12.0.0",
+    "@types/jest": "^29.0.0",
     "@types/react": "~19.2.2",
+    "jest": "^29.0.0",
+    "jest-expo": "~55.0.0",
     "typescript": "~5.9.2"
   },
   "private": true


### PR DESCRIPTION
## Summary

- Adds Jest + React Native Testing Library test suite for PR #50's 10-item test plan
- 13 tests across 4 files, all running headlessly with no simulator or server required
- Uses `jest-expo` preset; `expo-secure-store` and the API client are fully mocked

## Test coverage

| File | Tests | PR items |
|---|---|---|
| `LoginScreen.test.tsx` | valid login, empty fields, bad credentials | T2, T10 |
| `AuthContext.test.tsx` | no-session init, token-based session restore | T1, T3 |
| `FeedScreen.test.tsx` | day-block grouping (TODAY/TOMORROW/future), multi-workout same day, card tap navigation, pull-to-refresh | T4, T5, T6, T9 |
| `WodDetailScreen.test.tsx` | title/description display, level filter chips, current-user row highlight | T6, T7, T8 |

## Running

```bash
npm run test --workspace=@berntracker/mobile
# or
cd apps/mobile && npx jest
```

No server or Expo simulator needed — all external dependencies are mocked.

## Why Jest over Detox

Detox (native E2E) is the right choice once a beta build is being cut and device-level confidence is needed. At this stage, Jest + RNTL covers component behavior and UI logic headlessly, while the existing Playwright suite already validates the full API contract end-to-end.

Part of #39
Part of #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)