### PR TITLE
feat(api): request/response logging middleware with createLogger factory

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,7 +8,8 @@ import programsRouter from './routes/programs'
 import workoutsRouter from './routes/workouts'
 import resultsRouter from './routes/results'
 import namedWorkoutsRouter from './routes/namedWorkouts'
-import { createLogger, Log } from './lib/logger.js'
+import { createLogger } from './lib/logger.js'
+import { requestLogger } from './middleware/requestLogger.js'
 
 const app = express()
 const port = process.env.PORT ?? 3000
@@ -16,6 +17,7 @@ const port = process.env.PORT ?? 3000
 app.use(cors({ origin: 'http://localhost:5173', credentials: true }))
 app.use(express.json())
 app.use(cookieParser())
+app.use(requestLogger)
 
 app.use('/api/auth', authRouter)
 
@@ -36,7 +38,7 @@ const logError = createLogger('error')
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((err: unknown, req: Request, res: Response, _next: NextFunction) => {
   const message = err instanceof Error ? err.message : String(err)
-  logError(Log.ERROR, req, `${req.method} ${req.path} — ${message}`, err)
+  logError.error(req, `${req.method} ${req.path} — ${message}`, err)
   res.status(500).json({ error: 'Internal server error' })
 })
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import programsRouter from './routes/programs'
 import workoutsRouter from './routes/workouts'
 import resultsRouter from './routes/results'
 import namedWorkoutsRouter from './routes/namedWorkouts'
+import { createLogger, Log } from './lib/logger.js'
 
 const app = express()
 const port = process.env.PORT ?? 3000
@@ -29,11 +30,13 @@ app.use('/api', workoutsRouter)
 app.use('/api', resultsRouter)
 app.use('/api', namedWorkoutsRouter)
 
+const logError = createLogger('error')
+
 // Global error handler — catches any unhandled exception thrown from route handlers or middleware
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((err: unknown, req: Request, res: Response, _next: NextFunction) => {
   const message = err instanceof Error ? err.message : String(err)
-  console.log(`[error] ${req.method} ${req.path} — ${message}`, err)
+  logError(Log.ERROR, req, `${req.method} ${req.path} — ${message}`, err)
   res.status(500).json({ error: 'Internal server error' })
 })
 

--- a/apps/api/src/lib/logger.ts
+++ b/apps/api/src/lib/logger.ts
@@ -1,34 +1,49 @@
 import type { Request } from 'express'
 
-export const Log = {
-  ERROR: 'ERROR',
-  WARNING: 'WARNING',
-  INFO: 'INFO',
-  DEBUG: 'DEBUG',
-} as const
+type LogLevel = 'ERROR' | 'WARNING' | 'INFO' | 'DEBUG'
 
-export type LogLevel = (typeof Log)[keyof typeof Log]
+function emit(level: LogLevel, tag: string, reqOrMessage: Request | string, args: unknown[]): void {
+  if (typeof reqOrMessage === 'string') {
+    console.log(`${level} [${tag}] ${reqOrMessage}`, ...args)
+  } else {
+    const id = reqOrMessage.requestId
+    const prefix = id ? `${level} [${tag}](${id})` : `${level} [${tag}]`
+    const [message, ...extra] = args as [string, ...unknown[]]
+    console.log(`${prefix} ${message}`, ...extra)
+  }
+}
+
+export interface Logger {
+  error(req: Request, message: string, ...extra: unknown[]): void
+  error(message: string, ...extra: unknown[]): void
+  warning(req: Request, message: string, ...extra: unknown[]): void
+  warning(message: string, ...extra: unknown[]): void
+  info(req: Request, message: string, ...extra: unknown[]): void
+  info(message: string, ...extra: unknown[]): void
+  debug(req: Request, message: string, ...extra: unknown[]): void
+  debug(message: string, ...extra: unknown[]): void
+}
 
 /**
- * Returns a log function tagged with the given label.
+ * Returns a logger tagged with the given label. Each method maps to a log level:
  *
- * With a request:    log(level, req, message)  → LEVEL [tag](requestId) message
- * Without a request: log(level, message)        → LEVEL [tag] message
- *
- * Any additional arguments are forwarded to console.log (e.g. error objects).
+ *   log.info(req, message)   → INFO [tag](requestId) message
+ *   log.warning(message)     → WARNING [tag] message
+ *   log.error(req, msg, err) → ERROR [tag](requestId) msg  { err }
  */
-export function createLogger(tag: string) {
-  function log(level: LogLevel, req: Request, message: string, ...extra: unknown[]): void
-  function log(level: LogLevel, message: string, ...extra: unknown[]): void
-  function log(level: LogLevel, reqOrMessage: Request | string, ...args: unknown[]): void {
-    if (typeof reqOrMessage === 'string') {
-      console.log(`${level} [${tag}] ${reqOrMessage}`, ...args)
-    } else {
-      const id = reqOrMessage.requestId
-      const prefix = id ? `${level} [${tag}](${id})` : `${level} [${tag}]`
-      const [message, ...extra] = args as [string, ...unknown[]]
-      console.log(`${prefix} ${message}`, ...extra)
-    }
+export function createLogger(tag: string): Logger {
+  return {
+    error(reqOrMessage: Request | string, ...args: unknown[]) {
+      emit('ERROR', tag, reqOrMessage as Request, args)
+    },
+    warning(reqOrMessage: Request | string, ...args: unknown[]) {
+      emit('WARNING', tag, reqOrMessage as Request, args)
+    },
+    info(reqOrMessage: Request | string, ...args: unknown[]) {
+      emit('INFO', tag, reqOrMessage as Request, args)
+    },
+    debug(reqOrMessage: Request | string, ...args: unknown[]) {
+      emit('DEBUG', tag, reqOrMessage as Request, args)
+    },
   }
-  return log
 }

--- a/apps/api/src/lib/logger.ts
+++ b/apps/api/src/lib/logger.ts
@@ -1,0 +1,34 @@
+import type { Request } from 'express'
+
+export const Log = {
+  ERROR: 'ERROR',
+  WARNING: 'WARNING',
+  INFO: 'INFO',
+  DEBUG: 'DEBUG',
+} as const
+
+export type LogLevel = (typeof Log)[keyof typeof Log]
+
+/**
+ * Returns a log function tagged with the given label.
+ *
+ * With a request:    log(level, req, message)  → LEVEL [tag](requestId) message
+ * Without a request: log(level, message)        → LEVEL [tag] message
+ *
+ * Any additional arguments are forwarded to console.log (e.g. error objects).
+ */
+export function createLogger(tag: string) {
+  function log(level: LogLevel, req: Request, message: string, ...extra: unknown[]): void
+  function log(level: LogLevel, message: string, ...extra: unknown[]): void
+  function log(level: LogLevel, reqOrMessage: Request | string, ...args: unknown[]): void {
+    if (typeof reqOrMessage === 'string') {
+      console.log(`${level} [${tag}] ${reqOrMessage}`, ...args)
+    } else {
+      const id = reqOrMessage.requestId
+      const prefix = id ? `${level} [${tag}](${id})` : `${level} [${tag}]`
+      const [message, ...extra] = args as [string, ...unknown[]]
+      console.log(`${prefix} ${message}`, ...extra)
+    }
+  }
+  return log
+}

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,14 +1,14 @@
 import type { Request, Response, NextFunction } from 'express'
 import type { Role } from '@berntracker/db'
 import { verifyAccessToken } from '../lib/jwt.js'
-import { createLogger, Log } from '../lib/logger.js'
+import { createLogger } from '../lib/logger.js'
 
 const log = createLogger('auth')
 
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
   const header = req.headers.authorization
   if (!header?.startsWith('Bearer ')) {
-    log(Log.WARNING, req, `requireAuth: missing or malformed Authorization header — ${req.method} ${req.path}`)
+    log.warning(req, `requireAuth: missing or malformed Authorization header — ${req.method} ${req.path}`)
     res.status(401).json({ error: 'Missing or invalid Authorization header' })
     return
   }
@@ -18,7 +18,7 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
     req.user = { id: sub, role }
     next()
   } catch (err) {
-    log(Log.WARNING, req, `requireAuth: token verification failed — ${req.method} ${req.path}`, err instanceof Error ? err.message : err)
+    log.warning(req, `requireAuth: token verification failed — ${req.method} ${req.path}`, err instanceof Error ? err.message : err)
     res.status(401).json({ error: 'Invalid or expired token' })
   }
 }
@@ -26,7 +26,7 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
 export function requireRole(...roles: Role[]) {
   return (req: Request, res: Response, next: NextFunction): void => {
     if (!req.user || !roles.includes(req.user.role)) {
-      log(Log.WARNING, req, `requireRole: access denied — ${req.method} ${req.path} — userId=${req.user?.id ?? 'none'} role=${req.user?.role ?? 'none'} required=${roles.join('|')}`)
+      log.warning(req, `requireRole: access denied — ${req.method} ${req.path} — userId=${req.user?.id ?? 'none'} role=${req.user?.role ?? 'none'} required=${roles.join('|')}`)
       res.status(403).json({ error: 'Forbidden' })
       return
     }

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,11 +1,14 @@
 import type { Request, Response, NextFunction } from 'express'
 import type { Role } from '@berntracker/db'
 import { verifyAccessToken } from '../lib/jwt.js'
+import { createLogger, Log } from '../lib/logger.js'
+
+const log = createLogger('auth')
 
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
   const header = req.headers.authorization
   if (!header?.startsWith('Bearer ')) {
-    console.log(`[auth] requireAuth: missing or malformed Authorization header — ${req.method} ${req.path}`)
+    log(Log.WARNING, req, `requireAuth: missing or malformed Authorization header — ${req.method} ${req.path}`)
     res.status(401).json({ error: 'Missing or invalid Authorization header' })
     return
   }
@@ -15,7 +18,7 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
     req.user = { id: sub, role }
     next()
   } catch (err) {
-    console.log(`[auth] requireAuth: token verification failed — ${req.method} ${req.path}`, err instanceof Error ? err.message : err)
+    log(Log.WARNING, req, `requireAuth: token verification failed — ${req.method} ${req.path}`, err instanceof Error ? err.message : err)
     res.status(401).json({ error: 'Invalid or expired token' })
   }
 }
@@ -23,7 +26,7 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
 export function requireRole(...roles: Role[]) {
   return (req: Request, res: Response, next: NextFunction): void => {
     if (!req.user || !roles.includes(req.user.role)) {
-      console.log(`[auth] requireRole: access denied — ${req.method} ${req.path} — userId=${req.user?.id ?? 'none'} role=${req.user?.role ?? 'none'} required=${roles.join('|')}`)
+      log(Log.WARNING, req, `requireRole: access denied — ${req.method} ${req.path} — userId=${req.user?.id ?? 'none'} role=${req.user?.role ?? 'none'} required=${roles.join('|')}`)
       res.status(403).json({ error: 'Forbidden' })
       return
     }

--- a/apps/api/src/middleware/gym.ts
+++ b/apps/api/src/middleware/gym.ts
@@ -3,6 +3,9 @@ import { findGymById } from '../db/gymDbManager.js'
 import { findGymMembershipByUserAndGym } from '../db/userGymDbManager.js'
 import { findWorkoutProgramId } from '../db/workoutDbManager.js'
 import { findUserProgramMembership } from '../db/userProgramDbManager.js'
+import { createLogger, Log } from '../lib/logger.js'
+
+const log = createLogger('gym')
 
 const writeAccessRoles = ['OWNER', 'PROGRAMMER', 'COACH'];
 
@@ -97,7 +100,7 @@ export async function requireWorkoutProgramWriteAccess(req: Request, res: Respon
   }
   const membership = await findUserProgramMembership(userId, workout.programId)
   if (!checkMembershipHasWriteAccessRoles(membership)) {
-    console.log("Membership does not have write access roles:", membership)
+    log(Log.WARNING, req, `requireWorkoutProgramWriteAccess: insufficient role — ${req.method} ${req.path} — userId=${req.user?.id ?? 'none'} role=${membership?.role ?? 'none'}`, membership)
     res.status(403).json({ error: 'Forbidden' })
     return
   }

--- a/apps/api/src/middleware/gym.ts
+++ b/apps/api/src/middleware/gym.ts
@@ -3,7 +3,7 @@ import { findGymById } from '../db/gymDbManager.js'
 import { findGymMembershipByUserAndGym } from '../db/userGymDbManager.js'
 import { findWorkoutProgramId } from '../db/workoutDbManager.js'
 import { findUserProgramMembership } from '../db/userProgramDbManager.js'
-import { createLogger, Log } from '../lib/logger.js'
+import { createLogger } from '../lib/logger.js'
 
 const log = createLogger('gym')
 
@@ -100,7 +100,7 @@ export async function requireWorkoutProgramWriteAccess(req: Request, res: Respon
   }
   const membership = await findUserProgramMembership(userId, workout.programId)
   if (!checkMembershipHasWriteAccessRoles(membership)) {
-    log(Log.WARNING, req, `requireWorkoutProgramWriteAccess: insufficient role — ${req.method} ${req.path} — userId=${req.user?.id ?? 'none'} role=${membership?.role ?? 'none'}`, membership)
+    log.warning(req, `requireWorkoutProgramWriteAccess: insufficient role — ${req.method} ${req.path} — userId=${req.user?.id ?? 'none'} role=${membership?.role ?? 'none'}`, membership)
     res.status(403).json({ error: 'Forbidden' })
     return
   }

--- a/apps/api/src/middleware/requestLogger.ts
+++ b/apps/api/src/middleware/requestLogger.ts
@@ -1,0 +1,19 @@
+import type { Request, Response, NextFunction } from 'express'
+import { createLogger } from '../lib/logger.js'
+
+const request = createLogger('request')
+const response = createLogger('response')
+
+export function requestLogger(req: Request, res: Response, next: NextFunction): void {
+  req.requestId = crypto.randomUUID()
+  const start = Date.now()
+
+  request.info(req, `${req.method} ${req.path} —`)
+
+  res.on('finish', () => {
+    const elapsed = Date.now() - start
+    response.info(req, `${req.method} ${req.path} ${res.statusCode} ${elapsed}ms —`)
+  })
+
+  next()
+}

--- a/apps/api/src/routes/workouts.ts
+++ b/apps/api/src/routes/workouts.ts
@@ -74,7 +74,6 @@ async function getWorkoutsByGymAndDateRange(req: Request, res: Response) {
 
   const membership = await findGymMembershipByUserAndGym(req.user!.id, gymId)
   const publishedOnly = membership?.role === Role.MEMBER
-  console.log(membership?.role)
   const workouts = await findWorkoutsByGymAndDateRange(gymId, fromDate, toDate, { publishedOnly })
   res.json(workouts)
 }

--- a/apps/api/src/types/express.d.ts
+++ b/apps/api/src/types/express.d.ts
@@ -3,6 +3,7 @@ declare global {
   namespace Express {
     interface Request {
       user?: { id: string; role: Role }
+      requestId: string
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `createLogger(tag)` factory (`apps/api/src/lib/logger.ts`) — returns a logger with named methods (`log.error`, `log.warning`, `log.info`, `log.debug`) so the level is expressed at the call site without an extra parameter
- Adds `apps/api/src/middleware/requestLogger.ts` — generates a `requestId` via `crypto.randomUUID()`, attaches it to `req`, and emits an `INFO [request](id)` line on arrival and an `INFO [response](id)` line with status + elapsed ms on finish
- Mounts `requestLogger` in `index.ts` before all routers so every route is covered
- Adds `requestId: string` to the Express `Request` type augmentation
- Migrates all existing ad-hoc `console.log` calls in `auth.ts`, `gym.ts`, `index.ts` to use the named logger methods; removes a bare debug log from `workouts.ts`

**Log output example:**
```
INFO [request](f47ac10b-58cc-4372-a567-0e02b2c3d479) GET /api/workouts/abc123 —
WARNING [auth](f47ac10b-58cc-4372-a567-0e02b2c3d479) requireAuth: token verification failed — GET /api/workouts/abc123
INFO [response](f47ac10b-58cc-4372-a567-0e02b2c3d479) GET /api/workouts/abc123 401 3ms —
```

## Tests

**Not automated / manual verification needed:**
- [x] Start the API, make a request — confirm `INFO [request](...)` and `INFO [response](...)` lines appear in server output with the same requestId
- [x] Hit a protected route without a token — confirm `WARNING [auth](...)` appears between the request and response lines
- [ ] Trigger a 500 — confirm `ERROR [error](...)` appears with the same requestId as the `[request]` line

Existing API integration tests (`apps/api/tests/`) cover auth and gym middleware behaviour end-to-end; log output format is not asserted in automated tests.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)