### PR TITLE
feat(web): member feed + WOD detail pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,35 @@ cd apps/web && npx dotenv-cli -e ../../.env -- npx playwright test
 
 When creating a PR, always link the relevant issue in the PR body using a GitHub closing keyword (e.g. `Closes #11`) or a plain reference (e.g. `Part of #11`) so that context is well linked. Use `Closes` when the PR fully resolves the issue; use `Part of` when it is one slice of a multi-PR issue.
 
+### Testing section format
+
+Every PR must include a **Tests** section that describes what was tested and how. This is not just a checkbox list for reviewers — it should tell the reader what test coverage exists and what the remaining manual verification surface is.
+
+**Structure:**
+
+```markdown
+## Tests
+
+**API integration** (`apps/api/tests/<file>.ts`):
+- <what each case asserts — one bullet per meaningful assertion group>
+- Auth guards (401 / 403) for all protected routes
+
+**Playwright E2E** (`apps/web/tests/<file>.spec.ts`, N tests):
+- T1: <test name and what it verifies>
+- T2: ...
+- (list every named test with a one-line description)
+
+**Not automated / manual verification needed:**
+- [ ] <Anything that genuinely cannot be driven by a test, e.g. visual polish, third-party OAuth, device-specific behavior>
+```
+
+**Rules:**
+- Every test that exists should be named and briefly described. Do not just list "9 tests" — list each one.
+- Separate automated coverage from manual steps clearly. If a manual step can be automated, automate it first, then remove it from the manual list.
+- If a behaviour is tested by an existing test suite (not new to this PR), note which file covers it rather than leaving it as an unchecked box.
+- The manual checklist should be short. If it's more than 3–4 items, that is a sign more automation is needed.
+- For PRs touching auth, role gates, or visibility rules: always call out which roles were tested and how.
+
 ### Schema migrations — required pre-merge checklist item
 
 Every PR that modifies `packages/db/prisma/schema.prisma` **must** commit the generated migration file before merging:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,67 @@ enum Gender        { WOMAN, MAN, NON_BINARY, PREFER_NOT_TO_SAY }  // User.identi
 enum WorkoutGender { MALE, FEMALE, OPEN }                          // Result.workoutGender — required, leaderboard grouping
 ```
 
+## Testing
+
+### API integration tests
+
+Located in `apps/api/tests/`. Each file is a self-contained TypeScript script that:
+- Seeds all fixtures directly via Prisma (no HTTP for setup)
+- Signs JWT tokens in-process via `signTokenPair` from `../src/lib/jwt.js`
+- Drives assertions through the live API using `fetch()`
+- Cleans up all created data in a `finally` block
+
+**Run:**
+```bash
+npm run test --workspace=@berntracker/api
+# or from apps/api:
+cd apps/api && npx dotenv-cli -e ../../.env -- sh -c 'for f in tests/*.ts; do npx tsx "$f" || exit 1; done'
+```
+
+**Requires:** API running on `localhost:3000`, DB accessible via `DATABASE_URL`.
+
+**Test files:**
+
+| File | Covers |
+|---|---|
+| `tests/workouts.ts` | Workout CRUD, publish, dayOrder, role-based access, program subscriptions |
+| `tests/results.ts` | Result logging, leaderboard sorting/filtering, paginated history |
+| `tests/feed.ts` | Feed (member sees PUBLISHED-only), WOD detail, WorkoutResult shape |
+
+**Adding a new test file:** Follow the pattern in any existing file. Add the new script to the `test` command in `apps/api/package.json`.
+
+---
+
+### Web E2E tests (Playwright)
+
+Located in `apps/web/tests/`. Each spec file uses Playwright and seeds DB fixtures directly via `PrismaClient` (imported via `createRequire` to bypass ESM/CJS issues).
+
+**Run:**
+```bash
+npm run test --workspace=@berntracker/web
+# or from apps/web:
+cd apps/web && npx dotenv-cli -e ../../.env -- npx playwright test
+```
+
+**Requires:** `turbo dev` running (API on `:3000`, web on `:5173`).
+
+**Test files:**
+
+| File | Covers |
+|---|---|
+| `tests/calendar-multi-workout.spec.ts` | Multi-workout calendar: overflow pills, drawer create/edit/delete, reorder, role gates |
+| `tests/feed-wod-detail.spec.ts` | Feed page, WOD Detail page: sidebar role awareness, workout display, results table, level filter chips, "Your Result" badge |
+
+**Patterns to follow:**
+- Use `test.describe.configure({ mode: 'serial' })` — tests share seeded DB state.
+- Use `test.beforeAll` / `test.afterAll` with Prisma for setup/teardown.
+- Seed directly via Prisma (not via API) to keep setup fast and independent of API state.
+- Assign one isolated day or entity per test to avoid cross-test interference.
+- `gymId` must be set in `localStorage` before navigating to gym-scoped pages (pages read it on mount).
+- Import PrismaClient via `createRequire(import.meta.url)` — do not use ESM named imports from `@prisma/client`.
+
+---
+
 ## Pull requests
 
 When creating a PR, always link the relevant issue in the PR body using a GitHub closing keyword (e.g. `Closes #11`) or a plain reference (e.g. `Part of #11`) so that context is well linked. Use `Closes` when the PR fully resolves the issue; use `Part of` when it is one slice of a multi-PR issue.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
     "dev": "../../node_modules/.bin/nodemon",
     "build": "tsc",
     "start": "node --env-file=../../.env dist/index.js",
-    "test": "npx dotenv-cli -e ../../.env -- sh -c 'npx tsx tests/workouts.ts && npx tsx tests/results.ts'"
+    "test": "npx dotenv-cli -e ../../.env -- sh -c 'for f in tests/*.ts; do npx tsx \"$f\" || exit 1; done'"
   },
   "dependencies": {
     "@berntracker/db": "*",

--- a/apps/api/tests/feed.ts
+++ b/apps/api/tests/feed.ts
@@ -1,0 +1,298 @@
+/**
+ * Lightweight integration tests for the member feed & WOD detail endpoints.
+ *
+ * Covers the API surface used by the Feed page and WodDetail page (Issue #48):
+ *   - GET /gyms/:gymId/workouts → MEMBER sees only PUBLISHED; PROGRAMMER sees all
+ *   - GET /workouts/:id → returns full workout data for program subscribers
+ *   - GET /workouts/:id/results → leaderboard entries have WorkoutResult shape
+ *
+ * Requires: API running on localhost:3000, DB accessible via DATABASE_URL.
+ * Run: cd apps/api && npm test
+ */
+
+import { prisma, ProgramRole } from '@berntracker/db'
+import { signTokenPair } from '../src/lib/jwt.js'
+
+const BASE = 'http://localhost:3000/api'
+let pass = 0
+let fail = 0
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function check(label: string, expected: unknown, actual: unknown) {
+  if (String(expected) === String(actual)) {
+    console.log(`  ✓ ${label}`)
+    pass++
+  } else {
+    console.log(`  ✗ ${label}  [expected=${expected} actual=${actual}]`)
+    fail++
+  }
+}
+
+async function api(method: string, path: string, token?: string, body?: unknown) {
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  const text = await res.text()
+  let json: unknown
+  try {
+    json = JSON.parse(text)
+  } catch {
+    json = text
+  }
+  return { status: res.status, body: json as Record<string, unknown> }
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const TS = Date.now()
+let gymId = ''
+let programId = ''
+let memberUserId = ''
+let programmerUserId = ''
+let memberToken = ''
+let programmerToken = ''
+let publishedWorkoutId = ''
+let draftWorkoutId = ''
+
+async function setup() {
+  console.log('\n=== Setup ===')
+
+  const gym = await prisma.gym.create({
+    data: { name: `Feed Gym ${TS}`, slug: `feed-gym-${TS}`, timezone: 'UTC' },
+  })
+  gymId = gym.id
+
+  const [memberUser, programmerUser] = await Promise.all([
+    prisma.user.create({ data: { email: `feed-member-${TS}@test.com`, name: 'Feed Member' } }),
+    prisma.user.create({ data: { email: `feed-prog-${TS}@test.com`, name: 'Feed Programmer' } }),
+  ])
+  memberUserId = memberUser.id
+  programmerUserId = programmerUser.id
+
+  await prisma.userGym.createMany({
+    data: [
+      { userId: memberUserId, gymId, role: 'MEMBER' },
+      { userId: programmerUserId, gymId, role: 'PROGRAMMER' },
+    ],
+  })
+
+  const program = await prisma.program.create({
+    data: {
+      name: `Feed Program ${TS}`,
+      startDate: new Date('2026-01-01'),
+      gyms: { create: { gymId } },
+      members: {
+        createMany: {
+          data: [
+            { userId: memberUserId, role: ProgramRole.MEMBER },
+            { userId: programmerUserId, role: ProgramRole.PROGRAMMER },
+          ],
+        },
+      },
+    },
+  })
+  programId = program.id
+
+  const SCHEDULED_DATE = new Date('2026-04-15T10:00:00Z')
+
+  const [published, draft] = await Promise.all([
+    prisma.workout.create({
+      data: {
+        title: 'Feed PUBLISHED Workout',
+        description: 'Thrusters + pull-ups',
+        type: 'FOR_TIME',
+        status: 'PUBLISHED',
+        scheduledAt: SCHEDULED_DATE,
+        programId,
+        dayOrder: 0,
+      },
+    }),
+    prisma.workout.create({
+      data: {
+        title: 'Feed DRAFT Workout',
+        description: 'Draft only — should not appear to MEMBERs',
+        type: 'STRENGTH',
+        status: 'DRAFT',
+        scheduledAt: SCHEDULED_DATE,
+        programId,
+        dayOrder: 1,
+      },
+    }),
+  ])
+  publishedWorkoutId = published.id
+  draftWorkoutId = draft.id
+
+  memberToken = signTokenPair(memberUserId, 'MEMBER').accessToken
+  programmerToken = signTokenPair(programmerUserId, 'PROGRAMMER').accessToken
+
+  console.log(`  gym=${gymId}`)
+  console.log(`  program=${programId}`)
+  console.log(`  publishedWorkout=${publishedWorkoutId}`)
+  console.log(`  draftWorkout=${draftWorkoutId}`)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+async function runTests() {
+  // ── Feed: gym-scoped workout list ──────────────────────────────────────────
+  console.log('\n=== Feed: GET /gyms/:gymId/workouts ===')
+
+  {
+    // MEMBER → sees only PUBLISHED workouts
+    const r = await api('GET', `/gyms/${gymId}/workouts?from=2026-04-01&to=2026-04-30`, memberToken)
+    check('MEMBER GET workouts → 200', 200, r.status)
+    const workouts = r.body as Array<Record<string, unknown>>
+    check('MEMBER sees only PUBLISHED workouts', true, Array.isArray(workouts))
+    const titles = workouts.map((w) => w.title)
+    check('MEMBER can see published workout', true, titles.includes('Feed PUBLISHED Workout'))
+    check('MEMBER cannot see draft workout', false, titles.includes('Feed DRAFT Workout'))
+  }
+
+  {
+    // PROGRAMMER → sees DRAFT and PUBLISHED workouts
+    const r = await api('GET', `/gyms/${gymId}/workouts?from=2026-04-01&to=2026-04-30`, programmerToken)
+    check('PROGRAMMER GET workouts → 200', 200, r.status)
+    const workouts = r.body as Array<Record<string, unknown>>
+    const titles = workouts.map((w) => w.title)
+    check('PROGRAMMER can see published workout', true, titles.includes('Feed PUBLISHED Workout'))
+    check('PROGRAMMER can see draft workout', true, titles.includes('Feed DRAFT Workout'))
+  }
+
+  {
+    // Missing date range params → 400
+    const r = await api('GET', `/gyms/${gymId}/workouts`, memberToken)
+    check('GET /gyms/:gymId/workouts missing params → 400', 400, r.status)
+  }
+
+  {
+    // No auth → 401
+    const r = await api('GET', `/gyms/${gymId}/workouts?from=2026-04-01&to=2026-04-30`)
+    check('GET /gyms/:gymId/workouts no auth → 401', 401, r.status)
+  }
+
+  // ── WOD Detail: GET /workouts/:id ──────────────────────────────────────────
+  console.log('\n=== WOD Detail: GET /workouts/:id ===')
+
+  {
+    const r = await api('GET', `/workouts/${publishedWorkoutId}`, memberToken)
+    check('MEMBER GET /workouts/:id (published) → 200', 200, r.status)
+    const w = r.body
+    check('GET /workouts/:id → has id', publishedWorkoutId, w.id)
+    check('GET /workouts/:id → has title', 'Feed PUBLISHED Workout', w.title)
+    check('GET /workouts/:id → has type', 'FOR_TIME', w.type)
+    check('GET /workouts/:id → has status', 'PUBLISHED', w.status)
+    check('GET /workouts/:id → has scheduledAt', true, typeof w.scheduledAt === 'string')
+    check('GET /workouts/:id → has _count', true, w._count !== undefined)
+  }
+
+  {
+    // MEMBER can also access DRAFT workouts for programs they subscribe to
+    const r = await api('GET', `/workouts/${draftWorkoutId}`, memberToken)
+    check('MEMBER GET /workouts/:id (draft, subscribed) → 200', 200, r.status)
+  }
+
+  {
+    // User with no program subscription → 403
+    const outsider = await prisma.user.create({ data: { email: `feed-outsider-${TS}@test.com` } })
+    const outsiderToken = signTokenPair(outsider.id, 'MEMBER').accessToken
+    const r = await api('GET', `/workouts/${publishedWorkoutId}`, outsiderToken)
+    check('GET /workouts/:id (no program sub) → 403', 403, r.status)
+    await prisma.user.delete({ where: { id: outsider.id } })
+  }
+
+  // ── Results: GET /workouts/:id/results ──────────────────────────────────────
+  console.log('\n=== Results: GET /workouts/:workoutId/results ===')
+
+  // Seed results for the published workout
+  await api('POST', `/workouts/${publishedWorkoutId}/results`, memberToken, {
+    level: 'RX',
+    workoutGender: 'OPEN',
+    value: { type: 'FOR_TIME', seconds: 185, cappedOut: false },
+  })
+  await api('POST', `/workouts/${publishedWorkoutId}/results`, programmerToken, {
+    level: 'SCALED',
+    workoutGender: 'OPEN',
+    value: { type: 'FOR_TIME', seconds: 240, cappedOut: false },
+  })
+
+  {
+    const r = await api('GET', `/workouts/${publishedWorkoutId}/results`, memberToken)
+    check('GET /workouts/:id/results → 200', 200, r.status)
+    const entries = r.body as Array<Record<string, unknown>>
+    check('GET /workouts/:id/results → array', true, Array.isArray(entries))
+    check('GET /workouts/:id/results → 2 entries', 2, entries.length)
+
+    // Verify WorkoutResult shape
+    const first = entries[0]
+    check('WorkoutResult has id', true, typeof first.id === 'string')
+    check('WorkoutResult has userId', true, typeof first.userId === 'string')
+    check('WorkoutResult has workoutId', publishedWorkoutId, first.workoutId)
+    check('WorkoutResult has level', true, typeof first.level === 'string')
+    check('WorkoutResult has workoutGender', true, typeof first.workoutGender === 'string')
+    check('WorkoutResult has value', true, typeof first.value === 'object')
+    check('WorkoutResult has user.id', true, typeof (first.user as Record<string, unknown>)?.id === 'string')
+    check('WorkoutResult has workout.type', 'FOR_TIME', (first.workout as Record<string, unknown>)?.type)
+
+    // FOR_TIME sorted ascending by seconds — member (185s) faster than programmer (240s)
+    const firstUser = (first.user as Record<string, unknown>)
+    check('FOR_TIME results → faster result first', memberUserId, firstUser.id)
+  }
+
+  {
+    // Filter by level=RX → 1 result
+    const r = await api('GET', `/workouts/${publishedWorkoutId}/results?level=RX`, memberToken)
+    const entries = r.body as Array<Record<string, unknown>>
+    check('GET /workouts/:id/results ?level=RX → 1 entry', 1, entries.length)
+    check('GET /workouts/:id/results ?level=RX → correct level', 'RX', entries[0]?.level)
+  }
+
+  {
+    // Filter by level=MODIFIED → 0 results
+    const r = await api('GET', `/workouts/${publishedWorkoutId}/results?level=MODIFIED`, memberToken)
+    const entries = r.body as Array<Record<string, unknown>>
+    check('GET /workouts/:id/results ?level=MODIFIED → empty', true, Array.isArray(entries) && entries.length === 0)
+  }
+
+  {
+    // No auth → 401
+    const r = await api('GET', `/workouts/${publishedWorkoutId}/results`)
+    check('GET /workouts/:id/results no auth → 401', 401, r.status)
+  }
+}
+
+// ─── Teardown ─────────────────────────────────────────────────────────────────
+
+async function teardown() {
+  console.log('\n=== Teardown ===')
+  await prisma.result.deleteMany({ where: { workoutId: { in: [publishedWorkoutId, draftWorkoutId] } } })
+  await prisma.workout.deleteMany({ where: { programId } })
+  await prisma.program.delete({ where: { id: programId } }).catch(() => {})
+  await prisma.user.deleteMany({ where: { id: { in: [memberUserId, programmerUserId] } } })
+  await prisma.gym.delete({ where: { id: gymId } }).catch(() => {})
+  console.log('  cleaned up')
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  try {
+    await setup()
+    await runTests()
+  } finally {
+    await teardown()
+    await prisma.$disconnect()
+  }
+  console.log(`\n=== Results: ${pass} passed, ${fail} failed ===\n`)
+  if (fail > 0) process.exit(1)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider } from './context/AuthContext.tsx'
 import RequireAuth from './components/RequireAuth.tsx'
@@ -13,12 +14,14 @@ import Feed from './pages/Feed.tsx'
 import WodDetail from './pages/WodDetail.tsx'
 
 function AppLayout() {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false)
+
   return (
     <div className="flex h-screen bg-gray-950 text-white">
-      <Sidebar />
+      <Sidebar isOpen={mobileNavOpen} onClose={() => setMobileNavOpen(false)} />
       <div className="flex-1 flex flex-col min-h-0">
-        <TopBar />
-        <main className="flex-1 overflow-y-auto p-8">
+        <TopBar onMenuClick={() => setMobileNavOpen(true)} />
+        <main className="flex-1 overflow-y-auto p-4 md:p-8">
           <Routes>
             <Route path="/" element={<Navigate to="/feed" replace />} />
             <Route path="/feed" element={<Feed />} />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,11 +17,11 @@ function AppLayout() {
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
 
   return (
-    <div className="flex h-screen bg-gray-950 text-white">
+    <div className="flex h-screen w-full overflow-x-hidden bg-gray-950 text-white">
       <Sidebar isOpen={mobileNavOpen} onClose={() => setMobileNavOpen(false)} />
-      <div className="flex-1 flex flex-col min-h-0">
+      <div className="flex-1 min-w-0 flex flex-col min-h-0">
         <TopBar onMenuClick={() => setMobileNavOpen(true)} />
-        <main className="flex-1 overflow-y-auto p-4 md:p-8">
+        <main className="flex-1 overflow-y-auto overflow-x-hidden p-4 md:p-8">
           <Routes>
             <Route path="/" element={<Navigate to="/feed" replace />} />
             <Route path="/feed" element={<Feed />} />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,8 @@ import Dashboard from './pages/Dashboard.tsx'
 import Calendar from './pages/Calendar.tsx'
 import Members from './pages/Members.tsx'
 import Settings from './pages/Settings.tsx'
+import Feed from './pages/Feed.tsx'
+import WodDetail from './pages/WodDetail.tsx'
 
 function AppLayout() {
   return (
@@ -18,7 +20,9 @@ function AppLayout() {
         <TopBar />
         <main className="flex-1 overflow-y-auto p-8">
           <Routes>
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/" element={<Navigate to="/feed" replace />} />
+            <Route path="/feed" element={<Feed />} />
+            <Route path="/workouts/:id" element={<WodDetail />} />
             <Route path="/dashboard" element={<Dashboard />} />
             <Route path="/calendar" element={<Calendar />} />
             <Route path="/members" element={<Members />} />

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,31 +1,48 @@
+import { useEffect, useState } from 'react'
 import { NavLink, useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.tsx'
+import { api, type Role } from '../lib/api.ts'
 
-const links = [
-  { to: '/dashboard', label: 'Dashboard' },
-  { to: '/calendar',  label: 'Calendar'  },
-  { to: '/members',   label: 'Members'   },
-  { to: '/settings',  label: 'Settings'  },
+const memberLinks = [
+  { to: '/feed',    label: 'Feed'    },
+  { to: '/history', label: 'History' },
+]
+
+const staffLinks = [
+  { to: '/calendar', label: 'Calendar' },
+  { to: '/members',  label: 'Members'  },
+  { to: '/settings', label: 'Settings' },
 ]
 
 export default function Sidebar() {
   const { user, logout } = useAuth()
   const navigate = useNavigate()
+  const [gymRole, setGymRole] = useState<Role | null>(null)
+
+  useEffect(() => {
+    const gymId = localStorage.getItem('gymId')
+    if (!gymId) return
+    api.me.gyms().then((gyms) => {
+      const myGym = gyms.find((g) => g.id === gymId)
+      if (myGym) setGymRole(myGym.role)
+    }).catch(() => {})
+  }, [])
 
   async function handleSignOut() {
     await logout()
     navigate('/login', { replace: true })
   }
 
+  const isStaff = gymRole && gymRole !== 'MEMBER'
+
   return (
     <aside className="w-64 shrink-0 bg-gray-900 flex flex-col">
       <div className="px-6 py-5 border-b border-gray-800">
         <span className="text-lg font-bold tracking-tight">BernTracker</span>
-        <span className="ml-2 text-xs text-gray-500 uppercase tracking-widest">Admin</span>
       </div>
 
       <nav className="flex-1 px-3 py-4 space-y-1">
-        {links.map(({ to, label }) => (
+        {memberLinks.map(({ to, label }) => (
           <NavLink
             key={to}
             to={to}
@@ -41,6 +58,30 @@ export default function Sidebar() {
             {label}
           </NavLink>
         ))}
+
+        {isStaff && (
+          <>
+            <div className="pt-3 pb-1 px-3">
+              <span className="text-xs text-gray-600 uppercase tracking-widest">Staff</span>
+            </div>
+            {staffLinks.map(({ to, label }) => (
+              <NavLink
+                key={to}
+                to={to}
+                className={({ isActive }) =>
+                  [
+                    'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors',
+                    isActive
+                      ? 'bg-gray-800 text-white'
+                      : 'text-gray-400 hover:bg-gray-800 hover:text-white',
+                  ].join(' ')
+                }
+              >
+                {label}
+              </NavLink>
+            ))}
+          </>
+        )}
       </nav>
 
       <div className="px-4 py-4 border-t border-gray-800">

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -14,7 +14,12 @@ const staffLinks = [
   { to: '/settings', label: 'Settings' },
 ]
 
-export default function Sidebar() {
+interface SidebarProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export default function Sidebar({ isOpen, onClose }: SidebarProps) {
   const { user, logout } = useAuth()
   const navigate = useNavigate()
   const [gymRole, setGymRole] = useState<Role | null>(null)
@@ -35,10 +40,17 @@ export default function Sidebar() {
 
   const isStaff = gymRole && gymRole !== 'MEMBER'
 
-  return (
-    <aside className="w-64 shrink-0 bg-gray-900 flex flex-col">
-      <div className="px-6 py-5 border-b border-gray-800">
+  const navContent = (
+    <>
+      <div className="px-6 py-5 border-b border-gray-800 flex items-center justify-between">
         <span className="text-lg font-bold tracking-tight">BernTracker</span>
+        <button
+          onClick={onClose}
+          className="md:hidden text-gray-500 hover:text-white text-xl leading-none"
+          aria-label="Close menu"
+        >
+          ×
+        </button>
       </div>
 
       <nav className="flex-1 px-3 py-4 space-y-1">
@@ -46,6 +58,7 @@ export default function Sidebar() {
           <NavLink
             key={to}
             to={to}
+            onClick={onClose}
             className={({ isActive }) =>
               [
                 'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors',
@@ -68,6 +81,7 @@ export default function Sidebar() {
               <NavLink
                 key={to}
                 to={to}
+                onClick={onClose}
                 className={({ isActive }) =>
                   [
                     'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors',
@@ -93,6 +107,32 @@ export default function Sidebar() {
           Sign out
         </button>
       </div>
-    </aside>
+    </>
+  )
+
+  return (
+    <>
+      {/* Desktop: static sidebar, always visible */}
+      <aside className="hidden md:flex w-64 shrink-0 bg-gray-900 flex-col">
+        {navContent}
+      </aside>
+
+      {/* Mobile: overlay drawer, controlled by isOpen */}
+      {isOpen && (
+        <div className="fixed inset-0 z-50 md:hidden">
+          <div
+            className="absolute inset-0 bg-black/60"
+            onClick={onClose}
+            aria-hidden="true"
+          />
+          <aside
+            className="relative w-72 h-full bg-gray-900 flex flex-col shadow-2xl"
+            aria-label="Navigation menu"
+          >
+            {navContent}
+          </aside>
+        </div>
+      )}
+    </>
   )
 }

--- a/apps/web/src/components/TopBar.tsx
+++ b/apps/web/src/components/TopBar.tsx
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { api, type MyGym } from '../lib/api'
 
-export default function TopBar() {
+interface TopBarProps {
+  onMenuClick: () => void
+}
+
+export default function TopBar({ onMenuClick }: TopBarProps) {
   const [gyms, setGyms] = useState<MyGym[]>([])
   const currentGymId = localStorage.getItem('gymId') ?? ''
 
@@ -16,26 +20,40 @@ export default function TopBar() {
   }
 
   return (
-    <header className="h-12 flex items-center justify-end px-6 border-b border-gray-800 bg-gray-950 shrink-0">
-      {gyms.length === 0 ? (
-        <Link to="/settings" className="text-sm text-indigo-400 hover:text-indigo-300">
-          Set up a gym →
-        </Link>
-      ) : gyms.length === 1 ? (
-        <span className="text-sm text-gray-300">{gyms[0].name}</span>
-      ) : (
-        <select
-          value={currentGymId}
-          onChange={handleGymChange}
-          className="text-sm bg-gray-800 text-gray-200 border border-gray-700 rounded px-2 py-1 focus:outline-none focus:border-indigo-500"
-        >
-          {gyms.map((g) => (
-            <option key={g.id} value={g.id}>
-              {g.name}
-            </option>
-          ))}
-        </select>
-      )}
+    <header className="h-12 flex items-center px-4 border-b border-gray-800 bg-gray-950 shrink-0">
+      <button
+        onClick={onMenuClick}
+        className="md:hidden mr-3 p-1 text-gray-400 hover:text-white transition-colors"
+        aria-label="Open menu"
+      >
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+          <rect y="3" width="20" height="2" rx="1" />
+          <rect y="9" width="20" height="2" rx="1" />
+          <rect y="15" width="20" height="2" rx="1" />
+        </svg>
+      </button>
+
+      <div className="flex-1 flex justify-end">
+        {gyms.length === 0 ? (
+          <Link to="/settings" className="text-sm text-indigo-400 hover:text-indigo-300">
+            Set up a gym →
+          </Link>
+        ) : gyms.length === 1 ? (
+          <span className="text-sm text-gray-300">{gyms[0].name}</span>
+        ) : (
+          <select
+            value={currentGymId}
+            onChange={handleGymChange}
+            className="text-sm bg-gray-800 text-gray-200 border border-gray-700 rounded px-2 py-1 focus:outline-none focus:border-indigo-500"
+          >
+            {gyms.map((g) => (
+              <option key={g.id} value={g.id}>
+                {g.name}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
     </header>
   )
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -93,6 +93,22 @@ export interface Workout {
   updatedAt: string
 }
 
+export type WorkoutLevel = 'RX_PLUS' | 'RX' | 'SCALED' | 'MODIFIED'
+export type WorkoutGender = 'MALE' | 'FEMALE' | 'OPEN'
+
+export interface WorkoutResult {
+  id: string
+  userId: string
+  workoutId: string
+  level: WorkoutLevel
+  workoutGender: WorkoutGender
+  value: Record<string, unknown>
+  notes: string | null
+  createdAt: string
+  user: { id: string; name: string | null }
+  workout: { type: WorkoutType }
+}
+
 export interface MyGym {
   id: string
   name: string
@@ -202,6 +218,9 @@ export const api = {
     ) =>
       req<Workout>(`/api/workouts/${id}`, { method: 'PATCH', body: JSON.stringify(data), token }),
 
+    get: (id: string, token?: string) =>
+      req<Workout>(`/api/workouts/${id}`, { token }),
+
     publish: (id: string, token?: string) =>
       req<Workout>(`/api/workouts/${id}/publish`, { method: 'POST', token }),
 
@@ -211,7 +230,7 @@ export const api = {
 
   results: {
     leaderboard: (workoutId: string, token?: string) =>
-      req<unknown[]>(`/api/workouts/${workoutId}/results`, { token }),
+      req<WorkoutResult[]>(`/api/workouts/${workoutId}/results`, { token }),
   },
 
   programs: {

--- a/apps/web/src/pages/Feed.tsx
+++ b/apps/web/src/pages/Feed.tsx
@@ -1,0 +1,126 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api, TYPE_ABBR, type Workout } from '../lib/api.ts'
+
+function toDateKey(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+function formatDayLabel(dateKey: string, todayKey: string): string {
+  const [y, mo, d] = dateKey.split('-').map(Number)
+  const date = new Date(y, mo - 1, d)
+  const todayParts = todayKey.split('-').map(Number)
+  const today = new Date(todayParts[0], todayParts[1] - 1, todayParts[2])
+  const tomorrow = new Date(today)
+  tomorrow.setDate(today.getDate() + 1)
+
+  if (dateKey === todayKey) return 'TODAY'
+  if (dateKey === toDateKey(tomorrow)) return 'TOMORROW'
+
+  return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }).toUpperCase()
+}
+
+export default function Feed() {
+  const [gymId] = useState<string | null>(() => localStorage.getItem('gymId'))
+  const [workouts, setWorkouts] = useState<Workout[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const navigate = useNavigate()
+
+  const loadWorkouts = useCallback(async () => {
+    if (!gymId) return
+    setLoading(true)
+    setError(null)
+    try {
+      const today = new Date()
+      const from = new Date(today)
+      from.setDate(today.getDate() - 30)
+      const to = new Date(today)
+      to.setDate(today.getDate() + 14)
+      to.setHours(23, 59, 59, 999)
+      const data = await api.workouts.list(gymId, from.toISOString(), to.toISOString())
+      setWorkouts(data.filter((w) => w.status === 'PUBLISHED'))
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }, [gymId])
+
+  useEffect(() => {
+    loadWorkouts()
+  }, [loadWorkouts])
+
+  if (!gymId) {
+    return (
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold mb-2">Feed</h1>
+        <p className="text-gray-400">Set up your gym in Settings first.</p>
+      </div>
+    )
+  }
+
+  const today = new Date()
+  const todayKey = toDateKey(today)
+
+  const workoutsByDate: Record<string, Workout[]> = {}
+  for (const w of workouts) {
+    const key = toDateKey(new Date(w.scheduledAt))
+    if (!workoutsByDate[key]) workoutsByDate[key] = []
+    workoutsByDate[key].push(w)
+  }
+
+  // Sort: today first, then future ascending, then past descending
+  const allKeys = Object.keys(workoutsByDate)
+  const futureKeys = allKeys.filter((k) => k >= todayKey).sort()
+  const pastKeys = allKeys.filter((k) => k < todayKey).sort().reverse()
+  const sortedKeys = [...futureKeys, ...pastKeys]
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-6">Feed</h1>
+
+      {error && <p className="text-red-400 mb-4">{error}</p>}
+
+      {loading && <p className="text-gray-400">Loading...</p>}
+
+      {!loading && sortedKeys.length === 0 && (
+        <p className="text-gray-400">No published workouts in the last 30 days.</p>
+      )}
+
+      <div className="space-y-8">
+        {sortedKeys.map((dateKey) => (
+          <div key={dateKey}>
+            <div className="flex items-center gap-3 mb-3">
+              <span className="text-xs font-semibold tracking-widest text-gray-400">
+                {formatDayLabel(dateKey, todayKey)}
+              </span>
+              <hr className="flex-1 border-gray-800" />
+            </div>
+
+            <div className="space-y-2">
+              {workoutsByDate[dateKey].map((workout) => (
+                <button
+                  key={workout.id}
+                  onClick={() => navigate(`/workouts/${workout.id}`)}
+                  className="w-full flex items-center gap-3 px-4 py-3 rounded-lg bg-gray-900 hover:bg-gray-800 transition-colors text-left group"
+                >
+                  <span className="shrink-0 w-6 h-6 flex items-center justify-center rounded text-xs font-bold bg-gray-800 text-gray-300 group-hover:bg-gray-700">
+                    {TYPE_ABBR[workout.type]}
+                  </span>
+                  <span className="flex-1 text-sm font-medium text-white truncate">
+                    {workout.title}
+                  </span>
+                  <span className="text-gray-600 group-hover:text-gray-400 transition-colors">›</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/Feed.tsx
+++ b/apps/web/src/pages/Feed.tsx
@@ -106,15 +106,15 @@ export default function Feed() {
                 <button
                   key={workout.id}
                   onClick={() => navigate(`/workouts/${workout.id}`)}
-                  className="w-full flex items-center gap-3 px-4 py-3 rounded-lg bg-gray-900 hover:bg-gray-800 transition-colors text-left group"
+                  className="w-full flex items-start gap-3 px-4 py-3 rounded-lg bg-gray-900 hover:bg-gray-800 transition-colors text-left group"
                 >
-                  <span className="shrink-0 w-6 h-6 flex items-center justify-center rounded text-xs font-bold bg-gray-800 text-gray-300 group-hover:bg-gray-700">
+                  <span className="shrink-0 mt-0.5 w-6 h-6 flex items-center justify-center rounded text-xs font-bold bg-gray-800 text-gray-300 group-hover:bg-gray-700">
                     {TYPE_ABBR[workout.type]}
                   </span>
-                  <span className="flex-1 text-sm font-medium text-white truncate">
+                  <span className="flex-1 min-w-0 text-sm font-medium text-white break-words">
                     {workout.title}
                   </span>
-                  <span className="text-gray-600 group-hover:text-gray-400 transition-colors">›</span>
+                  <span className="shrink-0 mt-0.5 text-gray-600 group-hover:text-gray-400 transition-colors">›</span>
                 </button>
               ))}
             </div>

--- a/apps/web/src/pages/WodDetail.tsx
+++ b/apps/web/src/pages/WodDetail.tsx
@@ -1,0 +1,210 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext.tsx'
+import { api, TYPE_ABBR, type Workout, type WorkoutResult, type WorkoutLevel } from '../lib/api.ts'
+
+type LevelFilter = WorkoutLevel | 'ALL'
+
+const LEVEL_LABELS: Record<WorkoutLevel, string> = {
+  RX_PLUS: 'RX+',
+  RX: 'RX',
+  SCALED: 'Scaled',
+  MODIFIED: 'Modified',
+}
+
+const LEVEL_FILTERS: LevelFilter[] = ['ALL', 'RX_PLUS', 'RX', 'SCALED', 'MODIFIED']
+
+function formatSeconds(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+function formatResultValue(result: WorkoutResult): string {
+  const v = result.value
+  const type = result.workout.type
+
+  if (type === 'AMRAP') {
+    const rounds = v.rounds as number
+    const reps = v.reps as number
+    return `${rounds} rounds + ${reps} reps`
+  }
+
+  if (type === 'FOR_TIME') {
+    if (v.cappedOut) return 'CAPPED'
+    return formatSeconds(v.seconds as number)
+  }
+
+  return '—'
+}
+
+export default function WodDetail() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { user } = useAuth()
+
+  const [workout, setWorkout] = useState<Workout | null>(null)
+  const [results, setResults] = useState<WorkoutResult[]>([])
+  const [levelFilter, setLevelFilter] = useState<LevelFilter>('ALL')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    setLoading(true)
+    setError(null)
+    Promise.all([api.workouts.get(id), api.results.leaderboard(id)])
+      .then(([w, r]) => {
+        setWorkout(w)
+        setResults(r)
+      })
+      .catch((e) => setError((e as Error).message))
+      .finally(() => setLoading(false))
+  }, [id])
+
+  if (loading) {
+    return (
+      <div className="max-w-2xl mx-auto">
+        <p className="text-gray-400">Loading...</p>
+      </div>
+    )
+  }
+
+  if (error || !workout) {
+    return (
+      <div className="max-w-2xl mx-auto">
+        <p className="text-red-400">{error ?? 'Workout not found.'}</p>
+        <button
+          onClick={() => navigate('/feed')}
+          className="mt-4 text-sm text-gray-400 hover:text-white transition-colors"
+        >
+          ← Back to Feed
+        </button>
+      </div>
+    )
+  }
+
+  const scheduledDate = new Date(workout.scheduledAt).toLocaleDateString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+
+  const myResult = results.find((r) => r.userId === user?.id)
+
+  const filteredResults =
+    levelFilter === 'ALL' ? results : results.filter((r) => r.level === levelFilter)
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      {/* Back nav */}
+      <button
+        onClick={() => navigate('/feed')}
+        className="text-sm text-gray-400 hover:text-white transition-colors"
+      >
+        ← Back to Feed
+      </button>
+
+      {/* Header */}
+      <div>
+        <div className="flex items-center gap-3 mb-1">
+          <span className="w-8 h-8 flex items-center justify-center rounded bg-gray-800 text-sm font-bold text-gray-300">
+            {TYPE_ABBR[workout.type]}
+          </span>
+          <h1 className="text-2xl font-bold">{workout.title}</h1>
+        </div>
+        <p className="text-sm text-gray-500 ml-11">{scheduledDate}</p>
+      </div>
+
+      {/* Description */}
+      {workout.description && (
+        <div className="bg-gray-900 rounded-lg px-4 py-3">
+          <p className="text-sm text-gray-300 whitespace-pre-wrap">{workout.description}</p>
+        </div>
+      )}
+
+      {/* Log Result CTA */}
+      {myResult ? (
+        <div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-gray-900 border border-gray-700">
+          <span className="text-xs font-semibold text-gray-400 uppercase tracking-wide">Your Result</span>
+          <span className="text-sm font-medium text-white">{formatResultValue(myResult)}</span>
+          <span className="text-xs text-gray-500 ml-auto">{LEVEL_LABELS[myResult.level]}</span>
+        </div>
+      ) : (
+        <button
+          disabled
+          className="w-full py-2.5 rounded-lg bg-indigo-700 text-white text-sm font-medium opacity-50 cursor-not-allowed"
+          title="Result logging coming soon"
+        >
+          Log Result
+        </button>
+      )}
+
+      {/* Results table */}
+      <div>
+        <div className="flex items-center gap-3 mb-4">
+          <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide">Results</h2>
+          <hr className="flex-1 border-gray-800" />
+        </div>
+
+        {/* Level filter chips */}
+        <div className="flex flex-wrap gap-2 mb-4">
+          {LEVEL_FILTERS.map((lvl) => (
+            <button
+              key={lvl}
+              onClick={() => setLevelFilter(lvl)}
+              className={[
+                'px-3 py-1 rounded-full text-xs font-medium transition-colors',
+                levelFilter === lvl
+                  ? 'bg-gray-200 text-gray-900'
+                  : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-white',
+              ].join(' ')}
+            >
+              {lvl === 'ALL' ? 'All' : LEVEL_LABELS[lvl as WorkoutLevel]}
+            </button>
+          ))}
+        </div>
+
+        {filteredResults.length === 0 ? (
+          <p className="text-sm text-gray-500">No results yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-800 text-left">
+                  <th className="pb-2 pr-4 text-xs font-medium text-gray-500 w-10">#</th>
+                  <th className="pb-2 pr-4 text-xs font-medium text-gray-500">Athlete</th>
+                  <th className="pb-2 pr-4 text-xs font-medium text-gray-500">Level</th>
+                  <th className="pb-2 text-xs font-medium text-gray-500">Result</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredResults.map((result, index) => {
+                  const isMe = result.userId === user?.id
+                  return (
+                    <tr
+                      key={result.id}
+                      className={[
+                        'border-b border-gray-900',
+                        isMe ? 'text-indigo-300' : 'text-gray-300',
+                      ].join(' ')}
+                    >
+                      <td className="py-2.5 pr-4 text-gray-500">{index + 1}</td>
+                      <td className="py-2.5 pr-4 font-medium">
+                        {result.user.name ?? 'Unknown'}
+                        {isMe && <span className="ml-1.5 text-xs text-indigo-400">(you)</span>}
+                      </td>
+                      <td className="py-2.5 pr-4 text-gray-400">{LEVEL_LABELS[result.level]}</td>
+                      <td className="py-2.5 font-mono">{formatResultValue(result)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/tests/feed-wod-detail.spec.ts
+++ b/apps/web/tests/feed-wod-detail.spec.ts
@@ -315,4 +315,27 @@ test.describe('Feed + WOD Detail E2E (#48)', () => {
     // Log Result button is NOT visible when user already has a result
     await expect(page.getByRole('button', { name: 'Log Result' })).not.toBeVisible()
   })
+
+  // ── T10: Feed + WOD Detail usable at 375px (mobile viewport) ────────────
+
+  test('T10: Feed and WOD Detail are usable at 375px mobile viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 })
+    await loginAndGoToFeed(page, MEMBER_EMAIL, MEMBER_PASSWORD)
+
+    // Feed: workout card is still visible and not clipped
+    const card = page.locator('button', { hasText: 'E2E Fran' })
+    await expect(card).toBeVisible()
+    const cardBox = await card.boundingBox()
+    expect(cardBox?.width).toBeGreaterThan(0)
+    expect(cardBox?.x).toBeGreaterThanOrEqual(0)
+
+    // WOD Detail: navigates and renders within viewport
+    await card.click()
+    await page.waitForURL(`**/workouts/${publishedWorkoutId}`)
+    await expect(page.getByRole('heading', { name: 'E2E Fran' })).toBeVisible()
+
+    // Heading must not overflow the viewport
+    const headingBox = await page.getByRole('heading', { name: 'E2E Fran' }).boundingBox()
+    expect((headingBox?.x ?? 0) + (headingBox?.width ?? 0)).toBeLessThanOrEqual(375 + 1)
+  })
 })

--- a/apps/web/tests/feed-wod-detail.spec.ts
+++ b/apps/web/tests/feed-wod-detail.spec.ts
@@ -1,0 +1,318 @@
+/**
+ * Playwright E2E tests for Issue #48 — Feed page + WOD Detail page.
+ *
+ * Covers:
+ *   T1: MEMBER sidebar shows Feed + History only (no Calendar/Members/Settings)
+ *   T2: PROGRAMMER sidebar shows Feed + History + Calendar + Members + Settings
+ *   T3: /feed shows published workouts grouped by day
+ *   T4: Draft workouts do not appear on the feed for MEMBERs
+ *   T5: Clicking a workout card navigates to /workouts/:id (WOD Detail)
+ *   T6: WOD Detail shows workout info (type badge, title, description)
+ *   T7: WOD Detail results table shows logged results
+ *   T8: Level filter chips correctly filter results
+ *   T9: "Your Result" badge appears when the current user has a result
+ *
+ * Requires: turbo dev running (API on :3000, web on :5173)
+ * Run: npm run test --workspace=@berntracker/web
+ *   or: cd apps/web && npx dotenv-cli -e ../../.env -- npx playwright test
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+import { createRequire } from 'module'
+import bcrypt from 'bcryptjs'
+
+const _require = createRequire(import.meta.url)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const { PrismaClient, ProgramRole } = _require('@prisma/client') as any
+const prisma = new PrismaClient()
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const TS = Date.now()
+const MEMBER_EMAIL = `uat-feed-member-${TS}@test.com`
+const MEMBER_PASSWORD = 'TestPass1!'
+const PROGRAMMER_EMAIL = `uat-feed-prog-${TS}@test.com`
+const PROGRAMMER_PASSWORD = 'TestPass1!'
+
+// Fixed future date that won't collide with other test data
+const WORKOUT_DATE = '2026-07-15'
+const WORKOUT_ISO = `${WORKOUT_DATE}T12:00:00.000Z`
+
+let gymId = ''
+let programId = ''
+let memberUserId = ''
+let programmerUserId = ''
+let publishedWorkoutId = ''
+
+// ─── DB helpers ───────────────────────────────────────────────────────────────
+
+async function seedResult(
+  workoutId: string,
+  userId: string,
+  level: string,
+  value: Record<string, unknown>,
+) {
+  return prisma.result.create({
+    data: { workoutId, userId, level, workoutGender: 'OPEN', value },
+  })
+}
+
+// ─── Page helpers ─────────────────────────────────────────────────────────────
+
+async function loginAndGoToFeed(page: Page, email: string, password: string) {
+  await page.goto('/login')
+  await page.fill('#email', email)
+  await page.fill('#password', password)
+  await page.click('button[type="submit"]')
+  await page.waitForURL('**/feed')
+
+  // Feed reads gymId from localStorage on mount
+  await page.evaluate((id) => localStorage.setItem('gymId', id), gymId)
+  await page.goto('/feed')
+  await page.waitForSelector('h1:has-text("Feed")')
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('Feed + WOD Detail E2E (#48)', () => {
+  test.beforeAll(async () => {
+    const [memberHash, programmerHash] = await Promise.all([
+      bcrypt.hash(MEMBER_PASSWORD, 10),
+      bcrypt.hash(PROGRAMMER_PASSWORD, 10),
+    ])
+
+    const gym = await prisma.gym.create({
+      data: { name: `E2E Feed Gym ${TS}`, slug: `e2e-feed-gym-${TS}`, timezone: 'UTC' },
+    })
+    gymId = gym.id
+
+    const [member, programmer] = await Promise.all([
+      prisma.user.create({ data: { email: MEMBER_EMAIL, passwordHash: memberHash, name: 'E2E Member' } }),
+      prisma.user.create({ data: { email: PROGRAMMER_EMAIL, passwordHash: programmerHash, name: 'E2E Programmer' } }),
+    ])
+    memberUserId = member.id
+    programmerUserId = programmer.id
+
+    await prisma.userGym.createMany({
+      data: [
+        { userId: memberUserId, gymId, role: 'MEMBER' },
+        { userId: programmerUserId, gymId, role: 'PROGRAMMER' },
+      ],
+    })
+
+    const program = await prisma.program.create({
+      data: {
+        name: `E2E Feed Program ${TS}`,
+        startDate: new Date('2026-01-01'),
+        gyms: { create: { gymId } },
+        members: {
+          createMany: {
+            data: [
+              { userId: memberUserId, role: ProgramRole.MEMBER },
+              { userId: programmerUserId, role: ProgramRole.PROGRAMMER },
+            ],
+          },
+        },
+      },
+    })
+    programId = program.id
+
+    const published = await prisma.workout.create({
+      data: {
+        title: 'E2E Fran',
+        description: '21-15-9: Thrusters + Pull-ups',
+        type: 'FOR_TIME',
+        status: 'PUBLISHED',
+        scheduledAt: new Date(WORKOUT_ISO),
+        programId,
+        dayOrder: 0,
+      },
+    })
+    publishedWorkoutId = published.id
+
+    // DRAFT workout — should not appear on the MEMBER feed
+    await prisma.workout.create({
+      data: {
+        title: 'E2E Draft Warmup',
+        description: 'Draft warmup',
+        type: 'WARMUP',
+        status: 'DRAFT',
+        scheduledAt: new Date(WORKOUT_ISO),
+        programId,
+        dayOrder: 1,
+      },
+    })
+  })
+
+  test.afterAll(async () => {
+    await prisma.result.deleteMany({ where: { workoutId: publishedWorkoutId } })
+    await prisma.workout.deleteMany({ where: { programId } })
+    await prisma.program.delete({ where: { id: programId } }).catch(() => {})
+    await prisma.user.deleteMany({ where: { id: { in: [memberUserId, programmerUserId] } } })
+    await prisma.gym.delete({ where: { id: gymId } }).catch(() => {})
+    await prisma.$disconnect()
+  })
+
+  // ── T1: MEMBER sidebar shows Feed + History only ─────────────────────────
+
+  test('T1: MEMBER sidebar shows Feed + History only, not staff links', async ({ page }) => {
+    await loginAndGoToFeed(page, MEMBER_EMAIL, MEMBER_PASSWORD)
+
+    // Feed + History must be visible
+    await expect(page.getByRole('link', { name: 'Feed', exact: true })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'History', exact: true })).toBeVisible()
+
+    // Staff links must NOT be present
+    await expect(page.getByRole('link', { name: 'Calendar', exact: true })).not.toBeVisible()
+    await expect(page.getByRole('link', { name: 'Members', exact: true })).not.toBeVisible()
+    await expect(page.getByRole('link', { name: 'Settings', exact: true })).not.toBeVisible()
+  })
+
+  // ── T2: PROGRAMMER sidebar shows all links ───────────────────────────────
+
+  test('T2: PROGRAMMER sidebar shows Feed + History + all staff links', async ({ page }) => {
+    await loginAndGoToFeed(page, PROGRAMMER_EMAIL, PROGRAMMER_PASSWORD)
+
+    // Member links
+    await expect(page.getByRole('link', { name: 'Feed', exact: true })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'History', exact: true })).toBeVisible()
+
+    // Staff links — sidebar fetches gym role asynchronously; wait for Calendar to appear
+    await expect(page.getByRole('link', { name: 'Calendar', exact: true })).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole('link', { name: 'Members', exact: true })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Settings', exact: true })).toBeVisible()
+  })
+
+  // ── T3: Feed shows published workouts grouped by day ─────────────────────
+
+  test('T3: /feed shows published workouts grouped by day', async ({ page }) => {
+    await loginAndGoToFeed(page, MEMBER_EMAIL, MEMBER_PASSWORD)
+
+    // Workout card is present
+    await expect(page.getByText('E2E Fran')).toBeVisible()
+
+    // Type abbreviation badge for FOR_TIME is "F"
+    const card = page.locator('button', { hasText: 'E2E Fran' })
+    await expect(card.getByText('F')).toBeVisible()
+  })
+
+  // ── T4: MEMBER feed does not show draft workouts ─────────────────────────
+
+  test('T4: MEMBER feed does not show draft workouts', async ({ page }) => {
+    await loginAndGoToFeed(page, MEMBER_EMAIL, MEMBER_PASSWORD)
+
+    await expect(page.getByText('E2E Draft Warmup')).not.toBeVisible()
+  })
+
+  // ── T5: Clicking a card navigates to WOD Detail ──────────────────────────
+
+  test('T5: clicking a workout card navigates to /workouts/:id', async ({ page }) => {
+    await loginAndGoToFeed(page, MEMBER_EMAIL, MEMBER_PASSWORD)
+
+    await page.locator('button', { hasText: 'E2E Fran' }).click()
+
+    await page.waitForURL(`**/workouts/${publishedWorkoutId}`)
+    await expect(page.getByRole('heading', { name: 'E2E Fran' })).toBeVisible()
+  })
+
+  // ── T6: WOD Detail shows workout info ────────────────────────────────────
+
+  test('T6: WOD Detail shows type badge, title, date, and description', async ({ page }) => {
+    await loginAndGoToFeed(page, MEMBER_EMAIL, MEMBER_PASSWORD)
+    await page.goto(`/workouts/${publishedWorkoutId}`)
+    await page.waitForSelector(`h1:has-text("E2E Fran")`)
+
+    // Type badge
+    await expect(page.locator('span', { hasText: 'F' }).first()).toBeVisible()
+
+    // Title
+    await expect(page.getByRole('heading', { name: 'E2E Fran' })).toBeVisible()
+
+    // Description
+    await expect(page.getByText('21-15-9: Thrusters + Pull-ups')).toBeVisible()
+
+    // Scheduled date contains "Jul" (July 15)
+    await expect(page.getByText(/Jul.*15.*2026/)).toBeVisible()
+
+    // Log Result button present when user has no result
+    await expect(page.getByRole('button', { name: 'Log Result' })).toBeVisible()
+
+    // Back link
+    await expect(page.getByText('← Back to Feed')).toBeVisible()
+  })
+
+  // ── T7: WOD Detail results table shows logged results ────────────────────
+
+  test('T7: results table shows results after they are logged', async ({ page }) => {
+    // Seed a result directly via Prisma
+    await seedResult(publishedWorkoutId, programmerUserId, 'RX', {
+      type: 'FOR_TIME',
+      seconds: 240,
+      cappedOut: false,
+    })
+
+    await loginAndGoToFeed(page, MEMBER_EMAIL, MEMBER_PASSWORD)
+    await page.goto(`/workouts/${publishedWorkoutId}`)
+    await page.waitForSelector(`h1:has-text("E2E Fran")`)
+
+    // Results section header
+    await expect(page.getByText('Results', { exact: true })).toBeVisible()
+
+    // Programmer's result appears in the table
+    await expect(page.getByText('E2E Programmer')).toBeVisible()
+    await expect(page.getByText('4:00')).toBeVisible()
+
+    // Cleanup result for next test
+    await prisma.result.deleteMany({ where: { workoutId: publishedWorkoutId, userId: programmerUserId } })
+  })
+
+  // ── T8: Level filter chips filter results ────────────────────────────────
+
+  test('T8: level filter chips correctly filter results', async ({ page }) => {
+    // Seed an RX result and a SCALED result
+    await Promise.all([
+      seedResult(publishedWorkoutId, memberUserId, 'RX', { type: 'FOR_TIME', seconds: 185, cappedOut: false }),
+      seedResult(publishedWorkoutId, programmerUserId, 'SCALED', { type: 'FOR_TIME', seconds: 240, cappedOut: false }),
+    ])
+
+    await loginAndGoToFeed(page, MEMBER_EMAIL, MEMBER_PASSWORD)
+    await page.goto(`/workouts/${publishedWorkoutId}`)
+    await page.waitForSelector(`h1:has-text("E2E Fran")`)
+
+    // "All" filter: both results visible
+    await expect(page.getByText('E2E Member')).toBeVisible()
+    await expect(page.getByText('E2E Programmer')).toBeVisible()
+
+    // Click "RX" filter: only E2E Member (RX) visible, programmer hidden
+    await page.getByRole('button', { name: 'RX', exact: true }).click()
+    await expect(page.getByText('E2E Member')).toBeVisible()
+    await expect(page.getByText('E2E Programmer')).not.toBeVisible()
+
+    // Click "Scaled" filter: only programmer visible
+    await page.getByRole('button', { name: 'Scaled' }).click()
+    await expect(page.getByText('E2E Programmer')).toBeVisible()
+    await expect(page.getByText('E2E Member')).not.toBeVisible()
+
+    // Click "All" to reset
+    await page.getByRole('button', { name: 'All' }).click()
+    await expect(page.getByText('E2E Member')).toBeVisible()
+    await expect(page.getByText('E2E Programmer')).toBeVisible()
+  })
+
+  // ── T9: "Your Result" badge when current user has a result ───────────────
+
+  test('T9: "Your Result" badge replaces Log Result button when user has a result', async ({ page }) => {
+    // memberUserId already has an RX result from T8 (seeded above, not cleaned up yet)
+    await loginAndGoToFeed(page, MEMBER_EMAIL, MEMBER_PASSWORD)
+    await page.goto(`/workouts/${publishedWorkoutId}`)
+    await page.waitForSelector(`h1:has-text("E2E Fran")`)
+
+    // "Your Result" label is visible
+    await expect(page.getByText('Your Result')).toBeVisible()
+
+    // Log Result button is NOT visible when user already has a result
+    await expect(page.getByRole('button', { name: 'Log Result' })).not.toBeVisible()
+  })
+})

--- a/apps/web/tests/feed-wod-detail.spec.ts
+++ b/apps/web/tests/feed-wod-detail.spec.ts
@@ -48,6 +48,7 @@ let programId = ''
 let memberUserId = ''
 let programmerUserId = ''
 let publishedWorkoutId = ''
+let longTitleWorkoutId = ''
 
 // ─── DB helpers ───────────────────────────────────────────────────────────────
 
@@ -149,10 +150,24 @@ test.describe('Feed + WOD Detail E2E (#48)', () => {
         dayOrder: 1,
       },
     })
+
+    // Long-title workout — used by T11 to assert wrapping behaviour
+    const longTitle = await prisma.workout.create({
+      data: {
+        title: 'Testing a really long workout title THIS IS THE BEST NAME EVER FOR A WORKOUT',
+        description: 'Long title test',
+        type: 'AMRAP',
+        status: 'PUBLISHED',
+        scheduledAt: new Date(WORKOUT_ISO),
+        programId,
+        dayOrder: 2,
+      },
+    })
+    longTitleWorkoutId = longTitle.id
   })
 
   test.afterAll(async () => {
-    await prisma.result.deleteMany({ where: { workoutId: publishedWorkoutId } })
+    await prisma.result.deleteMany({ where: { workoutId: { in: [publishedWorkoutId, longTitleWorkoutId] } } })
     await prisma.workout.deleteMany({ where: { programId } })
     await prisma.program.delete({ where: { id: programId } }).catch(() => {})
     await prisma.user.deleteMany({ where: { id: { in: [memberUserId, programmerUserId] } } })
@@ -355,5 +370,27 @@ test.describe('Feed + WOD Detail E2E (#48)', () => {
     await page.getByRole('link', { name: 'Feed', exact: true }).click()
     // After navigating, sidebar overlay should be closed
     await expect(page.getByRole('link', { name: 'Feed', exact: true })).not.toBeVisible()
+  })
+
+  // ── T11: Long workout titles wrap without overflowing the card ───────────
+
+  test('T11: long workout titles wrap within the card and do not overflow the viewport', async ({ page }) => {
+    // Test on mobile viewport where overflow is most likely
+    await page.setViewportSize(VIEWPORT_MOBILE)
+    await loginAndGoToFeed(page, MEMBER_EMAIL, MEMBER_PASSWORD)
+
+    const card = page.locator('button', { hasText: 'Testing a really long workout title' })
+    await expect(card).toBeVisible()
+
+    // The full title text must be present in the DOM (not truncated by ellipsis)
+    await expect(card).toContainText('Testing a really long workout title THIS IS THE BEST NAME EVER FOR A WORKOUT')
+
+    // Card must not overflow the viewport — right edge ≤ viewport width
+    const cardBox = await card.boundingBox()
+    expect((cardBox?.x ?? 0) + (cardBox?.width ?? 0)).toBeLessThanOrEqual(VIEWPORT_MOBILE.width)
+
+    // Card must be taller than a single-line card (title has wrapped)
+    // Single-line cards are ~44px tall (py-3 top+bottom = 24px + ~20px text line)
+    expect(cardBox?.height).toBeGreaterThan(48)
   })
 })

--- a/apps/web/tests/feed-wod-detail.spec.ts
+++ b/apps/web/tests/feed-wod-detail.spec.ts
@@ -38,6 +38,11 @@ const PROGRAMMER_PASSWORD = 'TestPass1!'
 const WORKOUT_DATE = '2026-07-15'
 const WORKOUT_ISO = `${WORKOUT_DATE}T12:00:00.000Z`
 
+// iPhone X / 11 Pro logical CSS pixels — 375 is the smallest common phone width
+// (iPhone 6/7/8/SE are also 375 wide); 812 is the X/11 Pro height. Used to
+// verify that the sidebar collapses to a hamburger overlay below md (768px).
+const VIEWPORT_MOBILE = { width: 375, height: 812 }
+
 let gymId = ''
 let programId = ''
 let memberUserId = ''
@@ -316,26 +321,39 @@ test.describe('Feed + WOD Detail E2E (#48)', () => {
     await expect(page.getByRole('button', { name: 'Log Result' })).not.toBeVisible()
   })
 
-  // ── T10: Feed + WOD Detail usable at 375px (mobile viewport) ────────────
+  // ── T10: Collapsible sidebar on mobile (375px) ──────────────────────────
 
-  test('T10: Feed and WOD Detail are usable at 375px mobile viewport', async ({ page }) => {
-    await page.setViewportSize({ width: 375, height: 812 })
+  test('T10: sidebar collapses to hamburger on mobile; opens as overlay; closes on backdrop click', async ({ page }) => {
+    await page.setViewportSize(VIEWPORT_MOBILE)
     await loginAndGoToFeed(page, MEMBER_EMAIL, MEMBER_PASSWORD)
 
-    // Feed: workout card is still visible and not clipped
-    const card = page.locator('button', { hasText: 'E2E Fran' })
-    await expect(card).toBeVisible()
-    const cardBox = await card.boundingBox()
-    expect(cardBox?.width).toBeGreaterThan(0)
-    expect(cardBox?.x).toBeGreaterThanOrEqual(0)
+    // Sidebar nav links are NOT visible by default — sidebar is collapsed
+    await expect(page.getByRole('link', { name: 'Feed', exact: true })).not.toBeVisible()
+    await expect(page.getByRole('link', { name: 'History', exact: true })).not.toBeVisible()
 
-    // WOD Detail: navigates and renders within viewport
-    await card.click()
-    await page.waitForURL(`**/workouts/${publishedWorkoutId}`)
-    await expect(page.getByRole('heading', { name: 'E2E Fran' })).toBeVisible()
+    // Hamburger button is visible
+    const hamburger = page.getByRole('button', { name: 'Open menu' })
+    await expect(hamburger).toBeVisible()
 
-    // Heading must not overflow the viewport
-    const headingBox = await page.getByRole('heading', { name: 'E2E Fran' }).boundingBox()
-    expect((headingBox?.x ?? 0) + (headingBox?.width ?? 0)).toBeLessThanOrEqual(375 + 1)
+    // Main content fills full width (content area starts at x=0 with no sidebar offset)
+    const mainContent = page.locator('main')
+    const mainBox = await mainContent.boundingBox()
+    expect(mainBox?.x).toBe(0)
+    expect(mainBox?.width).toBe(VIEWPORT_MOBILE.width)
+
+    // Opening the menu: sidebar overlay appears with nav links
+    await hamburger.click()
+    await expect(page.getByRole('link', { name: 'Feed', exact: true })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'History', exact: true })).toBeVisible()
+
+    // Close menu by clicking the backdrop (area to the right of the sidebar panel)
+    await page.mouse.click(VIEWPORT_MOBILE.width - 10, VIEWPORT_MOBILE.height / 2)
+    await expect(page.getByRole('link', { name: 'Feed', exact: true })).not.toBeVisible()
+
+    // Navigate to WOD Detail via hamburger → link click (nav link closes menu on click)
+    await hamburger.click()
+    await page.getByRole('link', { name: 'Feed', exact: true }).click()
+    // After navigating, sidebar overlay should be closed
+    await expect(page.getByRole('link', { name: 'Feed', exact: true })).not.toBeVisible()
   })
 })

--- a/apps/web/tests/feed-wod-detail.spec.ts
+++ b/apps/web/tests/feed-wod-detail.spec.ts
@@ -350,6 +350,10 @@ test.describe('Feed + WOD Detail E2E (#48)', () => {
     const hamburger = page.getByRole('button', { name: 'Open menu' })
     await expect(hamburger).toBeVisible()
 
+    // No horizontal scroll — page width must equal viewport width
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth)
+    expect(scrollWidth).toBeLessThanOrEqual(VIEWPORT_MOBILE.width)
+
     // Main content fills full width (content area starts at x=0 with no sidebar offset)
     const mainContent = page.locator('main')
     const mainBox = await mainContent.boundingBox()
@@ -385,7 +389,11 @@ test.describe('Feed + WOD Detail E2E (#48)', () => {
     // The full title text must be present in the DOM (not truncated by ellipsis)
     await expect(card).toContainText('Testing a really long workout title THIS IS THE BEST NAME EVER FOR A WORKOUT')
 
-    // Card must not overflow the viewport — right edge ≤ viewport width
+    // No horizontal scroll — scrollWidth === viewport width means no overflow
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth)
+    expect(scrollWidth).toBeLessThanOrEqual(VIEWPORT_MOBILE.width)
+
+    // Card right edge must not exceed viewport
     const cardBox = await card.boundingBox()
     expect((cardBox?.x ?? 0) + (cardBox?.width ?? 0)).toBeLessThanOrEqual(VIEWPORT_MOBILE.width)
 


### PR DESCRIPTION
Closes #48

## Summary

- **Feed page** (`/feed`) — day-block feed of PUBLISHED workouts, 30 days past → 14 days ahead, sorted today-first. Type abbreviation badges, responsive layout. Replaces `/` → `/feed` as the default landing route. Long workout titles wrap within the card (indent-aligned to the type badge); short titles stay on a single line.
- **WOD Detail page** (`/workouts/:id`) — workout type badge, title, scheduled date, description, placeholder Log Result button (Issue I), and a results table with level filter chips (All / RX+ / RX / Scaled / Modified). Shows a "Your Result" badge when the current user has already logged.
- **Role-aware Sidebar** — Feed + History shown to all roles; Calendar / Members / Settings gated behind OWNER / PROGRAMMER / COACH. Collapsed to a hamburger overlay on viewports < 768px (md breakpoint) so the main content fills the full width on phones.
- **`WorkoutResult` type** — first-class type in `api.ts`, not anchored to leaderboard display. The leaderboard is a sorted/filtered view of these records. `api.workouts.get(id)` added.
- **Workout tagging spec** — design for `movements[]`, `namedWorkout`, and `NamedWorkoutCategory` documented in the plan. WodDetail and Feed are built with conditional rendering gates ready for when the schema lands in a future issue.

## Tests

**API integration** (`apps/api/tests/feed.ts`):
- MEMBER receives only PUBLISHED workouts via gym-scoped list
- PROGRAMMER receives DRAFT + PUBLISHED workouts
- `GET /workouts/:id` response shape — all fields WodDetail depends on present
- `WorkoutResult` shape validation — level, workoutGender, value, nested user + workout
- Leaderboard level filtering — per-level and cross-level grouping
- Auth guards: 401 on missing token, 403 on wrong gym membership

**Playwright E2E** (`apps/web/tests/feed-wod-detail.spec.ts`, 11 tests):
- T1: MEMBER sidebar shows Feed + History only — Calendar / Members / Settings absent
- T2: PROGRAMMER sidebar shows all links including Calendar, Members, Settings
- T3: `/feed` renders published workouts grouped by day with type abbreviation badge
- T4: Draft workouts are hidden from the MEMBER feed
- T5: Clicking a workout card navigates to `/workouts/:id`
- T6: WOD Detail renders type badge, title, formatted date, description, Log Result button, and back link
- T7: Results table shows logged results (athlete name + formatted time)
- T8: Level filter chips correctly filter results client-side (RX hides SCALED, Scaled hides RX, All resets)
- T9: "Your Result" badge replaces Log Result button when the authenticated user has a result
- T10: At 375px (iPhone X logical width): sidebar hidden by default; hamburger opens the overlay; backdrop click closes it; nav link click closes it; `<main>` fills full viewport width
- T11: Long workout title wraps within the card at 375px — full text visible, card stays within viewport bounds, card height exceeds single-line threshold

**Not automated / manual verification needed:**
- [x] Confirm sidebar role-gate transition is visually seamless (no flash of staff links) on first load as OWNER

## Dependencies

- Issue A (#35) — Workout API — closed
- Issue B (#36) — Result API — closed
- Issue C (#37) — Calendar Page — closed
- Issue D (#38) — Workout Drawer — closed
- Issue G (#46) — Multi-workout days — merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)