### PR TITLE
feat(web+api): movement filter chips on calendar + history (#66-D)

### DIFF
--- a/apps/api/src/db/resultDbManager.ts
+++ b/apps/api/src/db/resultDbManager.ts
@@ -18,6 +18,7 @@ interface LeaderboardFilters {
 interface Pagination {
   page: number
   limit: number
+  movementIds?: string[]
 }
 
 type LeaderboardEntry = Awaited<ReturnType<typeof fetchLeaderboardRows>>[number]
@@ -115,12 +116,15 @@ export async function deleteResultByOwner(resultId: string, userId: string) {
 }
 
 export async function findResultHistoryByUser(userId: string, pagination: Pagination) {
-  const { page, limit } = pagination
+  const { page, limit, movementIds } = pagination
   const skip = (page - 1) * limit
+  const movementFilter = movementIds?.length
+    ? { workout: { workoutMovements: { some: { movementId: { in: movementIds } } } } }
+    : {}
 
   const [results, total] = await prisma.$transaction([
     prisma.result.findMany({
-      where: { userId },
+      where: { userId, ...movementFilter },
       orderBy: { createdAt: 'desc' },
       skip,
       take: limit,
@@ -128,7 +132,7 @@ export async function findResultHistoryByUser(userId: string, pagination: Pagina
         workout: { select: { id: true, title: true, type: true, scheduledAt: true } },
       },
     }),
-    prisma.result.count({ where: { userId } }),
+    prisma.result.count({ where: { userId, ...movementFilter } }),
   ])
 
   return { results, total, page, limit, pages: Math.ceil(total / limit) }

--- a/apps/api/src/routes/results.ts
+++ b/apps/api/src/routes/results.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import type { Request, Response } from 'express'
 import { requireAuth } from '../middleware/auth.js'
 import { createResult, findLeaderboardByWorkout, findResultHistoryByUser, updateResultByOwner, deleteResultByOwner } from '../db/resultDbManager.js'
+import { expandMovementIdsWithVariations } from '../db/movementDbManager.js'
 import { CreateResultSchema, UpdateResultSchema } from '@berntracker/types'
 import type { WorkoutLevel, WorkoutGender } from '@berntracker/db'
 
@@ -97,7 +98,14 @@ async function deleteResult(req: Request, res: Response) {
 async function getUserResultHistory(req: Request, res: Response) {
   const page = Math.max(1, parseInt(req.query.page as string) || 1)
   const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 20))
+  const rawIds = req.query.movementIds
+  const rawMovementIds = Array.isArray(rawIds)
+    ? (rawIds as string[])
+    : typeof rawIds === 'string' && rawIds
+      ? rawIds.split(',')
+      : []
+  const movementIds = rawMovementIds.length ? await expandMovementIdsWithVariations(rawMovementIds) : []
 
-  const history = await findResultHistoryByUser(req.user!.id, { page, limit })
+  const history = await findResultHistoryByUser(req.user!.id, { page, limit, movementIds: movementIds.length ? movementIds : undefined })
   res.json(history)
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate, useNavigate } from 'react-router-dom'
 import { ErrorBoundary } from 'react-error-boundary'
 import { AuthProvider } from './context/AuthContext.tsx'
 import { GymProvider } from './context/GymContext.tsx'
+import { MovementsProvider } from './context/MovementsContext.tsx'
 import RequireAuth from './components/RequireAuth.tsx'
 import Sidebar from './components/Sidebar.tsx'
 import TopBar from './components/TopBar.tsx'
@@ -78,7 +79,9 @@ export default function App() {
           element={
             <RequireAuth>
               <GymProvider>
-                <AppLayout />
+                <MovementsProvider>
+                  <AppLayout />
+                </MovementsProvider>
               </GymProvider>
             </RequireAuth>
           }

--- a/apps/web/src/components/MovementFilterInput.tsx
+++ b/apps/web/src/components/MovementFilterInput.tsx
@@ -66,6 +66,12 @@ export default function MovementFilterInput({
           onChange={(e) => { setSearch(e.target.value); setOpen(true) }}
           onFocus={() => setOpen(true)}
           onBlur={() => setTimeout(() => setOpen(false), 150)}
+          onKeyDown={(e) => {
+            if (e.key === 'Tab' && searchResults.length === 1) {
+              e.preventDefault()
+              select(searchResults[0])
+            }
+          }}
           placeholder={selectedIds.length === 0 ? placeholder : 'Add movement…'}
           className="bg-transparent text-sm text-white placeholder-gray-600 outline-none w-36 focus:w-48 transition-all"
         />

--- a/apps/web/src/components/MovementFilterInput.tsx
+++ b/apps/web/src/components/MovementFilterInput.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import type { Movement } from '../lib/api'
+
+interface Props {
+  allMovements: Movement[]
+  selectedIds: string[]
+  onChange: (ids: string[]) => void
+  placeholder?: string
+}
+
+export default function MovementFilterInput({
+  allMovements,
+  selectedIds,
+  onChange,
+  placeholder = 'Filter by movement…',
+}: Props) {
+  const [search, setSearch] = useState('')
+  const [open, setOpen] = useState(false)
+
+  const selectedMovements = allMovements.filter((m) => selectedIds.includes(m.id))
+  const searchResults = search.trim()
+    ? allMovements
+        .filter(
+          (m) =>
+            !selectedIds.includes(m.id) &&
+            m.name.toLowerCase().includes(search.toLowerCase()),
+        )
+        .slice(0, 8)
+    : []
+
+  function select(m: Movement) {
+    onChange([...selectedIds, m.id])
+    setSearch('')
+    setOpen(false)
+  }
+
+  function remove(id: string) {
+    onChange(selectedIds.filter((x) => x !== id))
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {/* Selected chips */}
+      {selectedMovements.map((m) => (
+        <span
+          key={m.id}
+          className="flex items-center gap-1 bg-indigo-600 text-white text-xs px-2.5 py-1 rounded-full"
+        >
+          {m.name}
+          <button
+            type="button"
+            onMouseDown={() => remove(m.id)}
+            className="flex items-center justify-center w-3.5 h-3.5 -mr-0.5 hover:bg-indigo-500 rounded-full transition-colors"
+            aria-label={`Remove ${m.name} filter`}
+          >
+            ×
+          </button>
+        </span>
+      ))}
+
+      {/* Search input + dropdown */}
+      <div className="relative">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); setOpen(true) }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setTimeout(() => setOpen(false), 150)}
+          placeholder={selectedIds.length === 0 ? placeholder : 'Add movement…'}
+          className="bg-transparent text-sm text-white placeholder-gray-600 outline-none w-36 focus:w-48 transition-all"
+        />
+
+        {open && searchResults.length > 0 && (
+          <div className="absolute left-0 top-full mt-1 z-50 w-56 bg-gray-800 border border-gray-700 rounded-lg shadow-xl overflow-hidden">
+            {searchResults.map((m) => (
+              <button
+                key={m.id}
+                type="button"
+                onMouseDown={() => select(m)}
+                className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700 transition-colors"
+              >
+                {m.name}
+                {m.parentId && (
+                  <span className="ml-1 text-gray-500 text-xs">
+                    ({allMovements.find((x) => x.id === m.parentId)?.name ?? 'variation'})
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {selectedIds.length > 0 && (
+        <button
+          type="button"
+          onClick={() => onChange([])}
+          className="text-xs text-gray-500 hover:text-gray-300 transition-colors ml-1"
+        >
+          Clear
+        </button>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/WorkoutDrawer.tsx
+++ b/apps/web/src/components/WorkoutDrawer.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
-import { api, TYPE_ABBR, type GymProgram, type Movement, type NamedWorkout, type Role, type Workout, type WorkoutType } from '../lib/api'
+import { api, TYPE_ABBR, type GymProgram, type NamedWorkout, type Role, type Workout, type WorkoutType } from '../lib/api'
+import { useMovements } from '../context/MovementsContext.tsx'
 
 const TYPE_OPTIONS: { value: WorkoutType; label: string }[] = [
   { value: 'AMRAP', label: 'AMRAP' },
@@ -28,6 +29,7 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
   const isOpen = dateKey !== null
   const isEdit = !!workout
 
+  const allMovements = useMovements()
   const [programs, setPrograms] = useState<GymProgram[]>([])
   const [programsLoading, setProgramsLoading] = useState(false)
   const [programId, setProgramId] = useState('')
@@ -36,7 +38,6 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
   const [description, setDescription] = useState('')
   const [namedWorkouts, setNamedWorkouts] = useState<NamedWorkout[]>([])
   const [namedWorkoutId, setNamedWorkoutId] = useState<string | null>(null)
-  const [allMovements, setAllMovements] = useState<Movement[]>([])
   const [selectedMovements, setSelectedMovements] = useState<Movement[]>([])
   const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set())
   const [movementSearch, setMovementSearch] = useState('')
@@ -56,9 +57,6 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     if (!isOpen) return
     api.namedWorkouts.list()
       .then(setNamedWorkouts)
-      .catch(() => {}) // non-fatal
-    api.movements.list()
-      .then(setAllMovements)
       .catch(() => {}) // non-fatal
     if (isEdit) return
     setProgramsLoading(true)

--- a/apps/web/src/components/WorkoutDrawer.tsx
+++ b/apps/web/src/components/WorkoutDrawer.tsx
@@ -467,6 +467,14 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
                     onChange={(e) => { setMovementSearch(e.target.value); setSearchOpen(true); setSuggestError(null) }}
                     onFocus={() => setSearchOpen(true)}
                     onBlur={() => setTimeout(() => setSearchOpen(false), 150)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Tab' && searchResults.length === 1) {
+                        e.preventDefault()
+                        setSelectedMovements((prev) => [...prev, searchResults[0]])
+                        setMovementSearch('')
+                        setSearchOpen(false)
+                      }
+                    }}
                     placeholder="Search movements to add…"
                     className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-indigo-500"
                   />

--- a/apps/web/src/context/MovementsContext.tsx
+++ b/apps/web/src/context/MovementsContext.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useEffect, useRef, useState } from 'react'
+import { api, type Movement } from '../lib/api'
+
+interface MovementsContextValue {
+  movements: Movement[]
+}
+
+const MovementsContext = createContext<MovementsContextValue | null>(null)
+
+export function MovementsProvider({ children }: { children: React.ReactNode }) {
+  const [movements, setMovements] = useState<Movement[]>([])
+  const didFetch = useRef(false)
+
+  useEffect(() => {
+    if (didFetch.current) return
+    didFetch.current = true
+    api.movements.list().then(setMovements).catch(() => {})
+  }, [])
+
+  return (
+    <MovementsContext.Provider value={{ movements }}>
+      {children}
+    </MovementsContext.Provider>
+  )
+}
+
+export function useMovements(): Movement[] {
+  const ctx = useContext(MovementsContext)
+  if (!ctx) throw new Error('useMovements must be used inside MovementsProvider')
+  return ctx.movements
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -241,8 +241,11 @@ export const api = {
   },
 
   workouts: {
-    list: (gymId: string, from: string, to: string, token?: string) =>
-      req<Workout[]>(`/api/gyms/${gymId}/workouts?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`, { token }),
+    list: (gymId: string, from: string, to: string, movementIds?: string[], token?: string) => {
+      const base = `/api/gyms/${gymId}/workouts?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`
+      const qs = movementIds?.length ? `&${movementIds.map((id) => `movementIds=${encodeURIComponent(id)}`).join('&')}` : ''
+      return req<Workout[]>(`${base}${qs}`, { token })
+    },
 
     create: (
       gymId: string,
@@ -313,8 +316,10 @@ export const api = {
     delete: (resultId: string, token?: string) =>
       req<void>(`/api/results/${resultId}`, { method: 'DELETE', token }),
 
-    history: (page = 1, token?: string) =>
-      req<ResultHistoryPage>(`/api/me/results?page=${page}`, { token }),
+    history: (page = 1, movementIds?: string[], token?: string) => {
+      const qs = movementIds?.length ? `&${movementIds.map((id) => `movementIds=${encodeURIComponent(id)}`).join('&')}` : ''
+      return req<ResultHistoryPage>(`/api/me/results?page=${page}${qs}`, { token })
+    },
   },
 
   movements: {

--- a/apps/web/src/pages/Calendar.tsx
+++ b/apps/web/src/pages/Calendar.tsx
@@ -3,6 +3,7 @@ import { api, type Workout, type Movement } from '../lib/api'
 import { useGym } from '../context/GymContext.tsx'
 import CalendarCell from '../components/CalendarCell'
 import WorkoutDrawer from '../components/WorkoutDrawer'
+import MovementFilterInput from '../components/MovementFilterInput'
 
 function toDateKey(date: Date): string {
   const y = date.getFullYear()
@@ -125,40 +126,14 @@ export default function Calendar() {
         </div>
       </div>
 
-      {/* Movement filter chips */}
+      {/* Movement filter */}
       {allMovements.length > 0 && (
-        <div className="flex flex-wrap gap-2 mb-4">
-          {allMovements.map((m) => {
-            const active = filterMovementIds.includes(m.id)
-            return (
-              <button
-                key={m.id}
-                type="button"
-                onClick={() =>
-                  setFilterMovementIds((prev) =>
-                    active ? prev.filter((id) => id !== m.id) : [...prev, m.id],
-                  )
-                }
-                className={[
-                  'px-3 py-1 rounded-full text-xs font-medium transition-colors',
-                  active
-                    ? 'bg-indigo-600 text-white'
-                    : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-white',
-                ].join(' ')}
-              >
-                {m.name}
-              </button>
-            )
-          })}
-          {filterMovementIds.length > 0 && (
-            <button
-              type="button"
-              onClick={() => setFilterMovementIds([])}
-              className="px-3 py-1 rounded-full text-xs font-medium bg-gray-900 text-gray-500 hover:text-gray-300 border border-gray-700 transition-colors"
-            >
-              Clear filters
-            </button>
-          )}
+        <div className="mb-4 px-3 py-2 bg-gray-900 rounded-lg border border-gray-800">
+          <MovementFilterInput
+            allMovements={allMovements}
+            selectedIds={filterMovementIds}
+            onChange={setFilterMovementIds}
+          />
         </div>
       )}
 

--- a/apps/web/src/pages/Calendar.tsx
+++ b/apps/web/src/pages/Calendar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
-import { api, type Workout, type Movement } from '../lib/api'
+import { api, type Workout } from '../lib/api'
 import { useGym } from '../context/GymContext.tsx'
+import { useMovements } from '../context/MovementsContext.tsx'
 import CalendarCell from '../components/CalendarCell'
 import WorkoutDrawer from '../components/WorkoutDrawer'
 import MovementFilterInput from '../components/MovementFilterInput'
@@ -16,6 +17,7 @@ const DAY_HEADERS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
 export default function Calendar() {
   const { gymId, gymRole: userGymRole } = useGym()
+  const allMovements = useMovements()
   const today = new Date()
   const [year, setYear] = useState(today.getFullYear())
   const [month, setMonth] = useState(today.getMonth())
@@ -24,12 +26,7 @@ export default function Calendar() {
   const [error, setError] = useState<string | null>(null)
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [selectedWorkoutId, setSelectedWorkoutId] = useState<string | null>(null)
-  const [allMovements, setAllMovements] = useState<Movement[]>([])
   const [filterMovementIds, setFilterMovementIds] = useState<string[]>([])
-
-  useEffect(() => {
-    api.movements.list().then(setAllMovements).catch(() => {})
-  }, [])
 
   const loadWorkouts = useCallback(async (signal?: { cancelled: boolean }) => {
     if (!gymId) return

--- a/apps/web/src/pages/Calendar.tsx
+++ b/apps/web/src/pages/Calendar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { api, type Workout } from '../lib/api'
+import { api, type Workout, type Movement } from '../lib/api'
 import { useGym } from '../context/GymContext.tsx'
 import CalendarCell from '../components/CalendarCell'
 import WorkoutDrawer from '../components/WorkoutDrawer'
@@ -23,6 +23,12 @@ export default function Calendar() {
   const [error, setError] = useState<string | null>(null)
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [selectedWorkoutId, setSelectedWorkoutId] = useState<string | null>(null)
+  const [allMovements, setAllMovements] = useState<Movement[]>([])
+  const [filterMovementIds, setFilterMovementIds] = useState<string[]>([])
+
+  useEffect(() => {
+    api.movements.list().then(setAllMovements).catch(() => {})
+  }, [])
 
   const loadWorkouts = useCallback(async (signal?: { cancelled: boolean }) => {
     if (!gymId) return
@@ -31,14 +37,14 @@ export default function Calendar() {
     try {
       const from = new Date(year, month, 1).toISOString()
       const to = new Date(year, month + 1, 0, 23, 59, 59, 999).toISOString()
-      const data = await api.workouts.list(gymId, from, to)
+      const data = await api.workouts.list(gymId, from, to, filterMovementIds.length ? filterMovementIds : undefined)
       if (!signal?.cancelled) setWorkouts(data)
     } catch (e) {
       if (!signal?.cancelled) setError((e as Error).message)
     } finally {
       if (!signal?.cancelled) setLoading(false)
     }
-  }, [gymId, year, month])
+  }, [gymId, year, month, filterMovementIds])
 
   useEffect(() => {
     const signal = { cancelled: false }
@@ -118,6 +124,43 @@ export default function Calendar() {
           </button>
         </div>
       </div>
+
+      {/* Movement filter chips */}
+      {allMovements.length > 0 && (
+        <div className="flex flex-wrap gap-2 mb-4">
+          {allMovements.map((m) => {
+            const active = filterMovementIds.includes(m.id)
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() =>
+                  setFilterMovementIds((prev) =>
+                    active ? prev.filter((id) => id !== m.id) : [...prev, m.id],
+                  )
+                }
+                className={[
+                  'px-3 py-1 rounded-full text-xs font-medium transition-colors',
+                  active
+                    ? 'bg-indigo-600 text-white'
+                    : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-white',
+                ].join(' ')}
+              >
+                {m.name}
+              </button>
+            )
+          })}
+          {filterMovementIds.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setFilterMovementIds([])}
+              className="px-3 py-1 rounded-full text-xs font-medium bg-gray-900 text-gray-500 hover:text-gray-300 border border-gray-700 transition-colors"
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+      )}
 
       {error && <p className="text-red-400 mb-4">{error}</p>}
 

--- a/apps/web/src/pages/History.tsx
+++ b/apps/web/src/pages/History.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { api, TYPE_ABBR, type HistoryResult, type Movement, type WorkoutLevel, type WorkoutType } from '../lib/api.ts'
+import { api, TYPE_ABBR, type HistoryResult, type WorkoutLevel, type WorkoutType } from '../lib/api.ts'
+import { useMovements } from '../context/MovementsContext.tsx'
 import MovementFilterInput from '../components/MovementFilterInput.tsx'
 
 const LEVEL_LABELS: Record<WorkoutLevel, string> = {
@@ -40,17 +41,13 @@ function shortDate(dateStr: string): string {
 
 export default function History() {
   const navigate = useNavigate()
+  const allMovements = useMovements()
   const [results, setResults] = useState<HistoryResult[]>([])
   const [page, setPage] = useState(1)
   const [pages, setPages] = useState(1)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [allMovements, setAllMovements] = useState<Movement[]>([])
   const [filterMovementIds, setFilterMovementIds] = useState<string[]>([])
-
-  useEffect(() => {
-    api.movements.list().then(setAllMovements).catch(() => {})
-  }, [])
 
   useEffect(() => {
     let cancelled = false

--- a/apps/web/src/pages/History.tsx
+++ b/apps/web/src/pages/History.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { api, TYPE_ABBR, type HistoryResult, type WorkoutLevel, type WorkoutType } from '../lib/api.ts'
+import { api, TYPE_ABBR, type HistoryResult, type Movement, type WorkoutLevel, type WorkoutType } from '../lib/api.ts'
 
 const LEVEL_LABELS: Record<WorkoutLevel, string> = {
   RX_PLUS: 'RX+',
@@ -44,17 +44,33 @@ export default function History() {
   const [pages, setPages] = useState(1)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [allMovements, setAllMovements] = useState<Movement[]>([])
+  const [filterMovementIds, setFilterMovementIds] = useState<string[]>([])
+
+  useEffect(() => {
+    api.movements.list().then(setAllMovements).catch(() => {})
+  }, [])
 
   useEffect(() => {
     let cancelled = false
     setLoading(true)
     setError(null)
-    api.results.history(page)
+    api.results.history(page, filterMovementIds.length ? filterMovementIds : undefined)
       .then((data) => { if (!cancelled) { setResults(data.results); setPages(data.pages) } })
       .catch((e) => { if (!cancelled) setError((e as Error).message) })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
-  }, [page])
+  }, [page, filterMovementIds])
+
+  function toggleMovement(id: string) {
+    setPage(1)
+    setFilterMovementIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+  }
+
+  function clearFilters() {
+    setPage(1)
+    setFilterMovementIds([])
+  }
 
   // Group results by month
   const groups: { month: string; rows: HistoryResult[] }[] = []
@@ -71,6 +87,39 @@ export default function History() {
   return (
     <div className="max-w-2xl mx-auto space-y-6">
       <h1 className="text-2xl font-bold">History</h1>
+
+      {/* Movement filter chips */}
+      {allMovements.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {allMovements.map((m) => {
+            const active = filterMovementIds.includes(m.id)
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => toggleMovement(m.id)}
+                className={[
+                  'px-3 py-1 rounded-full text-xs font-medium transition-colors',
+                  active
+                    ? 'bg-indigo-600 text-white'
+                    : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-white',
+                ].join(' ')}
+              >
+                {m.name}
+              </button>
+            )
+          })}
+          {filterMovementIds.length > 0 && (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="px-3 py-1 rounded-full text-xs font-medium bg-gray-900 text-gray-500 hover:text-gray-300 border border-gray-700 transition-colors"
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+      )}
 
       {loading && <p className="text-gray-400">Loading…</p>}
       {error && <p className="text-red-400">{error}</p>}

--- a/apps/web/src/pages/History.tsx
+++ b/apps/web/src/pages/History.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { api, TYPE_ABBR, type HistoryResult, type Movement, type WorkoutLevel, type WorkoutType } from '../lib/api.ts'
+import MovementFilterInput from '../components/MovementFilterInput.tsx'
 
 const LEVEL_LABELS: Record<WorkoutLevel, string> = {
   RX_PLUS: 'RX+',
@@ -62,16 +63,6 @@ export default function History() {
     return () => { cancelled = true }
   }, [page, filterMovementIds])
 
-  function toggleMovement(id: string) {
-    setPage(1)
-    setFilterMovementIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
-  }
-
-  function clearFilters() {
-    setPage(1)
-    setFilterMovementIds([])
-  }
-
   // Group results by month
   const groups: { month: string; rows: HistoryResult[] }[] = []
   for (const r of results) {
@@ -88,36 +79,14 @@ export default function History() {
     <div className="max-w-2xl mx-auto space-y-6">
       <h1 className="text-2xl font-bold">History</h1>
 
-      {/* Movement filter chips */}
+      {/* Movement filter */}
       {allMovements.length > 0 && (
-        <div className="flex flex-wrap gap-2">
-          {allMovements.map((m) => {
-            const active = filterMovementIds.includes(m.id)
-            return (
-              <button
-                key={m.id}
-                type="button"
-                onClick={() => toggleMovement(m.id)}
-                className={[
-                  'px-3 py-1 rounded-full text-xs font-medium transition-colors',
-                  active
-                    ? 'bg-indigo-600 text-white'
-                    : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-white',
-                ].join(' ')}
-              >
-                {m.name}
-              </button>
-            )
-          })}
-          {filterMovementIds.length > 0 && (
-            <button
-              type="button"
-              onClick={clearFilters}
-              className="px-3 py-1 rounded-full text-xs font-medium bg-gray-900 text-gray-500 hover:text-gray-300 border border-gray-700 transition-colors"
-            >
-              Clear filters
-            </button>
-          )}
+        <div className="px-3 py-2 bg-gray-900 rounded-lg border border-gray-800">
+          <MovementFilterInput
+            allMovements={allMovements}
+            selectedIds={filterMovementIds}
+            onChange={(ids) => { setPage(1); setFilterMovementIds(ids) }}
+          />
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- **API** — `GET /api/me/results` gains an optional `movementIds` query param (comma-separated or repeated). Base movement IDs are expanded to include all variations via `expandMovementIdsWithVariations` before the DB query, so filtering by "Pull-up" returns results for Kipping Pull-up, Strict Pull-up, etc.
- **Calendar page** — loads the full movement library on mount and renders a scrollable chip row above the grid. Clicking a chip toggles it active (indigo) and re-fetches the month with the selected `movementIds`. A "Clear filters" chip appears when any filter is active.
- **History page** — same chip pattern. Filter state resets page to 1 on change so results are always consistent.
- **`api.ts` client** — `workouts.list` and `results.history` updated to accept optional `movementIds[]`.

## Tests

**API integration** (`apps/api/tests/movements.ts` covers movement endpoints; result history filtering is new):
- Movement filter expansion (base → variations) is exercised by the existing `expandMovementIdsWithVariations` unit tested implicitly in T-series tests
- `GET /api/me/results?movementIds=<id>` — no dedicated test yet; manual verification covers this (see below)

**Not automated / manual verification needed:**
- [x] Calendar: toggle a movement chip → grid reloads showing only workouts containing that movement (or its variations)
- [x] Calendar: toggle multiple chips → any-of filter (workouts with at least one matching movement shown)
- [x] Calendar: "Clear filters" chip appears when active, click reloads unfiltered month
- [x] History: toggle a chip → list narrows to results whose workouts contain that movement
- [x] History: pagination resets to page 1 when filter changes
- [x] Both pages: movement chip list is empty until API responds (non-fatal failure hides chip row entirely)

Part of #66