### PR TITLE
fix(web): use workoutMovements in WodDetail — was crashing on undefined .movements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,13 +177,48 @@ cd apps/api && npx dotenv-cli -e ../../.env -- sh -c 'for f in tests/*.ts; do np
 
 ---
 
+### Web unit tests (Vitest + React Testing Library)
+
+Located in `apps/web/src/**/*.test.tsx`. Each test file lives next to the component it covers.
+
+**Run:**
+```bash
+npm run test:unit --workspace=@berntracker/web
+# or from apps/web:
+cd apps/web && npx vitest run
+```
+
+**Requires:** nothing running — fully in-process, no server or DB needed.
+
+**Setup:** Vitest is configured in `vite.config.ts` (`test.environment: 'jsdom'`). The global setup file `src/test/setup.ts` imports `@testing-library/jest-dom` matchers. Vitest globals (`describe`, `it`, `expect`, `vi`) are enabled so no imports are needed in test files.
+
+**When to write unit tests vs E2E:**
+- Unit tests cover **component rendering and logic**: does the page render without crashing? Are the right elements shown given a mocked API response? Use `vi.mock('../lib/api')` to control API responses.
+- E2E tests (Playwright) cover **user flows end-to-end**: navigation, real API calls, DB state. Use E2E when the correctness depends on the full stack.
+- **Every page must have at least one render test** that asserts it mounts without throwing. This catches crashes from type mismatches, missing fields, or bad assumptions about API shape — bugs that would otherwise only surface in the browser.
+
+**Test files:**
+
+| File | Covers |
+|---|---|
+| `src/pages/WodDetail.test.tsx` | WodDetail renders with empty movements, with movement chips, and with undefined workoutMovements |
+
+**Patterns to follow:**
+- Wrap the component in `<MemoryRouter>` with `<Routes>` matching the real URL pattern so `useParams` works.
+- Mock `../lib/api` fully — every `api.*` call used by the component must be mocked or the test will hang.
+- Mock `../context/AuthContext` to return a minimal `{ user: { id, name } }`.
+- Use `screen.findBy*` (async) for elements that appear after a resolved promise.
+
+---
+
 ### Web E2E tests (Playwright)
 
 Located in `apps/web/tests/`. Each spec file uses Playwright and seeds DB fixtures directly via `PrismaClient` (imported via `createRequire` to bypass ESM/CJS issues).
 
 **Run:**
 ```bash
-npm run test --workspace=@berntracker/web
+npm run test --workspace=@berntracker/web   # runs unit tests first, then E2E
+npm run test:e2e --workspace=@berntracker/web  # E2E only
 # or from apps/web:
 cd apps/web && npx dotenv-cli -e ../../.env -- npx playwright test
 ```
@@ -195,7 +230,7 @@ cd apps/web && npx dotenv-cli -e ../../.env -- npx playwright test
 | File | Covers |
 |---|---|
 | `tests/calendar-multi-workout.spec.ts` | Multi-workout calendar: overflow pills, drawer create/edit/delete, reorder, role gates |
-| `tests/feed-wod-detail.spec.ts` | Feed page, WOD Detail page: sidebar role awareness, workout display, results table, level filter chips, "Your Result" badge |
+| `tests/feed-wod-detail.spec.ts` | Feed page, WOD Detail page: sidebar role awareness, workout display, results table, level filter chips, "Your Result" badge, movement chips |
 
 **Patterns to follow:**
 - Use `test.describe.configure({ mode: 'serial' })` — tests share seeded DB state.
@@ -219,6 +254,9 @@ Every PR must include a **Tests** section that describes what was tested and how
 
 ```markdown
 ## Tests
+
+**Unit** (`apps/web/src/pages/<Page>.test.tsx`):
+- <what each test asserts — e.g. "renders without crashing", "shows movement chips">
 
 **API integration** (`apps/api/tests/<file>.ts`):
 - <what each case asserts — one bullet per meaningful assertion group>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-error-boundary": "^6.1.1",
     "react-router-dom": "^7.3.0"
   },
   "devDependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,8 +8,9 @@
     "build": "tsc -b && vite build",
     "lint": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "npx dotenv-cli -e ../../.env -- npx playwright test",
-    "test:unit": "vitest run"
+    "test": "vitest run && npx dotenv-cli -e ../../.env -- npx playwright test",
+    "test:unit": "vitest run",
+    "test:e2e": "npx dotenv-cli -e ../../.env -- npx playwright test"
   },
   "dependencies": {
     "react": "^19.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "npx dotenv-cli -e ../../.env -- npx playwright test"
+    "test": "npx dotenv-cli -e ../../.env -- npx playwright test",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "react": "^19.0.0",
@@ -17,14 +18,20 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",
-    "@types/bcryptjs": "^2.4.6",
-    "bcryptjs": "^2.4.3",
     "@tailwindcss/vite": "^4.0.9",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/bcryptjs": "^2.4.6",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/coverage-v8": "^4.1.5",
+    "bcryptjs": "^2.4.3",
+    "jsdom": "^29.0.2",
     "tailwindcss": "^4.0.9",
     "typescript": "^5.7.3",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { ErrorBoundary } from 'react-error-boundary'
+import { PageErrorFallback } from './App'
+
+// Suppress the expected console.error from React when a render throws
+beforeEach(() => { vi.spyOn(console, 'error').mockImplementation(() => {}) })
+afterEach(() => { vi.restoreAllMocks() })
+
+function Bomb(): never {
+  throw new Error('Simulated render crash')
+}
+
+describe('PageErrorFallback (error boundary)', () => {
+  it('renders the fallback instead of crashing when a child throws', () => {
+    render(
+      <MemoryRouter>
+        <ErrorBoundary FallbackComponent={PageErrorFallback}>
+          <Bomb />
+        </ErrorBoundary>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Something went wrong on this page.')).toBeInTheDocument()
+    expect(screen.getByText('Simulated render crash')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Back to Feed' })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { Routes, Route, Navigate } from 'react-router-dom'
+import { Routes, Route, Navigate, useNavigate } from 'react-router-dom'
+import { ErrorBoundary } from 'react-error-boundary'
 import { AuthProvider } from './context/AuthContext.tsx'
 import { GymProvider } from './context/GymContext.tsx'
 import RequireAuth from './components/RequireAuth.tsx'
@@ -15,6 +16,30 @@ import Feed from './pages/Feed.tsx'
 import WodDetail from './pages/WodDetail.tsx'
 import History from './pages/History.tsx'
 
+export function PageErrorFallback({ error, resetErrorBoundary }: { error: Error; resetErrorBoundary: () => void }) {
+  const navigate = useNavigate()
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-4 text-center px-4">
+      <p className="text-gray-400 text-sm">Something went wrong on this page.</p>
+      <p className="text-gray-600 text-xs font-mono">{error.message}</p>
+      <div className="flex gap-3">
+        <button
+          onClick={resetErrorBoundary}
+          className="px-4 py-2 text-sm rounded bg-indigo-600 hover:bg-indigo-700 text-white transition-colors"
+        >
+          Try again
+        </button>
+        <button
+          onClick={() => { resetErrorBoundary(); navigate('/feed') }}
+          className="px-4 py-2 text-sm rounded bg-gray-800 hover:bg-gray-700 text-gray-300 transition-colors"
+        >
+          Back to Feed
+        </button>
+      </div>
+    </div>
+  )
+}
+
 function AppLayout() {
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
 
@@ -24,16 +49,18 @@ function AppLayout() {
       <div className="flex-1 min-w-0 flex flex-col min-h-0">
         <TopBar onMenuClick={() => setMobileNavOpen(true)} />
         <main className="flex-1 overflow-y-auto overflow-x-hidden p-4 md:p-8">
-          <Routes>
-            <Route path="/" element={<Navigate to="/feed" replace />} />
-            <Route path="/feed" element={<Feed />} />
-            <Route path="/workouts/:id" element={<WodDetail />} />
-            <Route path="/history" element={<History />} />
-            <Route path="/dashboard" element={<Dashboard />} />
-            <Route path="/calendar" element={<Calendar />} />
-            <Route path="/members" element={<Members />} />
-            <Route path="/settings" element={<Settings />} />
-          </Routes>
+          <ErrorBoundary FallbackComponent={PageErrorFallback} resetKeys={[window.location.pathname]}>
+            <Routes>
+              <Route path="/" element={<Navigate to="/feed" replace />} />
+              <Route path="/feed" element={<Feed />} />
+              <Route path="/workouts/:id" element={<WodDetail />} />
+              <Route path="/history" element={<History />} />
+              <Route path="/dashboard" element={<Dashboard />} />
+              <Route path="/calendar" element={<Calendar />} />
+              <Route path="/members" element={<Members />} />
+              <Route path="/settings" element={<Settings />} />
+            </Routes>
+          </ErrorBoundary>
         </main>
       </div>
     </div>

--- a/apps/web/src/pages/WodDetail.test.tsx
+++ b/apps/web/src/pages/WodDetail.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import WodDetail from './WodDetail'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../lib/api', () => ({
+  api: {
+    workouts: { get: vi.fn() },
+    results: { leaderboard: vi.fn() },
+  },
+  TYPE_ABBR: {
+    STRENGTH: 'S', FOR_TIME: 'F', EMOM: 'E', CARDIO: 'C',
+    AMRAP: 'A', METCON: 'M', WARMUP: 'W',
+  },
+}))
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-1', name: 'Test User' } }),
+}))
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+import { api } from '../lib/api'
+
+function makeWorkout(overrides = {}) {
+  return {
+    id: 'workout-1',
+    title: 'Test Workout',
+    description: '3 rounds',
+    type: 'FOR_TIME' as const,
+    status: 'PUBLISHED' as const,
+    scheduledAt: '2026-07-15T12:00:00.000Z',
+    dayOrder: 0,
+    workoutMovements: [],
+    programId: null,
+    program: null,
+    namedWorkoutId: null,
+    namedWorkout: null,
+    _count: { results: 0 },
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function renderPage(workoutId = 'workout-1') {
+  return render(
+    <MemoryRouter initialEntries={[`/workouts/${workoutId}`]}>
+      <Routes>
+        <Route path="/workouts/:id" element={<WodDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('WodDetail', () => {
+  beforeEach(() => {
+    vi.mocked(api.results.leaderboard).mockResolvedValue([])
+  })
+
+  it('renders the page when workoutMovements is empty', async () => {
+    vi.mocked(api.workouts.get).mockResolvedValue(makeWorkout())
+    renderPage()
+    expect(await screen.findByRole('heading', { name: 'Test Workout' })).toBeInTheDocument()
+  })
+
+  it('renders movement chips when workoutMovements is present', async () => {
+    vi.mocked(api.workouts.get).mockResolvedValue(
+      makeWorkout({
+        workoutMovements: [
+          { movement: { id: 'm-1', name: 'Thruster', parentId: null } },
+          { movement: { id: 'm-2', name: 'Pull-up', parentId: null } },
+        ],
+      }),
+    )
+    renderPage()
+    expect(await screen.findByText('Thruster')).toBeInTheDocument()
+    expect(await screen.findByText('Pull-up')).toBeInTheDocument()
+  })
+
+  it('renders without crashing when API returns a workout with no movements field', async () => {
+    // Simulates the pre-fix state: API response has workoutMovements undefined
+    // (e.g. an older API version or a missing include). Page must not throw.
+    vi.mocked(api.workouts.get).mockResolvedValue(
+      makeWorkout({ workoutMovements: undefined }),
+    )
+    renderPage()
+    expect(await screen.findByRole('heading', { name: 'Test Workout' })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/pages/WodDetail.tsx
+++ b/apps/web/src/pages/WodDetail.tsx
@@ -155,11 +155,11 @@ export default function WodDetail() {
       )}
 
       {/* Movements */}
-      {workout.movements.length > 0 && (
+      {(workout.workoutMovements?.length ?? 0) > 0 && (
         <div className="flex flex-wrap gap-1.5">
-          {workout.movements.map((m, i) => (
-            <span key={i} className="text-xs px-2.5 py-1 rounded-full bg-gray-800 text-gray-300 border border-gray-700">
-              {m}
+          {workout.workoutMovements?.map((wm) => (
+            <span key={wm.movement.id} className="text-xs px-2.5 py-1 rounded-full bg-gray-800 text-gray-300 border border-gray-700">
+              {wm.movement.name}
             </span>
           ))}
         </div>

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/apps/web/tests/feed-wod-detail.spec.ts
+++ b/apps/web/tests/feed-wod-detail.spec.ts
@@ -11,6 +11,7 @@
  *   T7: WOD Detail results table shows logged results
  *   T8: Level filter chips correctly filter results
  *   T9: "Your Result" badge appears when the current user has a result
+ *   T12: WOD Detail renders movement chips and does not crash when workoutMovements is present
  *
  * Requires: turbo dev running (API on :3000, web on :5173)
  * Run: npm run test --workspace=@berntracker/web
@@ -49,6 +50,8 @@ let memberUserId = ''
 let programmerUserId = ''
 let publishedWorkoutId = ''
 let longTitleWorkoutId = ''
+let movementWorkoutId = ''
+let movementId = ''
 
 // ─── DB helpers ───────────────────────────────────────────────────────────────
 
@@ -164,10 +167,33 @@ test.describe('Feed + WOD Detail E2E (#48)', () => {
       },
     })
     longTitleWorkoutId = longTitle.id
+
+    // Workout with a tagged movement — used by T12 to verify movements section renders
+    const movement = await prisma.movement.upsert({
+      where: { name: 'Thruster' },
+      update: {},
+      create: { name: 'Thruster', status: 'ACTIVE' },
+    })
+    movementId = movement.id
+
+    const movementWorkout = await prisma.workout.create({
+      data: {
+        title: 'E2E Movement Chips',
+        description: '5x5 Thruster',
+        type: 'STRENGTH',
+        status: 'PUBLISHED',
+        scheduledAt: new Date(WORKOUT_ISO),
+        programId,
+        dayOrder: 3,
+        workoutMovements: { create: { movementId } },
+      },
+    })
+    movementWorkoutId = movementWorkout.id
   })
 
   test.afterAll(async () => {
-    await prisma.result.deleteMany({ where: { workoutId: { in: [publishedWorkoutId, longTitleWorkoutId] } } })
+    await prisma.workoutMovement.deleteMany({ where: { workoutId: movementWorkoutId } })
+    await prisma.result.deleteMany({ where: { workoutId: { in: [publishedWorkoutId, longTitleWorkoutId, movementWorkoutId] } } })
     await prisma.workout.deleteMany({ where: { programId } })
     await prisma.program.delete({ where: { id: programId } }).catch(() => {})
     await prisma.user.deleteMany({ where: { id: { in: [memberUserId, programmerUserId] } } })
@@ -400,5 +426,22 @@ test.describe('Feed + WOD Detail E2E (#48)', () => {
     // Card must be taller than a single-line card (title has wrapped)
     // Single-line cards are ~44px tall (py-3 top+bottom = 24px + ~20px text line)
     expect(cardBox?.height).toBeGreaterThan(48)
+  })
+
+  // ── T12: WOD Detail renders movement chips without crashing ──────────────
+
+  test('T12: WOD Detail renders movement chips and does not crash when workoutMovements is present', async ({ page }) => {
+    await loginAndGoToFeed(page, MEMBER_EMAIL, MEMBER_PASSWORD)
+    await page.goto(`/workouts/${movementWorkoutId}`)
+    await page.waitForSelector(`h1:has-text("E2E Movement Chips")`)
+
+    // Page must load without JS errors — Playwright fails on uncaught exceptions by default
+    await expect(page.getByRole('heading', { name: 'E2E Movement Chips' })).toBeVisible()
+
+    // Movement chip for "Thruster" must be rendered
+    await expect(page.getByText('Thruster', { exact: true })).toBeVisible()
+
+    // Log Result button present (no result logged yet)
+    await expect(page.getByRole('button', { name: 'Log Result' })).toBeVisible()
   })
 })

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -11,7 +11,8 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
-    "strict": true
+    "strict": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src"]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,4 +8,10 @@ export default defineConfig({
     port: 5173,
     proxy: { '/api': { target: 'http://localhost:3000', changeOrigin: true } },
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
 })


### PR DESCRIPTION
## Summary

**Root cause:** \`WodDetail.tsx:158\` read \`workout.movements.length\` but the \`Workout\` type was changed from \`movements: string[]\` to \`workoutMovements: { movement: Movement }[]\` in PR #69. The field was absent on the API response, causing an uncaught \`TypeError\` that crashed the entire page render — blank screen.

**Fix 1 — correct the field reference:** \`WodDetail.tsx\` now reads \`workout.workoutMovements?.map(wm => wm.movement.name)\` with optional chaining.

**Fix 2 — top-level error boundary:** Added \`react-error-boundary\` wrapping the authenticated \`<Routes>\` in \`AppLayout\`. Any future uncaught render error now shows a fallback — error message, "Try again", and "Back to Feed" — instead of a blank screen. \`resetKeys={[window.location.pathname]}\` auto-resets the boundary on navigation so a crash on one page doesn't brick the rest of the app.

The unit tests and E2E test are the regression guards for the specific field-rename bug. The error boundary is the runtime safety net for anything that gets past testing.

## Tests

**Unit** (\`apps/web/src/App.test.tsx\` + \`src/pages/WodDetail.test.tsx\`, 4 tests — \`npm run test:unit --workspace=@berntracker/web\`):
- App.test.tsx: mounts a component that throws inside the boundary; asserts fallback text, error message, and both action buttons render
- WodDetail.test.tsx: renders without crashing when \`workoutMovements\` is empty
- WodDetail.test.tsx: renders movement chips when \`workoutMovements\` is present
- WodDetail.test.tsx: does not crash when \`workoutMovements\` is \`undefined\` — direct regression guard

**Playwright E2E** (\`apps/web/tests/feed-wod-detail.spec.ts\`, 12 tests):
- T1–T11: existing tests (unchanged)
- T12 *(new)*: seeds a workout with a \`WorkoutMovement\`, navigates to WOD Detail, asserts page loads and movement chip is visible

**Not automated / manual verification needed:**
- [ ] Verify the error boundary fallback UI renders (navigate to a broken route or temporarily break a page render)

Closes the regression introduced by #69.