### PR TITLE
feat(api): movement API endpoints — list, suggest, review, detect, workout filter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,6 @@ GOOGLE_IOS_CLIENT_ID=967542660167-ircfnmum03iap9fefa7o6nutgbsubf51.apps.googleus
 GOOGLE_ANDROID_CLIENT_ID=TODO
 GOOGLE_REDIRECT_URI="http://localhost:3000/api/auth/google/callback"
 FRONTEND_URL="http://localhost:5173"
+
+# ─── Movements ────────────────────────────────────────────────────────────────
+MOVEMENT_REVIEWER_EMAIL=   # email address allowed to review pending movement suggestions

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "express": "^4.21.2",
+    "fuse.js": "^7.3.0",
     "google-auth-library": "^10.6.1",
     "jsonwebtoken": "^9.0.2"
   },

--- a/apps/api/src/db/movementDbManager.ts
+++ b/apps/api/src/db/movementDbManager.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@berntracker/db'
+import Fuse from 'fuse.js'
 
 const movementBaseSelect = {
   select: { id: true, name: true, status: true, parentId: true },
@@ -27,4 +28,75 @@ export async function findMovementById(id: string) {
   const movement = await prisma.movement.findUnique({ where: { id }, ...movementWithVariationsSelect })
   if (!movement) throw Object.assign(new Error('Movement not found'), { statusCode: 404 })
   return movement
+}
+
+export async function createPendingMovement(data: { name: string; parentId?: string }) {
+  const existing = await prisma.movement.findUnique({ where: { name: data.name } })
+  if (existing) {
+    throw Object.assign(new Error('A movement with that name already exists'), { statusCode: 409 })
+  }
+  return prisma.movement.create({
+    data: { name: data.name, status: 'PENDING', parentId: data.parentId ?? null },
+    ...movementWithVariationsSelect,
+  })
+}
+
+export async function findPendingMovements() {
+  return prisma.movement.findMany({
+    where: { status: 'PENDING' },
+    orderBy: { createdAt: 'asc' },
+    ...movementBaseSelect,
+  })
+}
+
+export async function reviewMovementById(id: string, status: 'ACTIVE' | 'REJECTED') {
+  const movement = await prisma.movement.findUnique({ where: { id } })
+  if (!movement) throw Object.assign(new Error('Movement not found'), { statusCode: 404 })
+  if (movement.status !== 'PENDING') {
+    throw Object.assign(new Error('Only PENDING movements can be reviewed'), { statusCode: 400 })
+  }
+  return prisma.movement.update({
+    where: { id },
+    data: { status },
+    ...movementWithVariationsSelect,
+  })
+}
+
+export async function expandMovementIdsWithVariations(movementIds: string[]): Promise<string[]> {
+  if (movementIds.length === 0) return []
+  const movements = await prisma.movement.findMany({
+    where: { id: { in: movementIds } },
+    select: { id: true, variations: { select: { id: true } } },
+  })
+  const expanded = new Set(movementIds)
+  for (const m of movements) {
+    for (const v of m.variations) expanded.add(v.id)
+  }
+  return [...expanded]
+}
+
+export async function detectMovementsInText(description: string) {
+  const movements = await prisma.movement.findMany({
+    where: { status: 'ACTIVE' },
+    select: { id: true, name: true, parentId: true },
+  })
+
+  const fuse = new Fuse(movements, { keys: ['name'], threshold: 0.35, includeScore: true })
+
+  const words = description.toLowerCase().replace(/[^a-z0-9 ]/g, ' ').split(/\s+/).filter(Boolean)
+  const ngrams = new Set<string>()
+  for (let i = 0; i < words.length; i++) {
+    ngrams.add(words[i])
+    if (words[i + 1]) ngrams.add(`${words[i]} ${words[i + 1]}`)
+    if (words[i + 1] && words[i + 2]) ngrams.add(`${words[i]} ${words[i + 1]} ${words[i + 2]}`)
+  }
+
+  const matchedIds = new Set<string>()
+  for (const gram of ngrams) {
+    for (const result of fuse.search(gram)) {
+      matchedIds.add(result.item.id)
+    }
+  }
+
+  return movements.filter((m) => matchedIds.has(m.id))
 }

--- a/apps/api/src/db/workoutDbManager.ts
+++ b/apps/api/src/db/workoutDbManager.ts
@@ -25,6 +25,7 @@ interface UpdateWorkoutData {
 
 interface WorkoutDateRangeFilters {
   publishedOnly?: boolean
+  movementIds?: string[]
 }
 
 const programSelect = { select: { id: true, name: true } } as const
@@ -71,6 +72,9 @@ export async function findWorkoutsByGymAndDateRange(
       scheduledAt: { gte: from, lte: to },
       program: { gyms: { some: { gymId } } },
       ...(filters.publishedOnly ? { status: WorkoutStatus.PUBLISHED } : {}),
+      ...(filters.movementIds?.length
+        ? { workoutMovements: { some: { movementId: { in: filters.movementIds } } } }
+        : {}),
     },
     // createdAt is a stable tiebreaker for equal dayOrder values (e.g. pre-migration rows defaulted to 0)
     orderBy: [{ scheduledAt: 'asc' }, { dayOrder: 'asc' }, { createdAt: 'asc' }],

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import programsRouter from './routes/programs'
 import workoutsRouter from './routes/workouts'
 import resultsRouter from './routes/results'
 import namedWorkoutsRouter from './routes/namedWorkouts'
+import movementsRouter from './routes/movements'
 import { createLogger } from './lib/logger.js'
 import { requestLogger } from './middleware/requestLogger.js'
 
@@ -47,6 +48,7 @@ app.use('/api', programsRouter)
 app.use('/api', workoutsRouter)
 app.use('/api', resultsRouter)
 app.use('/api', namedWorkoutsRouter)
+app.use('/api', movementsRouter)
 
 const logError = createLogger('error')
 

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express'
 import type { Role } from '@berntracker/db'
+import { prisma } from '@berntracker/db'
 import { verifyAccessToken } from '../lib/jwt.js'
 import { createLogger } from '../lib/logger.js'
 
@@ -32,4 +33,20 @@ export function requireRole(...roles: Role[]) {
     }
     next()
   }
+}
+
+export async function requireMovementReviewer(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const reviewerEmail = process.env.MOVEMENT_REVIEWER_EMAIL
+  if (!reviewerEmail) {
+    log.warning(req, `requireMovementReviewer: MOVEMENT_REVIEWER_EMAIL not set — ${req.method} ${req.path}`)
+    res.status(403).json({ error: 'Forbidden' })
+    return
+  }
+  const user = await prisma.user.findUnique({ where: { id: req.user!.id }, select: { email: true } })
+  if (user?.email !== reviewerEmail) {
+    log.warning(req, `requireMovementReviewer: access denied — ${req.method} ${req.path} — userId=${req.user?.id}`)
+    res.status(403).json({ error: 'Forbidden' })
+    return
+  }
+  next()
 }

--- a/apps/api/src/routes/movements.ts
+++ b/apps/api/src/routes/movements.ts
@@ -1,0 +1,85 @@
+import { Router } from 'express'
+import type { Request, Response } from 'express'
+import { requireAuth, requireMovementReviewer } from '../middleware/auth.js'
+import {
+  findAllActiveMovements,
+  createPendingMovement,
+  findPendingMovements,
+  reviewMovementById,
+  detectMovementsInText,
+} from '../db/movementDbManager.js'
+import { SuggestMovementSchema, ReviewMovementSchema } from '@berntracker/types'
+
+const router = Router()
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+// /pending must be registered before /:id to avoid Express treating "pending" as an ID
+router.get('/movements', requireAuth, getMovements)
+router.post('/movements/suggest', requireAuth, suggestMovement)
+router.get('/movements/pending', requireAuth, requireMovementReviewer, getPendingMovements)
+router.patch('/movements/:id/review', requireAuth, requireMovementReviewer, reviewMovement)
+router.post('/movements/detect', requireAuth, detectMovements)
+
+export default router
+
+// ─── Handler functions ────────────────────────────────────────────────────────
+
+async function getMovements(_req: Request, res: Response) {
+  const movements = await findAllActiveMovements()
+  res.json(movements)
+}
+
+async function suggestMovement(req: Request, res: Response) {
+  const parsed = SuggestMovementSchema.safeParse(req.body)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const field = issue?.path[0] ?? 'request'
+    const message = issue?.message ?? 'Invalid request'
+    return res.status(400).json({ error: `${field}: ${message}` })
+  }
+
+  try {
+    const movement = await createPendingMovement(parsed.data)
+    res.status(201).json(movement)
+  } catch (err) {
+    const statusCode = (err as { statusCode?: number }).statusCode
+    if (statusCode) return res.status(statusCode).json({ error: err instanceof Error ? err.message : 'Error' })
+    throw err
+  }
+}
+
+async function getPendingMovements(_req: Request, res: Response) {
+  const movements = await findPendingMovements()
+  res.json(movements)
+}
+
+async function reviewMovement(req: Request, res: Response) {
+  const id = req.params.id as string
+  const parsed = ReviewMovementSchema.safeParse(req.body)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const field = issue?.path[0] ?? 'request'
+    const message = issue?.message ?? 'Invalid request'
+    return res.status(400).json({ error: `${field}: ${message}` })
+  }
+
+  try {
+    const movement = await reviewMovementById(id, parsed.data.status)
+    res.json(movement)
+  } catch (err) {
+    const statusCode = (err as { statusCode?: number }).statusCode
+    if (statusCode) return res.status(statusCode).json({ error: err instanceof Error ? err.message : 'Error' })
+    throw err
+  }
+}
+
+async function detectMovements(req: Request, res: Response) {
+  const { description } = req.body as { description?: string }
+  if (!description || typeof description !== 'string') {
+    return res.status(400).json({ error: 'description: Required' })
+  }
+
+  const movements = await detectMovementsInText(description)
+  res.json(movements)
+}

--- a/apps/api/src/routes/workouts.ts
+++ b/apps/api/src/routes/workouts.ts
@@ -19,6 +19,7 @@ import {
   deleteWorkout,
   applyTemplateToWorkout,
 } from '../db/workoutDbManager.js'
+import { expandMovementIdsWithVariations } from '../db/movementDbManager.js'
 import {
   findGymMembershipByUserAndGym
 } from '../db/userGymDbManager.js'
@@ -74,7 +75,14 @@ async function getWorkoutsByGymAndDateRange(req: Request, res: Response) {
 
   const membership = await findGymMembershipByUserAndGym(req.user!.id, gymId)
   const publishedOnly = membership?.role === Role.MEMBER
-  const workouts = await findWorkoutsByGymAndDateRange(gymId, fromDate, toDate, { publishedOnly })
+
+  const rawMovementIds = req.query.movementIds
+  const movementIdList = rawMovementIds ? String(rawMovementIds).split(',').filter(Boolean) : []
+  const movementIds = movementIdList.length
+    ? await expandMovementIdsWithVariations(movementIdList)
+    : undefined
+
+  const workouts = await findWorkoutsByGymAndDateRange(gymId, fromDate, toDate, { publishedOnly, movementIds })
   res.json(workouts)
 }
 

--- a/apps/api/tests/movements.ts
+++ b/apps/api/tests/movements.ts
@@ -1,0 +1,342 @@
+/**
+ * Integration tests for movement endpoints.
+ *
+ * Requires: API running on localhost:3000, DB accessible via DATABASE_URL.
+ * Requires: MOVEMENT_REVIEWER_EMAIL set in .env (the API server reads it at request time).
+ * Run: cd apps/api && npx tsx tests/movements.ts
+ */
+
+import { prisma, ProgramRole } from '@berntracker/db'
+import { signTokenPair } from '../src/lib/jwt.js'
+
+const BASE = 'http://localhost:3000/api'
+let pass = 0
+let fail = 0
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function check(label: string, expected: unknown, actual: unknown) {
+  if (String(expected) === String(actual)) {
+    console.log(`  ✓ ${label}`)
+    pass++
+  } else {
+    console.log(`  ✗ ${label}  [expected=${expected} actual=${actual}]`)
+    fail++
+  }
+}
+
+async function api(method: string, path: string, token?: string, body?: unknown) {
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  const text = await res.text()
+  let json: unknown
+  try {
+    json = JSON.parse(text)
+  } catch {
+    json = text
+  }
+  return { status: res.status, body: json as Record<string, unknown> }
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const TS = Date.now()
+let gymId = ''
+let programId = ''
+let memberUserId = ''
+let reviewerUserId = ''
+let reviewerUserCreated = false
+let memberToken = ''
+let reviewerToken = ''
+let thrusterMovementId = ''
+let pullUpMovementId = ''
+let workoutWithMovementId = ''
+let workoutWithoutMovementId = ''
+let pendingMovementId = ''
+
+async function setup() {
+  console.log('\n=== Setup ===')
+
+  // The API server reads MOVEMENT_REVIEWER_EMAIL from its own env at request time.
+  // The test must use the same email so the API's check passes.
+  const reviewerEmail = process.env.MOVEMENT_REVIEWER_EMAIL
+  if (!reviewerEmail) {
+    throw new Error('MOVEMENT_REVIEWER_EMAIL must be set in .env to run movements tests')
+  }
+
+  // Use existing reviewer account if present (e.g. ccmagrane@gmail.com in prod env);
+  // otherwise create a temporary test user and clean it up in teardown.
+  const existingReviewer = await prisma.user.findUnique({ where: { email: reviewerEmail } })
+  if (existingReviewer) {
+    reviewerUserId = existingReviewer.id
+  } else {
+    const created = await prisma.user.create({ data: { email: reviewerEmail } })
+    reviewerUserId = created.id
+    reviewerUserCreated = true
+  }
+
+  const gym = await prisma.gym.create({
+    data: { name: `MV Gym ${TS}`, slug: `mv-gym-${TS}`, timezone: 'UTC' },
+  })
+  gymId = gym.id
+
+  const memberUser = await prisma.user.create({ data: { email: `mv-member-${TS}@test.com` } })
+  memberUserId = memberUser.id
+
+  await prisma.userGym.create({ data: { userId: reviewerUserId, gymId, role: 'PROGRAMMER' } })
+  await prisma.userGym.create({ data: { userId: memberUserId, gymId, role: 'MEMBER' } })
+
+  const program = await prisma.program.create({
+    data: {
+      name: `MV Program ${TS}`,
+      startDate: new Date('2026-03-01'),
+      gyms: { create: { gymId } },
+      members: {
+        createMany: {
+          data: [
+            { userId: memberUserId, role: ProgramRole.MEMBER },
+            { userId: reviewerUserId, role: ProgramRole.PROGRAMMER },
+          ],
+        },
+      },
+    },
+  })
+  programId = program.id
+
+  memberToken = signTokenPair(memberUserId, 'MEMBER').accessToken
+  reviewerToken = signTokenPair(reviewerUserId, 'OWNER').accessToken
+
+  // Seed two active movements for testing
+  const thruster = await prisma.movement.upsert({
+    where: { name: `Thruster-${TS}` },
+    update: {},
+    create: { name: `Thruster-${TS}`, status: 'ACTIVE' },
+  })
+  thrusterMovementId = thruster.id
+
+  const pullUp = await prisma.movement.upsert({
+    where: { name: `Pull-up-${TS}` },
+    update: {},
+    create: { name: `Pull-up-${TS}`, status: 'ACTIVE' },
+  })
+  pullUpMovementId = pullUp.id
+
+  // Seed a variation of pull-up so expansion tests work
+  await prisma.movement.upsert({
+    where: { name: `Kipping Pull-up-${TS}` },
+    update: {},
+    create: { name: `Kipping Pull-up-${TS}`, status: 'ACTIVE', parentId: pullUpMovementId },
+  })
+
+  // Workout with the thruster + pull-up movements
+  const w1 = await prisma.workout.create({
+    data: {
+      programId,
+      title: 'Fran-like',
+      description: `21-15-9 Thruster-${TS} Pull-up-${TS}`,
+      type: 'FOR_TIME',
+      status: 'PUBLISHED',
+      scheduledAt: new Date('2026-03-15T10:00:00Z'),
+      workoutMovements: { create: [{ movementId: thrusterMovementId }, { movementId: pullUpMovementId }] },
+    },
+  })
+  workoutWithMovementId = w1.id
+
+  // Workout without movements
+  const w2 = await prisma.workout.create({
+    data: {
+      programId,
+      title: 'Pure Cardio',
+      description: 'Row 5k',
+      type: 'CARDIO',
+      status: 'PUBLISHED',
+      scheduledAt: new Date('2026-03-16T10:00:00Z'),
+    },
+  })
+  workoutWithoutMovementId = w2.id
+
+  // Pre-existing pending movement
+  const pending = await prisma.movement.create({
+    data: { name: `Pending-Move-${TS}`, status: 'PENDING' },
+  })
+  pendingMovementId = pending.id
+
+  console.log(`  gym=${gymId}  program=${programId}`)
+  console.log(`  reviewer=${reviewerUserId} (${reviewerEmail})`)
+  console.log(`  thruster=${thrusterMovementId}  pullUp=${pullUpMovementId}`)
+  console.log(`  workoutWithMovement=${workoutWithMovementId}  workoutWithout=${workoutWithoutMovementId}`)
+  console.log(`  pendingMovement=${pendingMovementId}`)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+async function runTests() {
+  // ── GET /api/movements ───────────────────────────────────────────────────────
+  console.log('\n=== GET /api/movements ===')
+
+  {
+    const r = await api('GET', '/movements', memberToken)
+    check('T1: GET /api/movements → 200', 200, r.status)
+    check('T1: returns array', true, Array.isArray(r.body))
+    const arr = r.body as unknown as { id: string }[]
+    check('T1: includes seeded thruster', true, arr.some((m) => m.id === thrusterMovementId))
+  }
+
+  {
+    const r = await api('GET', '/movements')
+    check('T2: GET /api/movements no auth → 401', 401, r.status)
+  }
+
+  // ── POST /api/movements/suggest ──────────────────────────────────────────────
+  console.log('\n=== POST /api/movements/suggest ===')
+
+  let suggestedMovementId = ''
+  {
+    const r = await api('POST', '/movements/suggest', memberToken, { name: `Suggested-${TS}` })
+    check('T3: POST /api/movements/suggest → 201', 201, r.status)
+    check('T3: status PENDING', 'PENDING', r.body.status)
+    suggestedMovementId = r.body.id as string
+  }
+
+  {
+    const r = await api('POST', '/movements/suggest', memberToken, { name: `Suggested-${TS}` })
+    check('T4: POST /api/movements/suggest duplicate → 409', 409, r.status)
+  }
+
+  {
+    const r = await api('POST', '/movements/suggest', undefined, { name: `No-Auth-${TS}` })
+    check('T5: POST /api/movements/suggest no auth → 401', 401, r.status)
+  }
+
+  // ── GET /api/movements/pending ───────────────────────────────────────────────
+  console.log('\n=== GET /api/movements/pending ===')
+
+  {
+    const r = await api('GET', '/movements/pending', reviewerToken)
+    check('T6: GET /api/movements/pending → 200', 200, r.status)
+    const arr = r.body as unknown as { id: string }[]
+    check('T6: includes pre-seeded pending', true, arr.some((m) => m.id === pendingMovementId))
+    check('T6: includes suggested movement', true, arr.some((m) => m.id === suggestedMovementId))
+  }
+
+  {
+    const r = await api('GET', '/movements/pending', memberToken)
+    check('T7: GET /api/movements/pending non-reviewer → 403', 403, r.status)
+  }
+
+  // ── PATCH /api/movements/:id/review ─────────────────────────────────────────
+  console.log('\n=== PATCH /api/movements/:id/review ===')
+
+  {
+    const r = await api('PATCH', `/movements/${pendingMovementId}/review`, reviewerToken, { status: 'ACTIVE' })
+    check('T8: PATCH review accept → 200', 200, r.status)
+    check('T8: status ACTIVE', 'ACTIVE', r.body.status)
+  }
+
+  {
+    const r = await api('PATCH', `/movements/${suggestedMovementId}/review`, reviewerToken, { status: 'REJECTED' })
+    check('T9: PATCH review reject → 200', 200, r.status)
+    check('T9: status REJECTED', 'REJECTED', r.body.status)
+  }
+
+  {
+    // pendingMovementId is now ACTIVE — reviewing it again should 400
+    const r = await api('PATCH', `/movements/${pendingMovementId}/review`, reviewerToken, { status: 'REJECTED' })
+    check('T10: PATCH review non-PENDING movement → 400', 400, r.status)
+  }
+
+  // ── POST /api/movements/detect ───────────────────────────────────────────────
+  console.log('\n=== POST /api/movements/detect ===')
+
+  {
+    const r = await api('POST', '/movements/detect', memberToken, {
+      description: `21-15-9 Thruster-${TS} Pull-up-${TS}`,
+    })
+    check('T11: POST /api/movements/detect → 200', 200, r.status)
+    const arr = r.body as unknown as { id: string }[]
+    check('T11: detects thruster', true, arr.some((m) => m.id === thrusterMovementId))
+    check('T11: detects pull-up', true, arr.some((m) => m.id === pullUpMovementId))
+  }
+
+  {
+    const r = await api('POST', '/movements/detect', undefined, { description: 'test' })
+    check('T12: POST /api/movements/detect no auth → 401', 401, r.status)
+  }
+
+  // ── GET /api/gyms/:gymId/workouts?movementIds= ───────────────────────────────
+  console.log('\n=== GET /api/gyms/:gymId/workouts?movementIds= ===')
+
+  {
+    const r = await api(
+      'GET',
+      `/gyms/${gymId}/workouts?from=2026-03-01&to=2026-03-31&movementIds=${thrusterMovementId}`,
+      reviewerToken,
+    )
+    check('T13: movementIds filter → 200', 200, r.status)
+    const arr = r.body as unknown as { id: string }[]
+    check('T13: includes workout with movement', true, arr.some((w) => w.id === workoutWithMovementId))
+    check('T13: excludes workout without movement', false, arr.some((w) => w.id === workoutWithoutMovementId))
+  }
+
+  {
+    // Filter by base (pullUpMovementId) — expansion should include kipping pull-up variation
+    // The workout directly has pullUpMovementId, so this verifies base movement matching
+    const r = await api(
+      'GET',
+      `/gyms/${gymId}/workouts?from=2026-03-01&to=2026-03-31&movementIds=${pullUpMovementId}`,
+      reviewerToken,
+    )
+    check('T14: movementIds base expands to variations → 200', 200, r.status)
+    const arr = r.body as unknown as { id: string }[]
+    check('T14: includes workout with base movement', true, arr.some((w) => w.id === workoutWithMovementId))
+  }
+
+  {
+    const r = await api(
+      'GET',
+      `/gyms/${gymId}/workouts?from=2026-03-01&to=2026-03-31&movementIds=${thrusterMovementId}`,
+    )
+    check('T15: movementIds filter no auth → 401', 401, r.status)
+  }
+}
+
+// ─── Teardown ─────────────────────────────────────────────────────────────────
+
+async function teardown() {
+  console.log('\n=== Teardown ===')
+  await prisma.workout.deleteMany({ where: { programId } })
+  await prisma.program.delete({ where: { id: programId } }).catch(() => {})
+  // Delete movements created in this test run (variations first due to parentId FK)
+  await prisma.movement.deleteMany({ where: { name: { endsWith: `-${TS}` }, parentId: { not: null } } })
+  await prisma.movement.deleteMany({ where: { name: { endsWith: `-${TS}` } } })
+  await prisma.userGym.deleteMany({ where: { gymId } }).catch(() => {})
+  await prisma.user.delete({ where: { id: memberUserId } }).catch(() => {})
+  if (reviewerUserCreated) await prisma.user.delete({ where: { id: reviewerUserId } }).catch(() => {})
+  await prisma.gym.delete({ where: { id: gymId } }).catch(() => {})
+  console.log('  cleaned up')
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  try {
+    await setup()
+    await runTests()
+  } finally {
+    await teardown()
+    await prisma.$disconnect()
+  }
+  console.log(`\n=== Results: ${pass} passed, ${fail} failed ===\n`)
+  if (fail > 0) process.exit(1)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/types/src/movement.ts
+++ b/packages/types/src/movement.ts
@@ -11,5 +11,16 @@ export const MovementSchema = z.object({
   variations: z.array(z.object({ id: z.string(), name: z.string() })).optional(),
 })
 
+export const SuggestMovementSchema = z.object({
+  name: z.string().min(1),
+  parentId: z.string().optional(),
+})
+
+export const ReviewMovementSchema = z.object({
+  status: z.enum(['ACTIVE', 'REJECTED']),
+})
+
 export type MovementStatus = z.infer<typeof MovementStatusSchema>
 export type Movement = z.infer<typeof MovementSchema>
+export type SuggestMovementInput = z.infer<typeof SuggestMovementSchema>
+export type ReviewMovementInput = z.infer<typeof ReviewMovementSchema>


### PR DESCRIPTION
Part of #66 — Sub-issue B (movement API endpoints)

## Summary

- `GET /api/movements` — list all ACTIVE movements (with `parentId` for hierarchy)
- `POST /api/movements/suggest` — create a PENDING movement suggestion (any authenticated user)
- `GET /api/movements/pending` — list pending submissions (reviewer only)
- `PATCH /api/movements/:id/review` — accept (`ACTIVE`) or reject a pending movement (reviewer only)
- `POST /api/movements/detect` — fuzzy-match movement names in a workout description using fuse.js
- `GET /api/gyms/:gymId/workouts?movementIds=<id,id,...>` — filter workouts by movement ID, auto-expanding base movement IDs to include all variations

Reviewer auth uses `MOVEMENT_REVIEWER_EMAIL` env var — one DB lookup per reviewer request to resolve email from the authenticated user's ID. Easy to evolve into role-based access later.

## Setup (one-time)

Add to `.env`:
```
MOVEMENT_REVIEWER_EMAIL=ccmagrane@gmail.com
```

Then restart the API server so it picks up the new env var.

## Tests

**API integration** (`apps/api/tests/movements.ts`, 15 cases):
- T1: `GET /api/movements` → 200, returns array including seeded movements
- T2: `GET /api/movements` no auth → 401
- T3: `POST /api/movements/suggest` → 201, status PENDING
- T4: `POST /api/movements/suggest` duplicate name → 409
- T5: `POST /api/movements/suggest` no auth → 401
- T6: `GET /api/movements/pending` reviewer → 200, includes pending submissions
- T7: `GET /api/movements/pending` non-reviewer → 403
- T8: `PATCH /api/movements/:id/review` accept → 200, status ACTIVE
- T9: `PATCH /api/movements/:id/review` reject → 200, status REJECTED
- T10: `PATCH /api/movements/:id/review` non-PENDING movement → 400
- T11: `POST /api/movements/detect` → 200, detects Thruster + Pull-up from description
- T12: `POST /api/movements/detect` no auth → 401
- T13: `GET /api/gyms/:gymId/workouts?movementIds=` → filters to workouts with that movement only
- T14: `GET /api/gyms/:gymId/workouts?movementIds=<base-id>` → auto-expands to include variation workouts
- T15: `movementIds` filter no auth → 401

**Existing suites** — all unaffected (128 tests, 0 failures):
- `tests/workouts.ts` — 37 passed
- `tests/results.ts` — 23 passed
- `tests/feed.ts` — 34 passed
- `tests/named-workouts.ts` — 34 passed

**Not automated / manual verification needed:**
- [x] Restart API server after adding `MOVEMENT_REVIEWER_EMAIL=ccmagrane@gmail.com` to `.env`, then run `npm run test --workspace=@berntracker/api` to confirm T6–T10 pass