### PR TITLE
feat(api): normalize movements — schema, seed, and DB manager foundation

### DIFF
--- a/apps/api/src/db/movementDbManager.ts
+++ b/apps/api/src/db/movementDbManager.ts
@@ -1,0 +1,30 @@
+import { prisma } from '@berntracker/db'
+
+const movementBaseSelect = {
+  select: { id: true, name: true, status: true, parentId: true },
+} as const
+
+const movementWithVariationsSelect = {
+  select: {
+    id: true,
+    name: true,
+    status: true,
+    parentId: true,
+    parent: { select: { id: true, name: true } },
+    variations: { select: { id: true, name: true } },
+  },
+} as const
+
+export async function findAllActiveMovements() {
+  return prisma.movement.findMany({
+    where: { status: 'ACTIVE' },
+    orderBy: { name: 'asc' },
+    ...movementBaseSelect,
+  })
+}
+
+export async function findMovementById(id: string) {
+  const movement = await prisma.movement.findUnique({ where: { id }, ...movementWithVariationsSelect })
+  if (!movement) throw Object.assign(new Error('Movement not found'), { statusCode: 404 })
+  return movement
+}

--- a/apps/api/src/db/namedWorkoutDbManager.ts
+++ b/apps/api/src/db/namedWorkoutDbManager.ts
@@ -2,7 +2,17 @@ import { prisma } from '@berntracker/db'
 import type { WorkoutCategory, WorkoutType } from '@berntracker/db'
 
 const templateWorkoutSelect = {
-  select: { id: true, type: true, description: true, movements: true },
+  select: {
+    id: true,
+    type: true,
+    description: true,
+    workoutMovements: {
+      select: {
+        movementId: true,
+        movement: { select: { id: true, name: true, parentId: true } },
+      },
+    },
+  },
 } as const
 
 export async function findAllActiveNamedWorkouts() {
@@ -24,7 +34,7 @@ export async function createNamedWorkoutWithOptionalTemplate(data: {
   name: string
   category: WorkoutCategory
   aliases?: string[]
-  template?: { type: WorkoutType; description: string; movements?: string[] }
+  template?: { type: WorkoutType; description: string; movementIds?: string[] }
 }) {
   let templateWorkoutId: string | undefined
 
@@ -37,8 +47,10 @@ export async function createNamedWorkoutWithOptionalTemplate(data: {
         title: data.name,
         description: data.template.description,
         type: data.template.type,
-        movements: data.template.movements ?? [],
         scheduledAt: new Date('2000-01-01T00:00:00Z'),
+        ...(data.template.movementIds?.length
+          ? { workoutMovements: { create: data.template.movementIds.map((id) => ({ movementId: id })) } }
+          : {}),
       },
     })
     templateWorkoutId = tw.id

--- a/apps/api/src/db/workoutDbManager.ts
+++ b/apps/api/src/db/workoutDbManager.ts
@@ -9,7 +9,7 @@ interface CreateWorkoutData {
   type: WorkoutType
   scheduledAt: Date
   dayOrder?: number
-  movements?: string[]
+  movementIds?: string[]
   namedWorkoutId?: string
 }
 
@@ -19,7 +19,7 @@ interface UpdateWorkoutData {
   type?: WorkoutType
   scheduledAt?: Date
   dayOrder?: number
-  movements?: string[]
+  movementIds?: string[]
   namedWorkoutId?: string | null
 }
 
@@ -29,6 +29,11 @@ interface WorkoutDateRangeFilters {
 
 const programSelect = { select: { id: true, name: true } } as const
 const namedWorkoutSelect = { select: { id: true, name: true, category: true } } as const
+const workoutMovementsInclude = {
+  workoutMovements: {
+    include: { movement: { select: { id: true, name: true, parentId: true } } },
+  },
+} as const
 
 
 export async function countWorkoutsOnSameDay(gymId: string, scheduledAt: Date): Promise<number> {
@@ -43,9 +48,15 @@ export async function countWorkoutsOnSameDay(gymId: string, scheduledAt: Date): 
 }
 
 export async function createWorkoutForProgram(data: CreateWorkoutData) {
+  const { movementIds, ...rest } = data
   return prisma.workout.create({
-    data,
-    include: { program: programSelect, namedWorkout: namedWorkoutSelect },
+    data: {
+      ...rest,
+      ...(movementIds?.length
+        ? { workoutMovements: { create: movementIds.map((id) => ({ movementId: id })) } }
+        : {}),
+    },
+    include: { program: programSelect, namedWorkout: namedWorkoutSelect, ...workoutMovementsInclude },
   })
 }
 
@@ -67,6 +78,7 @@ export async function findWorkoutsByGymAndDateRange(
       program: programSelect,
       namedWorkout: namedWorkoutSelect,
       _count: { select: { results: true } },
+      ...workoutMovementsInclude,
     },
   })
 
@@ -106,6 +118,7 @@ export async function findWorkoutById(id: string) {
       program: programSelect,
       namedWorkout: namedWorkoutSelect,
       _count: { select: { results: true } },
+      ...workoutMovementsInclude,
     },
   })
 }
@@ -119,10 +132,28 @@ export async function findWorkoutProgramId(id: string) {
 }
 
 export async function updateWorkout(id: string, data: UpdateWorkoutData) {
-  return prisma.workout.update({
-    where: { id },
-    data,
-    include: { program: programSelect, namedWorkout: namedWorkoutSelect },
+  const { movementIds, ...rest } = data
+
+  if (movementIds === undefined) {
+    return prisma.workout.update({
+      where: { id },
+      data: rest,
+      include: { program: programSelect, namedWorkout: namedWorkoutSelect, ...workoutMovementsInclude },
+    })
+  }
+
+  return prisma.$transaction(async (tx) => {
+    await tx.workoutMovement.deleteMany({ where: { workoutId: id } })
+    if (movementIds.length > 0) {
+      await tx.workoutMovement.createMany({
+        data: movementIds.map((movementId) => ({ workoutId: id, movementId })),
+      })
+    }
+    return tx.workout.update({
+      where: { id },
+      data: rest,
+      include: { program: programSelect, namedWorkout: namedWorkoutSelect, ...workoutMovementsInclude },
+    })
   })
 }
 
@@ -130,7 +161,7 @@ export async function publishWorkoutById(id: string) {
   return prisma.workout.update({
     where: { id },
     data: { status: WorkoutStatus.PUBLISHED },
-    include: { program: programSelect, namedWorkout: namedWorkoutSelect },
+    include: { program: programSelect, namedWorkout: namedWorkoutSelect, ...workoutMovementsInclude },
   })
 }
 
@@ -145,17 +176,33 @@ export async function applyTemplateToWorkout(workoutId: string) {
 
   const namedWorkout = await prisma.namedWorkout.findUnique({
     where: { id: workout.namedWorkoutId },
-    include: { templateWorkout: { select: { type: true, description: true, movements: true } } },
+    include: {
+      templateWorkout: {
+        select: {
+          type: true,
+          description: true,
+          workoutMovements: { select: { movementId: true } },
+        },
+      },
+    },
   })
   if (!namedWorkout?.templateWorkout) {
     throw Object.assign(new Error('Named workout has no template'), { statusCode: 400 })
   }
 
-  const { type, description, movements } = namedWorkout.templateWorkout
+  const { type, description, workoutMovements } = namedWorkout.templateWorkout
+  const movementIds = workoutMovements.map((wm) => wm.movementId)
+
+  await prisma.workoutMovement.deleteMany({ where: { workoutId } })
+  if (movementIds.length > 0) {
+    await prisma.workoutMovement.createMany({
+      data: movementIds.map((movementId) => ({ workoutId, movementId })),
+    })
+  }
   return prisma.workout.update({
     where: { id: workoutId },
-    data: { type, description, movements },
-    include: { program: programSelect, namedWorkout: namedWorkoutSelect },
+    data: { type, description },
+    include: { program: programSelect, namedWorkout: namedWorkoutSelect, ...workoutMovementsInclude },
   })
 }
 

--- a/apps/api/src/routes/workouts.ts
+++ b/apps/api/src/routes/workouts.ts
@@ -87,7 +87,7 @@ async function createWorkoutForProgram(req: Request, res: Response) {
     return res.status(400).json({ error: `${field}: ${message}` })
   }
 
-  const { programId, title, description, type, scheduledAt, dayOrder } = parsed.data
+  const { programId, title, description, type, scheduledAt, dayOrder, movementIds } = parsed.data
   const gymId = req.params.gymId as string
   const scheduledAtDate = new Date(scheduledAt)
   const resolvedDayOrder = dayOrder ?? await countWorkoutsOnSameDay(gymId, scheduledAtDate)
@@ -98,6 +98,7 @@ async function createWorkoutForProgram(req: Request, res: Response) {
     type,
     scheduledAt: scheduledAtDate,
     dayOrder: resolvedDayOrder,
+    movementIds,
   })
   res.status(201).json(workout)
 }
@@ -137,14 +138,14 @@ async function patchWorkout(req: Request, res: Response) {
     return res.status(400).json({ error: `${field}: ${message}` })
   }
 
-  const { title, description, type, scheduledAt, dayOrder, movements, namedWorkoutId } = parsed.data
+  const { title, description, type, scheduledAt, dayOrder, movementIds, namedWorkoutId } = parsed.data
   const workout = await updateWorkout(id, {
     title,
     description,
     type,
     scheduledAt: scheduledAt ? new Date(scheduledAt) : undefined,
     dayOrder,
-    movements,
+    movementIds,
     namedWorkoutId,
   })
   res.json(workout)
@@ -176,6 +177,7 @@ async function applyTemplate(req: Request, res: Response) {
   const id = req.params.id as string
   const existing = await findWorkoutById(id)
   if (!existing) return res.status(404).json({ error: 'Workout not found' })
+  if (!existing.namedWorkoutId) return res.status(400).json({ error: 'Workout has no named workout set' })
 
   const workout = await applyTemplateToWorkout(id)
   res.json(workout)

--- a/apps/api/tests/named-workouts.ts
+++ b/apps/api/tests/named-workouts.ts
@@ -57,6 +57,8 @@ let workoutId = ''
 let namedWorkoutId = ''
 let programmerToken = ''
 let memberToken = ''
+let thrusterId = ''
+let pullUpId = ''
 
 async function setup() {
   const gym = await prisma.gym.create({
@@ -91,6 +93,20 @@ async function setup() {
   })
   programId = program.id
 
+  // Seed two movements used across movement-related tests
+  const thruster = await prisma.movement.upsert({
+    where: { name: `NW-Thruster-${TS}` },
+    update: {},
+    create: { name: `NW-Thruster-${TS}`, status: 'ACTIVE' },
+  })
+  const pullUp = await prisma.movement.upsert({
+    where: { name: `NW-PullUp-${TS}` },
+    update: {},
+    create: { name: `NW-PullUp-${TS}`, status: 'ACTIVE' },
+  })
+  thrusterId = thruster.id
+  pullUpId = pullUp.id
+
   const workout = await prisma.workout.create({
     data: {
       title: 'NW Workout',
@@ -98,7 +114,6 @@ async function setup() {
       type: 'AMRAP',
       scheduledAt: new Date('2030-06-01T12:00:00Z'),
       programId,
-      movements: [],
     },
   })
   workoutId = workout.id
@@ -121,6 +136,8 @@ async function teardown() {
   }
   // Clean up any other named workouts created during tests
   await prisma.namedWorkout.deleteMany({ where: { name: { contains: `NW-${TS}` } } })
+  // Clean up seeded movements
+  await prisma.movement.deleteMany({ where: { name: { contains: `-${TS}` } } })
   await prisma.program.delete({ where: { id: programId } }).catch(() => {})
   await prisma.gym.delete({ where: { id: gymId } }).catch(() => {})
 }
@@ -152,7 +169,7 @@ async function testCreateNamedWorkoutWithTemplate() {
     template: {
       type: 'FOR_TIME',
       description: '21-15-9\nThrusters 95/65\nPull-ups',
-      movements: ['thrusters', 'pull-ups'],
+      movementIds: [thrusterId, pullUpId],
     },
   })
   check('status 201', 201, r.status)
@@ -161,7 +178,9 @@ async function testCreateNamedWorkoutWithTemplate() {
   const tmpl = (r.body as Record<string, unknown>).templateWorkout as Record<string, unknown> | null
   check('templateWorkout exists', true, tmpl !== null)
   check('template type', 'FOR_TIME', tmpl?.type)
-  check('template movements', 'thrusters,pull-ups', (tmpl?.movements as string[])?.join(','))
+  const wms = tmpl?.workoutMovements as { movement: { id: string } }[] | undefined
+  const returnedIds = wms?.map((wm) => wm.movement.id).sort().join(',') ?? ''
+  check('template movementIds', [thrusterId, pullUpId].sort().join(','), returnedIds)
   namedWorkoutId = (r.body as Record<string, unknown>).id as string
 }
 
@@ -196,13 +215,15 @@ async function testPatchNamedWorkout() {
 }
 
 async function testPatchWorkoutWithMovementsAndNamedWorkout() {
-  console.log('\n[PATCH /workouts/:id] — movements + namedWorkoutId')
+  console.log('\n[PATCH /workouts/:id] — movementIds + namedWorkoutId')
   const r = await api('PATCH', `/workouts/${workoutId}`, programmerToken, {
-    movements: ['thrusters', 'pull-ups'],
+    movementIds: [thrusterId, pullUpId],
     namedWorkoutId,
   })
   check('status 200', 200, r.status)
-  check('movements set', 'thrusters,pull-ups', ((r.body as Record<string, unknown>).movements as string[])?.join(','))
+  const wms = (r.body as Record<string, unknown>).workoutMovements as { movement: { id: string; name: string } }[] | undefined
+  const returnedIds = wms?.map((wm) => wm.movement.id).sort().join(',') ?? ''
+  check('workoutMovements set', [thrusterId, pullUpId].sort().join(','), returnedIds)
   check('namedWorkoutId set', namedWorkoutId, (r.body as Record<string, unknown>).namedWorkoutId)
   const nw = (r.body as Record<string, unknown>).namedWorkout as Record<string, unknown> | null
   check('namedWorkout included', true, nw !== null)
@@ -210,10 +231,12 @@ async function testPatchWorkoutWithMovementsAndNamedWorkout() {
 }
 
 async function testGetWorkoutIncludesNewFields() {
-  console.log('\n[GET /workouts/:id] — includes movements + namedWorkout')
+  console.log('\n[GET /workouts/:id] — includes workoutMovements + namedWorkout')
   const r = await api('GET', `/workouts/${workoutId}`, programmerToken)
   check('status 200', 200, r.status)
-  check('movements present', 'thrusters,pull-ups', ((r.body as Record<string, unknown>).movements as string[])?.join(','))
+  const wms = (r.body as Record<string, unknown>).workoutMovements as { movement: { id: string } }[] | undefined
+  const returnedIds = wms?.map((wm) => wm.movement.id).sort().join(',') ?? ''
+  check('workoutMovements present', [thrusterId, pullUpId].sort().join(','), returnedIds)
   const nw = (r.body as Record<string, unknown>).namedWorkout as Record<string, unknown> | null
   check('namedWorkout present', true, nw !== null)
   check('namedWorkout category', 'GIRL_WOD', nw?.category)
@@ -225,7 +248,9 @@ async function testApplyTemplate() {
   check('status 200', 200, r.status)
   check('type copied from template', 'FOR_TIME', (r.body as Record<string, unknown>).type)
   check('description copied from template', '21-15-9\nThrusters 95/65\nPull-ups', (r.body as Record<string, unknown>).description)
-  check('movements copied from template', 'thrusters,pull-ups', ((r.body as Record<string, unknown>).movements as string[])?.join(','))
+  const wms = (r.body as Record<string, unknown>).workoutMovements as { movement: { id: string } }[] | undefined
+  const returnedIds = wms?.map((wm) => wm.movement.id).sort().join(',') ?? ''
+  check('movements copied from template', [thrusterId, pullUpId].sort().join(','), returnedIds)
 }
 
 async function testApplyTemplateNoNamedWorkout() {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "db:generate": "dotenv -e ../../.env -- prisma generate",
     "db:migrate": "dotenv -e ../../.env -- prisma migrate dev",
-    "db:studio": "dotenv -e ../../.env -- prisma studio"
+    "db:studio": "dotenv -e ../../.env -- prisma studio",
+    "db:seed-movements": "dotenv -e ../../.env -- npx tsx prisma/seed-movements.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.4.1"

--- a/packages/db/prisma/migrations/20260419000000_normalize_movements/migration.sql
+++ b/packages/db/prisma/migrations/20260419000000_normalize_movements/migration.sql
@@ -1,0 +1,43 @@
+-- CreateEnum
+CREATE TYPE "MovementStatus" AS ENUM ('ACTIVE', 'PENDING', 'REJECTED');
+
+-- AlterTable: drop the old denormalized array column
+ALTER TABLE "Workout" DROP COLUMN "movements";
+
+-- CreateTable
+CREATE TABLE "Movement" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "status" "MovementStatus" NOT NULL DEFAULT 'ACTIVE',
+    "parentId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Movement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WorkoutMovement" (
+    "workoutId" TEXT NOT NULL,
+    "movementId" TEXT NOT NULL,
+
+    CONSTRAINT "WorkoutMovement_pkey" PRIMARY KEY ("workoutId","movementId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Movement_name_key" ON "Movement"("name");
+
+-- CreateIndex: parentId for fast variation lookups
+CREATE INDEX "Movement_parentId_idx" ON "Movement"("parentId");
+
+-- CreateIndex: movementId for reverse FK lookups (all workouts for a movement)
+CREATE INDEX "WorkoutMovement_movementId_idx" ON "WorkoutMovement"("movementId");
+
+-- AddForeignKey
+ALTER TABLE "Movement" ADD CONSTRAINT "Movement_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Movement"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkoutMovement" ADD CONSTRAINT "WorkoutMovement_workoutId_fkey" FOREIGN KEY ("workoutId") REFERENCES "Workout"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkoutMovement" ADD CONSTRAINT "WorkoutMovement_movementId_fkey" FOREIGN KEY ("movementId") REFERENCES "Movement"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -38,6 +38,12 @@ enum WorkoutStatus {
   PUBLISHED
 }
 
+enum MovementStatus {
+  ACTIVE
+  PENDING
+  REJECTED
+}
+
 // Self-identified gender — stored on the user profile for demographics
 // and communication preferences. Nullable: users are never required to share.
 enum Gender {
@@ -197,16 +203,16 @@ model Workout {
   status      WorkoutStatus @default(DRAFT)
   scheduledAt DateTime
   dayOrder    Int           @default(0)
-  movements   String[]      @default([])
   namedWorkoutId String?
   createdAt   DateTime      @default(now())
   updatedAt   DateTime      @updatedAt
 
   // nullable: members can log personal workouts outside any program
-  program      Program?      @relation(fields: [programId], references: [id], onDelete: SetNull)
-  results      Result[]
-  namedWorkout NamedWorkout? @relation("NamedWorkoutInstances", fields: [namedWorkoutId], references: [id])
-  templateFor  NamedWorkout? @relation("NamedWorkoutTemplate")  // required by Prisma parser — not used in queries
+  program          Program?      @relation(fields: [programId], references: [id], onDelete: SetNull)
+  results          Result[]
+  namedWorkout     NamedWorkout? @relation("NamedWorkoutInstances", fields: [namedWorkoutId], references: [id])
+  templateFor      NamedWorkout? @relation("NamedWorkoutTemplate")  // required by Prisma parser — not used in queries
+  workoutMovements WorkoutMovement[]
 }
 
 model Result {
@@ -223,4 +229,28 @@ model Result {
   workout Workout @relation(fields: [workoutId], references: [id], onDelete: Cascade)
 
   @@unique([userId, workoutId])
+}
+
+model Movement {
+  id         String         @id @default(cuid())
+  name       String         @unique
+  status     MovementStatus @default(ACTIVE)
+  parentId   String?
+  parent     Movement?      @relation("MovementVariations", fields: [parentId], references: [id])
+  variations Movement[]     @relation("MovementVariations")
+  workouts   WorkoutMovement[]
+  createdAt  DateTime       @default(now())
+  updatedAt  DateTime       @updatedAt
+
+  @@index([parentId])
+}
+
+model WorkoutMovement {
+  workoutId  String
+  movementId String
+  workout    Workout  @relation(fields: [workoutId], references: [id], onDelete: Cascade)
+  movement   Movement @relation(fields: [movementId], references: [id], onDelete: Restrict)
+
+  @@id([workoutId, movementId])
+  @@index([movementId])
 }

--- a/packages/db/prisma/seed-movements.ts
+++ b/packages/db/prisma/seed-movements.ts
@@ -1,0 +1,179 @@
+/**
+ * Seed script: CrossFit movement library
+ *
+ * Safe to rerun — all operations use upsert on the unique name field.
+ * To add new movements in future iterations: add entries to BASES or VARIATIONS
+ * below and rerun. Existing rows will not be duplicated or overwritten.
+ *
+ * Run: npm run db:seed-movements --workspace=@berntracker/db
+ */
+
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+// ─── Base movements (parentId = null) ────────────────────────────────────────
+
+const BASES: string[] = [
+  'Snatch',
+  'Clean',
+  'Jerk',
+  'Clean & Jerk',
+  'Deadlift',
+  'Back Squat',
+  'Front Squat',
+  'Overhead Squat',
+  'Strict Press',
+  'Push Press',
+  'Push Jerk',
+  'Thruster',
+  'Pull-up',
+  'Muscle-up',
+  'Handstand Push-up',
+  'Toes-to-Bar',
+  'Knees-to-Elbow',
+  'Wall Ball',
+  'Kettlebell Swing',
+  'Box Jump',
+  'Double Under',
+  'Burpee',
+  'Rope Climb',
+  'Row',
+  'Bike',
+  'Run',
+  'Ski',
+  'GHD Sit-up',
+  'Back Extension',
+  'Handstand Walk',
+  'Pistol',
+  'Lunge',
+  'Step-up',
+  'Push-up',
+  'Sit-up',
+]
+
+// ─── Variations (name + parentName) ──────────────────────────────────────────
+
+const VARIATIONS: { name: string; parentName: string }[] = [
+  // Snatch
+  { name: 'Power Snatch', parentName: 'Snatch' },
+  { name: 'Squat Snatch', parentName: 'Snatch' },
+  { name: 'Hang Power Snatch', parentName: 'Snatch' },
+  { name: 'Hang Squat Snatch', parentName: 'Snatch' },
+  { name: 'High Hang Power Snatch', parentName: 'Snatch' },
+  { name: 'High Hang Squat Snatch', parentName: 'Snatch' },
+  { name: 'Snatch Balance', parentName: 'Snatch' },
+
+  // Clean
+  { name: 'Power Clean', parentName: 'Clean' },
+  { name: 'Squat Clean', parentName: 'Clean' },
+  { name: 'Hang Power Clean', parentName: 'Clean' },
+  { name: 'Hang Squat Clean', parentName: 'Clean' },
+  { name: 'High Hang Power Clean', parentName: 'Clean' },
+
+  // Jerk
+  { name: 'Split Jerk', parentName: 'Jerk' },
+  { name: 'Power Jerk', parentName: 'Jerk' },
+  { name: 'Squat Jerk', parentName: 'Jerk' },
+
+  // Deadlift
+  { name: 'Romanian Deadlift', parentName: 'Deadlift' },
+  { name: 'Sumo Deadlift', parentName: 'Deadlift' },
+  { name: 'Sumo Deadlift High Pull', parentName: 'Deadlift' },
+  { name: 'Stiff-Leg Deadlift', parentName: 'Deadlift' },
+
+  // Pull-up
+  { name: 'Strict Pull-up', parentName: 'Pull-up' },
+  { name: 'Kipping Pull-up', parentName: 'Pull-up' },
+  { name: 'Butterfly Pull-up', parentName: 'Pull-up' },
+  { name: 'Chest-to-Bar Pull-up', parentName: 'Pull-up' },
+
+  // Muscle-up
+  { name: 'Ring Muscle-up', parentName: 'Muscle-up' },
+  { name: 'Bar Muscle-up', parentName: 'Muscle-up' },
+
+  // Handstand Push-up
+  { name: 'Strict Handstand Push-up', parentName: 'Handstand Push-up' },
+  { name: 'Kipping Handstand Push-up', parentName: 'Handstand Push-up' },
+  { name: 'Deficit Handstand Push-up', parentName: 'Handstand Push-up' },
+
+  // Kettlebell Swing
+  { name: 'Russian Kettlebell Swing', parentName: 'Kettlebell Swing' },
+  { name: 'American Kettlebell Swing', parentName: 'Kettlebell Swing' },
+
+  // Box Jump
+  { name: 'Box Jump Over', parentName: 'Box Jump' },
+  { name: 'Box Step-up Over', parentName: 'Box Jump' },
+
+  // Double Under
+  { name: 'Single Under', parentName: 'Double Under' },
+  { name: 'Triple Under', parentName: 'Double Under' },
+
+  // Burpee
+  { name: 'Bar-facing Burpee', parentName: 'Burpee' },
+  { name: 'Burpee Box Jump Over', parentName: 'Burpee' },
+  { name: 'Burpee Pull-up', parentName: 'Burpee' },
+
+  // Bike
+  { name: 'Assault Bike', parentName: 'Bike' },
+  { name: 'Echo Bike', parentName: 'Bike' },
+
+  // Lunge
+  { name: 'Walking Lunge', parentName: 'Lunge' },
+  { name: 'Overhead Lunge', parentName: 'Lunge' },
+  { name: 'Front Rack Lunge', parentName: 'Lunge' },
+
+  // Push-up
+  { name: 'Hand Release Push-up', parentName: 'Push-up' },
+  { name: 'Ring Push-up', parentName: 'Push-up' },
+]
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('Seeding movements...')
+
+  // Pass 1: base movements
+  for (const name of BASES) {
+    await prisma.movement.upsert({
+      where: { name },
+      update: {},
+      create: { name, status: 'ACTIVE' },
+    })
+  }
+  console.log(`  ✓ ${BASES.length} base movements`)
+
+  // Pass 2: variations — resolve parentId by name
+  const parentRows = await prisma.movement.findMany({
+    where: { name: { in: [...new Set(VARIATIONS.map((v) => v.parentName))] } },
+    select: { id: true, name: true },
+  })
+  const byName = new Map(parentRows.map((m) => [m.name, m.id]))
+
+  let seeded = 0
+  let skipped = 0
+  for (const { name, parentName } of VARIATIONS) {
+    const parentId = byName.get(parentName)
+    if (!parentId) {
+      console.warn(`  ⚠ parent not found for variation "${name}" (parent: "${parentName}") — skipped`)
+      skipped++
+      continue
+    }
+    await prisma.movement.upsert({
+      where: { name },
+      update: { parentId },
+      create: { name, status: 'ACTIVE', parentId },
+    })
+    seeded++
+  }
+  console.log(`  ✓ ${seeded} variations${skipped > 0 ? `, ${skipped} skipped` : ''}`)
+
+  console.log('Done.')
+}
+
+main()
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(() => prisma.$disconnect())

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,4 @@
 export * from './result.js'
 export * from './auth.js'
 export * from './workout.js'
+export * from './movement.js'

--- a/packages/types/src/movement.ts
+++ b/packages/types/src/movement.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const MovementStatusSchema = z.enum(['ACTIVE', 'PENDING', 'REJECTED'])
+
+export const MovementSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: MovementStatusSchema,
+  parentId: z.string().nullable(),
+  parent: z.object({ id: z.string(), name: z.string() }).nullable().optional(),
+  variations: z.array(z.object({ id: z.string(), name: z.string() })).optional(),
+})
+
+export type MovementStatus = z.infer<typeof MovementStatusSchema>
+export type Movement = z.infer<typeof MovementSchema>

--- a/packages/types/src/workout.ts
+++ b/packages/types/src/workout.ts
@@ -11,7 +11,7 @@ export const CreateWorkoutSchema = z.object({
   type: WorkoutTypeSchema,
   scheduledAt: z.string().datetime(),
   dayOrder: z.number().int().min(0).optional(),
-  movements: z.array(z.string().min(1)).optional(),
+  movementIds: z.array(z.string()).optional(),
   namedWorkoutId: z.string().optional(),
 })
 
@@ -22,7 +22,7 @@ export const UpdateWorkoutSchema = z
     type: WorkoutTypeSchema.optional(),
     scheduledAt: z.string().datetime().optional(),
     dayOrder: z.number().int().min(0).optional(),
-    movements: z.array(z.string().min(1)).optional(),
+    movementIds: z.array(z.string()).optional(),
     namedWorkoutId: z.string().nullable().optional(),
   })
   .refine((data) => Object.keys(data).length > 0, { message: 'At least one field is required' })
@@ -34,7 +34,7 @@ export const CreateNamedWorkoutSchema = z.object({
   template: z.object({
     type: WorkoutTypeSchema,
     description: z.string().min(1),
-    movements: z.array(z.string().min(1)).optional(),
+    movementIds: z.array(z.string()).optional(),
   }).optional(),
 })
 


### PR DESCRIPTION
## Summary

- Replaces `Workout.movements: String[]` with a normalized `Movement` entity: a `Movement` model with ACTIVE/PENDING/REJECTED status, a self-referential parent/variation hierarchy, and a `WorkoutMovement` join table
- FK indexes on `Movement.parentId` and `WorkoutMovement.movementId` for fast variation lookups and reverse queries
- Idempotent seed script (`seed-movements.ts`) ships 35 base CrossFit movements + 44 named variations
- New `movementDbManager.ts`, updated `workoutDbManager.ts` / `namedWorkoutDbManager.ts` / Zod types

This is **Sub-issue A** of the Movement Normalization feature — the foundation layer. Sub-issue B (API endpoints for suggest/review/detect and movement filtering) builds on top of this.

## What changed

| Area | Change |
|---|---|
| `packages/db/prisma/schema.prisma` | `MovementStatus` enum, `Movement` model, `WorkoutMovement` join table, FK indexes; removed `movements String[]` from `Workout` |
| `packages/db/prisma/migrations/20260419000000_normalize_movements/` | Generated + applied migration SQL |
| `packages/db/prisma/seed-movements.ts` | New — two-pass idempotent upsert of bases + variations |
| `packages/db/package.json` | Added `db:seed-movements` script |
| `packages/types/src/movement.ts` | New — `MovementStatusSchema`, `MovementSchema` |
| `packages/types/src/workout.ts` | `movements` → `movementIds: z.array(z.string())` in all three schemas |
| `apps/api/src/db/movementDbManager.ts` | New — `findAllActiveMovements`, `findMovementById` |
| `apps/api/src/db/workoutDbManager.ts` | `movementIds` replace-all pattern (transaction only when `movementIds` defined), `workoutMovementsInclude` const on all queries |
| `apps/api/src/db/namedWorkoutDbManager.ts` | `templateWorkoutSelect` returns `workoutMovements` not string array |
| `apps/api/src/routes/workouts.ts` | `movementIds` passed through on create + patch; explicit `namedWorkoutId` guard in `applyTemplate` handler (fixes pre-existing Express 4 async-error hang) |
| `apps/api/tests/named-workouts.ts` | Seeds `Movement` fixtures; asserts on `workoutMovements` shape |

## Tests

**API integration** (`apps/api/tests/`, 128 tests total, 0 failures):

**`tests/feed.ts`** (34 tests — unchanged, all passing):
- Member/programmer feed visibility and WOD detail access
- Results leaderboard shape and auth guards

**`tests/named-workouts.ts`** (34 tests — updated for this PR):
- T1: POST named workout without template → 201, correct fields
- T2: POST named workout with template + `movementIds` → 201, `workoutMovements` shape on response
- T3: GET /named-workouts list → includes new workout
- T4: GET /named-workouts/:id → templateWorkout included
- T5: PATCH named workout isActive → toggles correctly
- T6: PATCH workout with `movementIds` + `namedWorkoutId` → asserts `workoutMovements[*].movement.id`
- T7: GET workout → `workoutMovements` present, `namedWorkout` included
- T8: POST apply-template → type, description, and movements copied from template
- T9: POST apply-template with no namedWorkoutId → 400 (explicit guard in route handler)
- T10: Auth guards on named-workout routes → 401

**`tests/results.ts`** (23 tests — unchanged, all passing):
- Result logging, leaderboard sorting/filtering, paginated history

**`tests/workouts.ts`** (37 tests — unchanged, all passing):
- Workout CRUD, publish, dayOrder, role-based access, program subscriptions

**Not automated / manual verification needed:**
- [x] Run `npm run db:seed-movements --workspace=@berntracker/db` on a fresh DB and confirm 35 bases + 44 variations are seeded
- [x] Rerunning the seed script is idempotent (no duplicate rows created)

## Running the seed

```bash
npm run db:seed-movements --workspace=@berntracker/db
```

Part of #66