### PR TITLE
feat: workout tagging — movements + named WODs

### DIFF
--- a/apps/api/src/db/namedWorkoutDbManager.ts
+++ b/apps/api/src/db/namedWorkoutDbManager.ts
@@ -1,0 +1,73 @@
+import { prisma } from '@berntracker/db'
+import type { WorkoutCategory, WorkoutType } from '@berntracker/db'
+
+const templateWorkoutSelect = {
+  select: { id: true, type: true, description: true, movements: true },
+} as const
+
+export async function findAllActiveNamedWorkouts() {
+  return prisma.namedWorkout.findMany({
+    where: { isActive: true },
+    orderBy: { name: 'asc' },
+    include: { templateWorkout: templateWorkoutSelect },
+  })
+}
+
+export async function findNamedWorkoutById(id: string) {
+  return prisma.namedWorkout.findUnique({
+    where: { id },
+    include: { templateWorkout: templateWorkoutSelect },
+  })
+}
+
+export async function createNamedWorkoutWithOptionalTemplate(data: {
+  name: string
+  category: WorkoutCategory
+  aliases?: string[]
+  template?: { type: WorkoutType; description: string; movements?: string[] }
+}) {
+  let templateWorkoutId: string | undefined
+
+  if (data.template) {
+    // Template workout rows have no program, no scheduled date.
+    // Sentinel scheduledAt keeps the non-nullable column satisfied while ensuring
+    // these rows never appear in any gym-scoped date-range query.
+    const tw = await prisma.workout.create({
+      data: {
+        title: data.name,
+        description: data.template.description,
+        type: data.template.type,
+        movements: data.template.movements ?? [],
+        scheduledAt: new Date('2000-01-01T00:00:00Z'),
+      },
+    })
+    templateWorkoutId = tw.id
+  }
+
+  return prisma.namedWorkout.create({
+    data: {
+      name: data.name,
+      category: data.category,
+      aliases: data.aliases ?? [],
+      templateWorkoutId,
+    },
+    include: { templateWorkout: templateWorkoutSelect },
+  })
+}
+
+export async function updateNamedWorkoutById(
+  id: string,
+  data: {
+    name?: string
+    category?: WorkoutCategory
+    aliases?: string[]
+    isActive?: boolean
+    templateWorkoutId?: string | null
+  },
+) {
+  return prisma.namedWorkout.update({
+    where: { id },
+    data,
+    include: { templateWorkout: templateWorkoutSelect },
+  })
+}

--- a/apps/api/src/db/workoutDbManager.ts
+++ b/apps/api/src/db/workoutDbManager.ts
@@ -9,6 +9,8 @@ interface CreateWorkoutData {
   type: WorkoutType
   scheduledAt: Date
   dayOrder?: number
+  movements?: string[]
+  namedWorkoutId?: string
 }
 
 interface UpdateWorkoutData {
@@ -17,6 +19,8 @@ interface UpdateWorkoutData {
   type?: WorkoutType
   scheduledAt?: Date
   dayOrder?: number
+  movements?: string[]
+  namedWorkoutId?: string | null
 }
 
 interface WorkoutDateRangeFilters {
@@ -24,6 +28,7 @@ interface WorkoutDateRangeFilters {
 }
 
 const programSelect = { select: { id: true, name: true } } as const
+const namedWorkoutSelect = { select: { id: true, name: true, category: true } } as const
 
 
 export async function countWorkoutsOnSameDay(gymId: string, scheduledAt: Date): Promise<number> {
@@ -40,7 +45,7 @@ export async function countWorkoutsOnSameDay(gymId: string, scheduledAt: Date): 
 export async function createWorkoutForProgram(data: CreateWorkoutData) {
   return prisma.workout.create({
     data,
-    include: { program: programSelect },
+    include: { program: programSelect, namedWorkout: namedWorkoutSelect },
   })
 }
 
@@ -60,6 +65,7 @@ export async function findWorkoutsByGymAndDateRange(
     orderBy: [{ scheduledAt: 'asc' }, { dayOrder: 'asc' }, { createdAt: 'asc' }],
     include: {
       program: programSelect,
+      namedWorkout: namedWorkoutSelect,
       _count: { select: { results: true } },
     },
   })
@@ -98,6 +104,7 @@ export async function findWorkoutById(id: string) {
     where: { id },
     include: {
       program: programSelect,
+      namedWorkout: namedWorkoutSelect,
       _count: { select: { results: true } },
     },
   })
@@ -115,7 +122,7 @@ export async function updateWorkout(id: string, data: UpdateWorkoutData) {
   return prisma.workout.update({
     where: { id },
     data,
-    include: { program: programSelect },
+    include: { program: programSelect, namedWorkout: namedWorkoutSelect },
   })
 }
 
@@ -123,7 +130,32 @@ export async function publishWorkoutById(id: string) {
   return prisma.workout.update({
     where: { id },
     data: { status: WorkoutStatus.PUBLISHED },
-    include: { program: programSelect },
+    include: { program: programSelect, namedWorkout: namedWorkoutSelect },
+  })
+}
+
+export async function applyTemplateToWorkout(workoutId: string) {
+  const workout = await prisma.workout.findUnique({
+    where: { id: workoutId },
+    select: { namedWorkoutId: true },
+  })
+  if (!workout?.namedWorkoutId) {
+    throw Object.assign(new Error('Workout has no named workout set'), { statusCode: 400 })
+  }
+
+  const namedWorkout = await prisma.namedWorkout.findUnique({
+    where: { id: workout.namedWorkoutId },
+    include: { templateWorkout: { select: { type: true, description: true, movements: true } } },
+  })
+  if (!namedWorkout?.templateWorkout) {
+    throw Object.assign(new Error('Named workout has no template'), { statusCode: 400 })
+  }
+
+  const { type, description, movements } = namedWorkout.templateWorkout
+  return prisma.workout.update({
+    where: { id: workoutId },
+    data: { type, description, movements },
+    include: { program: programSelect, namedWorkout: namedWorkoutSelect },
   })
 }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,6 +7,7 @@ import gymsRouter from './routes/gyms'
 import programsRouter from './routes/programs'
 import workoutsRouter from './routes/workouts'
 import resultsRouter from './routes/results'
+import namedWorkoutsRouter from './routes/namedWorkouts'
 
 const app = express()
 const port = process.env.PORT ?? 3000
@@ -26,6 +27,7 @@ app.use('/api', gymsRouter)
 app.use('/api', programsRouter)
 app.use('/api', workoutsRouter)
 app.use('/api', resultsRouter)
+app.use('/api', namedWorkoutsRouter)
 
 // Global error handler — catches any unhandled exception thrown from route handlers or middleware
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/apps/api/src/routes/namedWorkouts.ts
+++ b/apps/api/src/routes/namedWorkouts.ts
@@ -1,0 +1,65 @@
+import { Router } from 'express'
+import type { Request, Response } from 'express'
+import { requireAuth } from '../middleware/auth.js'
+import {
+  findAllActiveNamedWorkouts,
+  findNamedWorkoutById,
+  createNamedWorkoutWithOptionalTemplate,
+  updateNamedWorkoutById,
+} from '../db/namedWorkoutDbManager.js'
+import { CreateNamedWorkoutSchema, UpdateNamedWorkoutSchema } from '@berntracker/types'
+
+const router = Router()
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+router.get('/named-workouts', requireAuth, listNamedWorkouts)
+router.get('/named-workouts/:id', requireAuth, getNamedWorkout)
+router.post('/named-workouts', requireAuth, createNamedWorkout)
+router.patch('/named-workouts/:id', requireAuth, patchNamedWorkout)
+
+export default router
+
+// ─── Handler functions ────────────────────────────────────────────────────────
+
+async function listNamedWorkouts(_req: Request, res: Response) {
+  const namedWorkouts = await findAllActiveNamedWorkouts()
+  res.json(namedWorkouts)
+}
+
+async function getNamedWorkout(req: Request, res: Response) {
+  const namedWorkout = await findNamedWorkoutById(req.params.id as string)
+  if (!namedWorkout) return res.status(404).json({ error: 'Named workout not found' })
+  res.json(namedWorkout)
+}
+
+async function createNamedWorkout(req: Request, res: Response) {
+  const parsed = CreateNamedWorkoutSchema.safeParse(req.body)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const field = issue?.path[0] ?? 'request'
+    const message = issue?.message ?? 'Invalid request'
+    return res.status(400).json({ error: `${field}: ${message}` })
+  }
+
+  const namedWorkout = await createNamedWorkoutWithOptionalTemplate(parsed.data)
+  res.status(201).json(namedWorkout)
+}
+
+async function patchNamedWorkout(req: Request, res: Response) {
+  const id = req.params.id as string
+
+  const existing = await findNamedWorkoutById(id)
+  if (!existing) return res.status(404).json({ error: 'Named workout not found' })
+
+  const parsed = UpdateNamedWorkoutSchema.safeParse(req.body)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const field = issue?.path[0] ?? 'request'
+    const message = issue?.message ?? 'Invalid request'
+    return res.status(400).json({ error: `${field}: ${message}` })
+  }
+
+  const namedWorkout = await updateNamedWorkoutById(id, parsed.data)
+  res.json(namedWorkout)
+}

--- a/apps/api/src/routes/workouts.ts
+++ b/apps/api/src/routes/workouts.ts
@@ -17,6 +17,7 @@ import {
   publishWorkoutById,
   publishWorkoutsByGymAndDateRange,
   deleteWorkout,
+  applyTemplateToWorkout,
 } from '../db/workoutDbManager.js'
 import {
   findGymMembershipByUserAndGym
@@ -47,6 +48,9 @@ router.patch('/workouts/:id', requireAuth, requireWorkoutProgramWriteAccess, pat
 
 // POST /api/workouts/:id/publish
 router.post('/workouts/:id/publish', requireAuth, requireWorkoutProgramWriteAccess, publishSingleWorkout)
+
+// POST /api/workouts/:id/apply-template
+router.post('/workouts/:id/apply-template', requireAuth, requireWorkoutProgramWriteAccess, applyTemplate)
 
 // DELETE /api/workouts/:id
 router.delete('/workouts/:id', requireAuth, requireWorkoutProgramWriteAccess, deleteWorkoutById)
@@ -134,13 +138,15 @@ async function patchWorkout(req: Request, res: Response) {
     return res.status(400).json({ error: `${field}: ${message}` })
   }
 
-  const { title, description, type, scheduledAt, dayOrder } = parsed.data
+  const { title, description, type, scheduledAt, dayOrder, movements, namedWorkoutId } = parsed.data
   const workout = await updateWorkout(id, {
     title,
     description,
     type,
     scheduledAt: scheduledAt ? new Date(scheduledAt) : undefined,
     dayOrder,
+    movements,
+    namedWorkoutId,
   })
   res.json(workout)
 }
@@ -165,4 +171,13 @@ async function deleteWorkoutById(req: Request, res: Response) {
 
   await deleteWorkout(id)
   res.status(204).send()
+}
+
+async function applyTemplate(req: Request, res: Response) {
+  const id = req.params.id as string
+  const existing = await findWorkoutById(id)
+  if (!existing) return res.status(404).json({ error: 'Workout not found' })
+
+  const workout = await applyTemplateToWorkout(id)
+  res.json(workout)
 }

--- a/apps/api/tests/named-workouts.ts
+++ b/apps/api/tests/named-workouts.ts
@@ -1,0 +1,277 @@
+/**
+ * Lightweight integration tests for NamedWorkout CRUD endpoints and
+ * the apply-template action on workouts.
+ *
+ * Requires: API running on localhost:3000, DB accessible via DATABASE_URL.
+ * Run: cd apps/api && npx tsx tests/named-workouts.ts
+ *
+ * Strategy: seed all fixtures directly via Prisma (no HTTP for setup),
+ * sign tokens in-process, then drive assertions through the live API.
+ * Teardown runs in a finally block so the DB stays clean on failure.
+ */
+
+import { prisma, ProgramRole } from '@berntracker/db'
+import { signTokenPair } from '../src/lib/jwt.js'
+
+const BASE = 'http://localhost:3000/api'
+let pass = 0
+let fail = 0
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function check(label: string, expected: unknown, actual: unknown) {
+  if (String(expected) === String(actual)) {
+    console.log(`  ✓ ${label}`)
+    pass++
+  } else {
+    console.log(`  ✗ ${label}  [expected=${expected} actual=${actual}]`)
+    fail++
+  }
+}
+
+async function api(method: string, path: string, token?: string, body?: unknown) {
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  const text = await res.text()
+  let json: unknown
+  try {
+    json = JSON.parse(text)
+  } catch {
+    json = text
+  }
+  return { status: res.status, body: json as Record<string, unknown> }
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const TS = Date.now()
+let gymId = ''
+let programId = ''
+let workoutId = ''
+let namedWorkoutId = ''
+let programmerToken = ''
+let memberToken = ''
+
+async function setup() {
+  const gym = await prisma.gym.create({
+    data: { name: `NW Test Gym ${TS}`, slug: `nw-test-gym-${TS}`, timezone: 'UTC' },
+  })
+  gymId = gym.id
+
+  const prog = await prisma.user.create({
+    data: {
+      email: `nw-prog-${TS}@test.com`,
+      name: 'NW Programmer',
+      passwordHash: 'x',
+      gyms: { create: { gymId: gym.id, role: 'PROGRAMMER' } },
+    },
+  })
+  const member = await prisma.user.create({
+    data: {
+      email: `nw-member-${TS}@test.com`,
+      name: 'NW Member',
+      passwordHash: 'x',
+      gyms: { create: { gymId: gym.id, role: 'MEMBER' } },
+    },
+  })
+
+  const program = await prisma.program.create({
+    data: {
+      name: `NW Program ${TS}`,
+      startDate: new Date(),
+      gyms: { create: { gymId: gym.id } },
+      members: { create: { userId: prog.id, role: ProgramRole.PROGRAMMER } },
+    },
+  })
+  programId = program.id
+
+  const workout = await prisma.workout.create({
+    data: {
+      title: 'NW Workout',
+      description: 'original description',
+      type: 'AMRAP',
+      scheduledAt: new Date('2030-06-01T12:00:00Z'),
+      programId,
+      movements: [],
+    },
+  })
+  workoutId = workout.id
+
+  const { accessToken: pt } = await signTokenPair(prog.id, prog.email)
+  const { accessToken: mt } = await signTokenPair(member.id, member.email)
+  programmerToken = pt
+  memberToken = mt
+}
+
+async function teardown() {
+  await prisma.workout.deleteMany({ where: { programId } })
+  // Delete any named workouts seeded (template workouts + named workout rows)
+  if (namedWorkoutId) {
+    const nw = await prisma.namedWorkout.findUnique({ where: { id: namedWorkoutId }, select: { templateWorkoutId: true } })
+    await prisma.namedWorkout.delete({ where: { id: namedWorkoutId } }).catch(() => {})
+    if (nw?.templateWorkoutId) {
+      await prisma.workout.delete({ where: { id: nw.templateWorkoutId } }).catch(() => {})
+    }
+  }
+  // Clean up any other named workouts created during tests
+  await prisma.namedWorkout.deleteMany({ where: { name: { contains: `NW-${TS}` } } })
+  await prisma.program.delete({ where: { id: programId } }).catch(() => {})
+  await prisma.gym.delete({ where: { id: gymId } }).catch(() => {})
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+async function testCreateNamedWorkoutNoTemplate() {
+  console.log('\n[POST /named-workouts] — no template')
+  const r = await api('POST', '/named-workouts', programmerToken, {
+    name: `NW-${TS}-Benchmark`,
+    category: 'BENCHMARK',
+    aliases: ['bench'],
+  })
+  check('status 201', 201, r.status)
+  check('name matches', `NW-${TS}-Benchmark`, (r.body as Record<string, unknown>).name)
+  check('category matches', 'BENCHMARK', (r.body as Record<string, unknown>).category)
+  check('templateWorkout is null', 'null', String((r.body as Record<string, unknown>).templateWorkout))
+  // cleanup this one inline
+  const id = (r.body as Record<string, unknown>).id as string
+  await prisma.namedWorkout.delete({ where: { id } }).catch(() => {})
+}
+
+async function testCreateNamedWorkoutWithTemplate() {
+  console.log('\n[POST /named-workouts] — with template')
+  const r = await api('POST', '/named-workouts', programmerToken, {
+    name: `NW-${TS}-Fran`,
+    category: 'GIRL_WOD',
+    aliases: [],
+    template: {
+      type: 'FOR_TIME',
+      description: '21-15-9\nThrusters 95/65\nPull-ups',
+      movements: ['thrusters', 'pull-ups'],
+    },
+  })
+  check('status 201', 201, r.status)
+  check('name matches', `NW-${TS}-Fran`, (r.body as Record<string, unknown>).name)
+  check('category matches', 'GIRL_WOD', (r.body as Record<string, unknown>).category)
+  const tmpl = (r.body as Record<string, unknown>).templateWorkout as Record<string, unknown> | null
+  check('templateWorkout exists', true, tmpl !== null)
+  check('template type', 'FOR_TIME', tmpl?.type)
+  check('template movements', 'thrusters,pull-ups', (tmpl?.movements as string[])?.join(','))
+  namedWorkoutId = (r.body as Record<string, unknown>).id as string
+}
+
+async function testListNamedWorkouts() {
+  console.log('\n[GET /named-workouts]')
+  const r = await api('GET', '/named-workouts', programmerToken)
+  check('status 200', 200, r.status)
+  check('returns array', true, Array.isArray(r.body))
+  const list = r.body as unknown as Record<string, unknown>[]
+  const found = list.find((nw) => nw.id === namedWorkoutId)
+  check('created named workout in list', true, found !== undefined)
+}
+
+async function testGetNamedWorkout() {
+  console.log('\n[GET /named-workouts/:id]')
+  const r = await api('GET', `/named-workouts/${namedWorkoutId}`, programmerToken)
+  check('status 200', 200, r.status)
+  check('id matches', namedWorkoutId, (r.body as Record<string, unknown>).id)
+  const tmpl = (r.body as Record<string, unknown>).templateWorkout as Record<string, unknown> | null
+  check('templateWorkout included', true, tmpl !== null)
+}
+
+async function testPatchNamedWorkout() {
+  console.log('\n[PATCH /named-workouts/:id] — update isActive')
+  const r = await api('PATCH', `/named-workouts/${namedWorkoutId}`, programmerToken, {
+    isActive: false,
+  })
+  check('status 200', 200, r.status)
+  check('isActive false', 'false', String((r.body as Record<string, unknown>).isActive))
+  // Restore active so it still shows in list
+  await api('PATCH', `/named-workouts/${namedWorkoutId}`, programmerToken, { isActive: true })
+}
+
+async function testPatchWorkoutWithMovementsAndNamedWorkout() {
+  console.log('\n[PATCH /workouts/:id] — movements + namedWorkoutId')
+  const r = await api('PATCH', `/workouts/${workoutId}`, programmerToken, {
+    movements: ['thrusters', 'pull-ups'],
+    namedWorkoutId,
+  })
+  check('status 200', 200, r.status)
+  check('movements set', 'thrusters,pull-ups', ((r.body as Record<string, unknown>).movements as string[])?.join(','))
+  check('namedWorkoutId set', namedWorkoutId, (r.body as Record<string, unknown>).namedWorkoutId)
+  const nw = (r.body as Record<string, unknown>).namedWorkout as Record<string, unknown> | null
+  check('namedWorkout included', true, nw !== null)
+  check('namedWorkout name', `NW-${TS}-Fran`, nw?.name)
+}
+
+async function testGetWorkoutIncludesNewFields() {
+  console.log('\n[GET /workouts/:id] — includes movements + namedWorkout')
+  const r = await api('GET', `/workouts/${workoutId}`, programmerToken)
+  check('status 200', 200, r.status)
+  check('movements present', 'thrusters,pull-ups', ((r.body as Record<string, unknown>).movements as string[])?.join(','))
+  const nw = (r.body as Record<string, unknown>).namedWorkout as Record<string, unknown> | null
+  check('namedWorkout present', true, nw !== null)
+  check('namedWorkout category', 'GIRL_WOD', nw?.category)
+}
+
+async function testApplyTemplate() {
+  console.log('\n[POST /workouts/:id/apply-template]')
+  const r = await api('POST', `/workouts/${workoutId}/apply-template`, programmerToken)
+  check('status 200', 200, r.status)
+  check('type copied from template', 'FOR_TIME', (r.body as Record<string, unknown>).type)
+  check('description copied from template', '21-15-9\nThrusters 95/65\nPull-ups', (r.body as Record<string, unknown>).description)
+  check('movements copied from template', 'thrusters,pull-ups', ((r.body as Record<string, unknown>).movements as string[])?.join(','))
+}
+
+async function testApplyTemplateNoNamedWorkout() {
+  console.log('\n[POST /workouts/:id/apply-template] — no named workout → 400')
+  // Clear namedWorkoutId first
+  await api('PATCH', `/workouts/${workoutId}`, programmerToken, { namedWorkoutId: null })
+  const r = await api('POST', `/workouts/${workoutId}/apply-template`, programmerToken)
+  check('status 400', 400, r.status)
+}
+
+async function testRequireAuth() {
+  console.log('\n[Auth guards]')
+  const r1 = await api('GET', '/named-workouts')
+  check('GET /named-workouts requires auth → 401', 401, r1.status)
+  const r2 = await api('POST', '/named-workouts')
+  check('POST /named-workouts requires auth → 401', 401, r2.status)
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('Setting up fixtures...')
+  await setup()
+
+  try {
+    await testCreateNamedWorkoutNoTemplate()
+    await testCreateNamedWorkoutWithTemplate()
+    await testListNamedWorkouts()
+    await testGetNamedWorkout()
+    await testPatchNamedWorkout()
+    await testPatchWorkoutWithMovementsAndNamedWorkout()
+    await testGetWorkoutIncludesNewFields()
+    await testApplyTemplate()
+    await testApplyTemplateNoNamedWorkout()
+    await testRequireAuth()
+  } finally {
+    console.log('\nTearing down fixtures...')
+    await teardown()
+    await prisma.$disconnect()
+  }
+
+  console.log(`\nResults: ${pass} passed, ${fail} failed`)
+  if (fail > 0) process.exit(1)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/apps/web/src/components/WorkoutDrawer.tsx
+++ b/apps/web/src/components/WorkoutDrawer.tsx
@@ -89,6 +89,7 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
   function handleApplyTemplate() {
     const nw = namedWorkouts.find((n) => n.id === namedWorkoutId)
     if (!nw?.templateWorkout) return
+    setTitle(nw.name)
     setType(nw.templateWorkout.type)
     setDescription(nw.templateWorkout.description)
     setMovements(nw.templateWorkout.movements)

--- a/apps/web/src/components/WorkoutDrawer.tsx
+++ b/apps/web/src/components/WorkoutDrawer.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { api, TYPE_ABBR, type GymProgram, type Role, type Workout, type WorkoutType } from '../lib/api'
+import { api, TYPE_ABBR, type GymProgram, type NamedWorkout, type Role, type Workout, type WorkoutType } from '../lib/api'
 
 const TYPE_OPTIONS: { value: WorkoutType; label: string }[] = [
   { value: 'AMRAP', label: 'AMRAP' },
@@ -34,6 +34,10 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
   const [title, setTitle] = useState('')
   const [type, setType] = useState<WorkoutType>('AMRAP')
   const [description, setDescription] = useState('')
+  const [namedWorkouts, setNamedWorkouts] = useState<NamedWorkout[]>([])
+  const [namedWorkoutId, setNamedWorkoutId] = useState<string | null>(null)
+  const [movements, setMovements] = useState<string[]>([])
+  const [movementsInput, setMovementsInput] = useState('')
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [reordering, setReordering] = useState(false)
@@ -41,9 +45,13 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
   const [showPublishConfirm, setShowPublishConfirm] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
-  // Fetch programs when drawer opens (only needed for create mode, but load always so it's ready)
+  // Fetch programs and named workouts when drawer opens
   useEffect(() => {
-    if (!isOpen || isEdit) return
+    if (!isOpen) return
+    api.namedWorkouts.list()
+      .then(setNamedWorkouts)
+      .catch(() => {}) // non-fatal
+    if (isEdit) return
     setProgramsLoading(true)
     api.gyms.programs.list(gymId)
       .then((list) => {
@@ -60,6 +68,9 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
       setType(workout?.type ?? 'AMRAP')
       setDescription(workout?.description ?? '')
       setProgramId(workout?.programId ?? '')
+      setNamedWorkoutId(workout?.namedWorkoutId ?? null)
+      setMovements(workout?.movements ?? [])
+      setMovementsInput('')
       setError(null)
       setShowPublishConfirm(false)
       setShowDeleteConfirm(false)
@@ -75,6 +86,22 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     return () => window.removeEventListener('keydown', onKey)
   }, [isOpen, onClose])
 
+  function handleApplyTemplate() {
+    const nw = namedWorkouts.find((n) => n.id === namedWorkoutId)
+    if (!nw?.templateWorkout) return
+    setType(nw.templateWorkout.type)
+    setDescription(nw.templateWorkout.description)
+    setMovements(nw.templateWorkout.movements)
+  }
+
+  function handleMovementsKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if ((e.key === ',' || e.key === 'Enter') && movementsInput.trim()) {
+      e.preventDefault()
+      setMovements((prev) => [...prev, movementsInput.trim()])
+      setMovementsInput('')
+    }
+  }
+
   function validate() {
     if (!isEdit && !programId) { setError('Program is required'); return false }
     if (!title.trim()) { setError('Title is required'); return false }
@@ -88,10 +115,10 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     setError(null)
     try {
       if (isEdit) {
-        await api.workouts.update(workout.id, { title: title.trim(), description, type })
+        await api.workouts.update(workout.id, { title: title.trim(), description, type, movements, namedWorkoutId })
       } else {
         const scheduledAt = new Date(dateKey! + 'T12:00:00').toISOString()
-        await api.workouts.create(gymId, { programId, title: title.trim(), description, type, scheduledAt })
+        await api.workouts.create(gymId, { programId, title: title.trim(), description, type, scheduledAt, movements, namedWorkoutId: namedWorkoutId ?? undefined })
       }
       onSaved()
       setSaving(false)
@@ -107,11 +134,11 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     setError(null)
     try {
       if (isEdit) {
-        await api.workouts.update(workout.id, { title: title.trim(), description, type })
+        await api.workouts.update(workout.id, { title: title.trim(), description, type, movements, namedWorkoutId })
         await api.workouts.publish(workout.id)
       } else {
         const scheduledAt = new Date(dateKey! + 'T12:00:00').toISOString()
-        const created = await api.workouts.create(gymId, { programId, title: title.trim(), description, type, scheduledAt })
+        const created = await api.workouts.create(gymId, { programId, title: title.trim(), description, type, scheduledAt, movements, namedWorkoutId: namedWorkoutId ?? undefined })
         await api.workouts.publish(created.id)
       }
       onSaved()
@@ -334,6 +361,62 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
               placeholder="Workout details, movements, reps..."
               rows={6}
               className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-indigo-500 resize-none"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">Named Workout <span className="text-gray-600">(optional)</span></label>
+            <div className="flex gap-2">
+              <select
+                value={namedWorkoutId ?? ''}
+                onChange={(e) => setNamedWorkoutId(e.target.value || null)}
+                className="flex-1 bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500"
+              >
+                <option value="">None</option>
+                {namedWorkouts.map((nw) => (
+                  <option key={nw.id} value={nw.id}>{nw.name}</option>
+                ))}
+              </select>
+              {namedWorkoutId && namedWorkouts.find((n) => n.id === namedWorkoutId)?.templateWorkout && (
+                <button
+                  type="button"
+                  onClick={handleApplyTemplate}
+                  className="shrink-0 px-3 py-2 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 hover:text-white rounded transition-colors"
+                  title="Copy type, description, and movements from template"
+                >
+                  Apply Template
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">Movements</label>
+            <div className="flex flex-wrap gap-1.5 mb-2">
+              {movements.map((m, i) => (
+                <span
+                  key={i}
+                  className="flex items-center gap-1 bg-gray-700 text-gray-200 text-xs px-2 py-1 rounded-full"
+                >
+                  {m}
+                  <button
+                    type="button"
+                    onClick={() => setMovements((prev) => prev.filter((_, idx) => idx !== i))}
+                    className="text-gray-400 hover:text-white leading-none"
+                    aria-label={`Remove ${m}`}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+            <input
+              type="text"
+              value={movementsInput}
+              onChange={(e) => setMovementsInput(e.target.value)}
+              onKeyDown={handleMovementsKeyDown}
+              placeholder="e.g. thrusters, pull-ups — press comma or Enter to add"
+              className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-indigo-500"
             />
           </div>
         </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -66,6 +66,7 @@ async function req<T>(path: string, opts: RequestInit & { token?: string } = {})
 
 export type Role = 'OWNER' | 'PROGRAMMER' | 'COACH' | 'MEMBER'
 export type WorkoutType = 'STRENGTH' | 'FOR_TIME' | 'EMOM' | 'CARDIO' | 'AMRAP' | 'METCON' | 'WARMUP'
+export type WorkoutCategory = 'GIRL_WOD' | 'HERO_WOD' | 'OPEN_WOD' | 'GAMES_WOD' | 'BENCHMARK'
 
 export const TYPE_ABBR: Record<WorkoutType, string> = {
   WARMUP: 'W',
@@ -78,6 +79,15 @@ export const TYPE_ABBR: Record<WorkoutType, string> = {
 }
 export type WorkoutStatus = 'DRAFT' | 'PUBLISHED'
 
+export interface NamedWorkout {
+  id: string
+  name: string
+  category: WorkoutCategory
+  aliases: string[]
+  isActive: boolean
+  templateWorkout: { id: string; type: WorkoutType; description: string; movements: string[] } | null
+}
+
 export interface Workout {
   id: string
   title: string
@@ -86,8 +96,11 @@ export interface Workout {
   status: WorkoutStatus
   scheduledAt: string
   dayOrder: number
+  movements: string[]
   programId: string | null
   program: { id: string; name: string } | null
+  namedWorkoutId: string | null
+  namedWorkout: { id: string; name: string; category: WorkoutCategory } | null
   _count: { results: number }
   createdAt: string
   updatedAt: string
@@ -206,14 +219,14 @@ export const api = {
 
     create: (
       gymId: string,
-      data: { programId?: string; title: string; description: string; type: WorkoutType; scheduledAt: string },
+      data: { programId?: string; title: string; description: string; type: WorkoutType; scheduledAt: string; movements?: string[]; namedWorkoutId?: string },
       token?: string,
     ) =>
       req<Workout>(`/api/gyms/${gymId}/workouts`, { method: 'POST', body: JSON.stringify(data), token }),
 
     update: (
       id: string,
-      data: { title?: string; description?: string; type?: WorkoutType; scheduledAt?: string; dayOrder?: number },
+      data: { title?: string; description?: string; type?: WorkoutType; scheduledAt?: string; dayOrder?: number; movements?: string[]; namedWorkoutId?: string | null },
       token?: string,
     ) =>
       req<Workout>(`/api/workouts/${id}`, { method: 'PATCH', body: JSON.stringify(data), token }),
@@ -226,6 +239,30 @@ export const api = {
 
     delete: (id: string, token?: string) =>
       req<void>(`/api/workouts/${id}`, { method: 'DELETE', token }),
+
+    applyTemplate: (id: string, token?: string) =>
+      req<Workout>(`/api/workouts/${id}/apply-template`, { method: 'POST', token }),
+  },
+
+  namedWorkouts: {
+    list: (token?: string) =>
+      req<NamedWorkout[]>('/api/named-workouts', { token }),
+
+    get: (id: string, token?: string) =>
+      req<NamedWorkout>(`/api/named-workouts/${id}`, { token }),
+
+    create: (
+      data: { name: string; category: WorkoutCategory; aliases?: string[]; template?: { type: WorkoutType; description: string; movements?: string[] } },
+      token?: string,
+    ) =>
+      req<NamedWorkout>('/api/named-workouts', { method: 'POST', body: JSON.stringify(data), token }),
+
+    update: (
+      id: string,
+      data: { name?: string; category?: WorkoutCategory; aliases?: string[]; isActive?: boolean; templateWorkoutId?: string | null },
+      token?: string,
+    ) =>
+      req<NamedWorkout>(`/api/named-workouts/${id}`, { method: 'PATCH', body: JSON.stringify(data), token }),
   },
 
   results: {

--- a/apps/web/src/pages/Feed.tsx
+++ b/apps/web/src/pages/Feed.tsx
@@ -111,8 +111,13 @@ export default function Feed() {
                   <span className="shrink-0 mt-0.5 w-6 h-6 flex items-center justify-center rounded text-xs font-bold bg-gray-800 text-gray-300 group-hover:bg-gray-700">
                     {TYPE_ABBR[workout.type]}
                   </span>
-                  <span className="flex-1 min-w-0 text-sm font-medium text-white break-words">
-                    {workout.title}
+                  <span className="flex-1 min-w-0">
+                    <span className="block text-sm font-medium text-white break-words">
+                      {workout.title}
+                    </span>
+                    {workout.namedWorkout && (
+                      <span className="text-xs text-indigo-400">● {workout.namedWorkout.name}</span>
+                    )}
                   </span>
                   <span className="shrink-0 mt-0.5 text-gray-600 group-hover:text-gray-400 transition-colors">›</span>
                 </button>

--- a/apps/web/src/pages/WodDetail.tsx
+++ b/apps/web/src/pages/WodDetail.tsx
@@ -1,7 +1,15 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.tsx'
-import { api, TYPE_ABBR, type Workout, type WorkoutResult, type WorkoutLevel } from '../lib/api.ts'
+import { api, TYPE_ABBR, type Workout, type WorkoutCategory, type WorkoutResult, type WorkoutLevel } from '../lib/api.ts'
+
+const CATEGORY_LABELS: Record<WorkoutCategory, string> = {
+  GIRL_WOD: 'Girl WOD',
+  HERO_WOD: 'Hero WOD',
+  OPEN_WOD: 'Open WOD',
+  GAMES_WOD: 'Games WOD',
+  BENCHMARK: 'Benchmark',
+}
 
 type LevelFilter = WorkoutLevel | 'ALL'
 
@@ -113,6 +121,14 @@ export default function WodDetail() {
             {TYPE_ABBR[workout.type]}
           </span>
           <h1 className="text-2xl font-bold">{workout.title}</h1>
+          {workout.namedWorkout && (
+            <span className="flex items-center gap-1.5 ml-1">
+              <span className="text-sm text-indigo-400">● {workout.namedWorkout.name}</span>
+              <span className="text-xs px-2 py-0.5 rounded-full bg-indigo-900/50 text-indigo-300 border border-indigo-700/40">
+                {CATEGORY_LABELS[workout.namedWorkout.category]}
+              </span>
+            </span>
+          )}
         </div>
         <p className="text-sm text-gray-500 ml-11">{scheduledDate}</p>
       </div>
@@ -121,6 +137,17 @@ export default function WodDetail() {
       {workout.description && (
         <div className="bg-gray-900 rounded-lg px-4 py-3">
           <p className="text-sm text-gray-300 whitespace-pre-wrap">{workout.description}</p>
+        </div>
+      )}
+
+      {/* Movements */}
+      {workout.movements.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {workout.movements.map((m, i) => (
+            <span key={i} className="text-xs px-2.5 py-1 rounded-full bg-gray-800 text-gray-300 border border-gray-700">
+              {m}
+            </span>
+          ))}
         </div>
       )}
 

--- a/packages/db/prisma/migrations/20260413230440_add_named_workout_and_movements/migration.sql
+++ b/packages/db/prisma/migrations/20260413230440_add_named_workout_and_movements/migration.sql
@@ -1,0 +1,32 @@
+-- CreateEnum
+CREATE TYPE "WorkoutCategory" AS ENUM ('GIRL_WOD', 'HERO_WOD', 'OPEN_WOD', 'GAMES_WOD', 'BENCHMARK');
+
+-- AlterTable
+ALTER TABLE "Workout" ADD COLUMN     "movements" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "namedWorkoutId" TEXT;
+
+-- CreateTable
+CREATE TABLE "NamedWorkout" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "category" "WorkoutCategory" NOT NULL,
+    "aliases" TEXT[],
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "templateWorkoutId" TEXT,
+
+    CONSTRAINT "NamedWorkout_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NamedWorkout_name_key" ON "NamedWorkout"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NamedWorkout_templateWorkoutId_key" ON "NamedWorkout"("templateWorkoutId");
+
+-- AddForeignKey
+ALTER TABLE "NamedWorkout" ADD CONSTRAINT "NamedWorkout_templateWorkoutId_fkey" FOREIGN KEY ("templateWorkoutId") REFERENCES "Workout"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Workout" ADD CONSTRAINT "Workout_namedWorkoutId_fkey" FOREIGN KEY ("namedWorkoutId") REFERENCES "NamedWorkout"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -63,6 +63,14 @@ enum ProgramRole {
   PROGRAMMER
 }
 
+enum WorkoutCategory {
+  GIRL_WOD    // e.g. Fran, Cindy, Grace
+  HERO_WOD    // e.g. Murph, Badger, DT
+  OPEN_WOD    // e.g. 22.1, 23.3
+  GAMES_WOD   // individual/team events from the Games
+  BENCHMARK   // other common benchmarks (Fight Gone Bad, etc.)
+}
+
 // ─── Models ───────────────────────────────────────────────────────────────────
 
 model User {
@@ -166,6 +174,20 @@ model UserProgram {
   @@id([userId, programId])
 }
 
+model NamedWorkout {
+  id                String          @id @default(cuid())
+  name              String          @unique
+  category          WorkoutCategory
+  aliases           String[]
+  isActive          Boolean         @default(true)
+  createdAt         DateTime        @default(now())
+  updatedAt         DateTime        @updatedAt
+
+  templateWorkoutId String?         @unique
+  templateWorkout   Workout?        @relation("NamedWorkoutTemplate", fields: [templateWorkoutId], references: [id])
+  workouts          Workout[]       @relation("NamedWorkoutInstances")
+}
+
 model Workout {
   id          String        @id @default(cuid())
   programId   String?
@@ -175,12 +197,16 @@ model Workout {
   status      WorkoutStatus @default(DRAFT)
   scheduledAt DateTime
   dayOrder    Int           @default(0)
+  movements   String[]      @default([])
+  namedWorkoutId String?
   createdAt   DateTime      @default(now())
   updatedAt   DateTime      @updatedAt
 
   // nullable: members can log personal workouts outside any program
-  program Program?  @relation(fields: [programId], references: [id], onDelete: SetNull)
-  results Result[]
+  program      Program?      @relation(fields: [programId], references: [id], onDelete: SetNull)
+  results      Result[]
+  namedWorkout NamedWorkout? @relation("NamedWorkoutInstances", fields: [namedWorkoutId], references: [id])
+  templateFor  NamedWorkout? @relation("NamedWorkoutTemplate")  // required by Prisma parser — not used in queries
 }
 
 model Result {

--- a/packages/types/src/workout.ts
+++ b/packages/types/src/workout.ts
@@ -2,6 +2,8 @@ import { z } from 'zod'
 
 export const WorkoutTypeSchema = z.enum(['STRENGTH', 'FOR_TIME', 'EMOM', 'CARDIO', 'AMRAP', 'METCON', 'WARMUP'])
 
+export const WorkoutCategorySchema = z.enum(['GIRL_WOD', 'HERO_WOD', 'OPEN_WOD', 'GAMES_WOD', 'BENCHMARK'])
+
 export const CreateWorkoutSchema = z.object({
   programId: z.string().optional(),
   title: z.string().min(1, 'Title is required'),
@@ -9,6 +11,8 @@ export const CreateWorkoutSchema = z.object({
   type: WorkoutTypeSchema,
   scheduledAt: z.string().datetime(),
   dayOrder: z.number().int().min(0).optional(),
+  movements: z.array(z.string().min(1)).optional(),
+  namedWorkoutId: z.string().optional(),
 })
 
 export const UpdateWorkoutSchema = z
@@ -18,8 +22,33 @@ export const UpdateWorkoutSchema = z
     type: WorkoutTypeSchema.optional(),
     scheduledAt: z.string().datetime().optional(),
     dayOrder: z.number().int().min(0).optional(),
+    movements: z.array(z.string().min(1)).optional(),
+    namedWorkoutId: z.string().nullable().optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, { message: 'At least one field is required' })
+
+export const CreateNamedWorkoutSchema = z.object({
+  name: z.string().min(1),
+  category: WorkoutCategorySchema,
+  aliases: z.array(z.string()).optional(),
+  template: z.object({
+    type: WorkoutTypeSchema,
+    description: z.string().min(1),
+    movements: z.array(z.string().min(1)).optional(),
+  }).optional(),
+})
+
+export const UpdateNamedWorkoutSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    category: WorkoutCategorySchema.optional(),
+    aliases: z.array(z.string()).optional(),
+    isActive: z.boolean().optional(),
+    templateWorkoutId: z.string().nullable().optional(),
   })
   .refine((data) => Object.keys(data).length > 0, { message: 'At least one field is required' })
 
 export type CreateWorkoutInput = z.infer<typeof CreateWorkoutSchema>
 export type UpdateWorkoutInput = z.infer<typeof UpdateWorkoutSchema>
+export type CreateNamedWorkoutInput = z.infer<typeof CreateNamedWorkoutSchema>
+export type UpdateNamedWorkoutInput = z.infer<typeof UpdateNamedWorkoutSchema>


### PR DESCRIPTION
## Summary

- Adds `NamedWorkout` table (normalized benchmark/hero/girl WODs) with optional FK to a canonical template `Workout` row; `Workout` gains a `movements[]` array
- New `/named-workouts` CRUD API (list, get, create with optional template, patch); `POST /workouts/:id/apply-template` copies type/description/movements from the named workout's template
- `WorkoutDrawer` gains a named workout selector, "Apply Template" button (client-side copy from template data already in the dropdown), and a movements chip input
- Feed card shows a `● Name` pill for tagged workouts; WodDetail shows a name badge, category chip, and movements chips below description

## Dependencies

Branches from `slice-5/member-web-feed-wod-detail` (PR #54) so `Feed.tsx` and `WodDetail.tsx` are present. When #54 merges to main, this branch rebases cleanly.

## Schema migration

Migration `20260413230440_add_named_workout_and_movements` committed — run `npm run db:migrate` after checking out.

## Test plan

- [x] `npx tsx apps/api/tests/named-workouts.ts` — all assertions pass
- [x] `POST /api/named-workouts` with template body → 201, templateWorkout populated
- [x] Open WorkoutDrawer → named workout dropdown populated from API
- [x] Select a named workout with a template → "Apply Template" button appears → click → type/description/movements pre-fill
- [x] Add movements chips via comma/Enter → save → `GET /workouts/:id` returns both `movements` and `namedWorkout`
- [x] Feed card shows `● Fran` pill for a tagged workout
- [x] WodDetail shows name badge + category chip + movements chips

Part of #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)