### PR TITLE
feat: inline edit for pending movements — rename + parent tagging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,13 +165,7 @@ cd apps/api && npx dotenv-cli -e ../../.env -- sh -c 'for f in tests/*.ts; do np
 
 **Requires:** API running on `localhost:3000`, DB accessible via `DATABASE_URL`.
 
-**Test files:**
-
-| File | Covers |
-|---|---|
-| `tests/workouts.ts` | Workout CRUD, publish, dayOrder, role-based access, program subscriptions |
-| `tests/results.ts` | Result logging, leaderboard sorting/filtering, paginated history |
-| `tests/feed.ts` | Feed (member sees PUBLISHED-only), WOD detail, WorkoutResult shape |
+**Test files:** See scripts under `apps/api/tests/` — one `.ts` file per domain (workouts, results, feed, etc.).
 
 **Adding a new test file:** Follow the pattern in any existing file. Add the new script to the `test` command in `apps/api/package.json`.
 
@@ -197,11 +191,7 @@ cd apps/web && npx vitest run
 - E2E tests (Playwright) cover **user flows end-to-end**: navigation, real API calls, DB state. Use E2E when the correctness depends on the full stack.
 - **Every page must have at least one render test** that asserts it mounts without throwing. This catches crashes from type mismatches, missing fields, or bad assumptions about API shape — bugs that would otherwise only surface in the browser.
 
-**Test files:**
-
-| File | Covers |
-|---|---|
-| `src/pages/WodDetail.test.tsx` | WodDetail renders with empty movements, with movement chips, and with undefined workoutMovements |
+**Test files:** Co-located with the component they cover as `*.test.tsx` under `apps/web/src/` (e.g., `src/pages/WodDetail.test.tsx` sits next to `src/pages/WodDetail.tsx`).
 
 **Patterns to follow:**
 - Wrap the component in `<MemoryRouter>` with `<Routes>` matching the real URL pattern so `useParams` works.
@@ -225,12 +215,7 @@ cd apps/web && npx dotenv-cli -e ../../.env -- npx playwright test
 
 **Requires:** `turbo dev` running (API on `:3000`, web on `:5173`).
 
-**Test files:**
-
-| File | Covers |
-|---|---|
-| `tests/calendar-multi-workout.spec.ts` | Multi-workout calendar: overflow pills, drawer create/edit/delete, reorder, role gates |
-| `tests/feed-wod-detail.spec.ts` | Feed page, WOD Detail page: sidebar role awareness, workout display, results table, level filter chips, "Your Result" badge, movement chips |
+**Test files:** See specs under `apps/web/tests/` — one `.spec.ts` file per user flow (calendar, feed, WOD detail, autosave, etc.).
 
 **Patterns to follow:**
 - Use `test.describe.configure({ mode: 'serial' })` — tests share seeded DB state.

--- a/apps/api/src/db/movementDbManager.ts
+++ b/apps/api/src/db/movementDbManager.ts
@@ -62,6 +62,23 @@ export async function reviewMovementById(id: string, status: 'ACTIVE' | 'REJECTE
   })
 }
 
+export async function updatePendingMovementById(id: string, data: { name?: string; parentId?: string | null }) {
+  const movement = await prisma.movement.findUnique({ where: { id } })
+  if (!movement) throw Object.assign(new Error('Movement not found'), { statusCode: 404 })
+  if (movement.status !== 'PENDING') {
+    throw Object.assign(new Error('Only PENDING movements can be edited'), { statusCode: 400 })
+  }
+  if (data.name && data.name !== movement.name) {
+    const conflict = await prisma.movement.findUnique({ where: { name: data.name } })
+    if (conflict) throw Object.assign(new Error('A movement with that name already exists'), { statusCode: 409 })
+  }
+  return prisma.movement.update({
+    where: { id },
+    data: { ...(data.name !== undefined && { name: data.name }), ...(data.parentId !== undefined && { parentId: data.parentId }) },
+    ...movementWithVariationsSelect,
+  })
+}
+
 export async function expandMovementIdsWithVariations(movementIds: string[]): Promise<string[]> {
   if (movementIds.length === 0) return []
   const movements = await prisma.movement.findMany({

--- a/apps/api/src/routes/movements.ts
+++ b/apps/api/src/routes/movements.ts
@@ -6,9 +6,10 @@ import {
   createPendingMovement,
   findPendingMovements,
   reviewMovementById,
+  updatePendingMovementById,
   detectMovementsInText,
 } from '../db/movementDbManager.js'
-import { SuggestMovementSchema, ReviewMovementSchema } from '@berntracker/types'
+import { SuggestMovementSchema, ReviewMovementSchema, UpdatePendingMovementSchema } from '@berntracker/types'
 
 const router = Router()
 
@@ -19,6 +20,7 @@ router.get('/movements', requireAuth, getMovements)
 router.post('/movements/suggest', requireAuth, suggestMovement)
 router.get('/movements/pending', requireAuth, requireMovementReviewer, getPendingMovements)
 router.patch('/movements/:id/review', requireAuth, requireMovementReviewer, reviewMovement)
+router.patch('/movements/:id', requireAuth, requireMovementReviewer, updatePendingMovement)
 router.post('/movements/detect', requireAuth, detectMovements)
 
 export default router
@@ -66,6 +68,26 @@ async function reviewMovement(req: Request, res: Response) {
 
   try {
     const movement = await reviewMovementById(id, parsed.data.status)
+    res.json(movement)
+  } catch (err) {
+    const statusCode = (err as { statusCode?: number }).statusCode
+    if (statusCode) return res.status(statusCode).json({ error: err instanceof Error ? err.message : 'Error' })
+    throw err
+  }
+}
+
+async function updatePendingMovement(req: Request, res: Response) {
+  const id = req.params.id as string
+  const parsed = UpdatePendingMovementSchema.safeParse(req.body)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const field = issue?.path[0] ?? 'request'
+    const message = issue?.message ?? 'Invalid request'
+    return res.status(400).json({ error: `${field}: ${message}` })
+  }
+
+  try {
+    const movement = await updatePendingMovementById(id, parsed.data)
     res.json(movement)
   } catch (err) {
     const statusCode = (err as { statusCode?: number }).statusCode

--- a/apps/api/tests/movements.ts
+++ b/apps/api/tests/movements.ts
@@ -59,6 +59,7 @@ let pullUpMovementId = ''
 let workoutWithMovementId = ''
 let workoutWithoutMovementId = ''
 let pendingMovementId = ''
+let pendingEditMovementId = ''
 
 async function setup() {
   console.log('\n=== Setup ===')
@@ -161,11 +162,17 @@ async function setup() {
   })
   workoutWithoutMovementId = w2.id
 
-  // Pre-existing pending movement
+  // Pre-existing pending movement (used for review tests)
   const pending = await prisma.movement.create({
     data: { name: `Pending-Move-${TS}`, status: 'PENDING' },
   })
   pendingMovementId = pending.id
+
+  // Separate pending movement for edit tests (review tests don't touch this one)
+  const pendingEdit = await prisma.movement.create({
+    data: { name: `Pending-Edit-${TS}`, status: 'PENDING' },
+  })
+  pendingEditMovementId = pendingEdit.id
 
   console.log(`  gym=${gymId}  program=${programId}`)
   console.log(`  reviewer=${reviewerUserId} (${reviewerEmail})`)
@@ -303,6 +310,44 @@ async function runTests() {
       `/gyms/${gymId}/workouts?from=2026-03-01&to=2026-03-31&movementIds=${thrusterMovementId}`,
     )
     check('T15: movementIds filter no auth → 401', 401, r.status)
+  }
+
+  // ── PATCH /api/movements/:id (update pending) ────────────────────────────────
+  console.log('\n=== PATCH /api/movements/:id ===')
+
+  {
+    const r = await api('PATCH', `/movements/${pendingEditMovementId}`, reviewerToken, { name: `Renamed-Edit-${TS}` })
+    check('T16: rename PENDING movement → 200', 200, r.status)
+    check('T16: name updated', `Renamed-Edit-${TS}`, r.body.name)
+    check('T16: still PENDING', 'PENDING', r.body.status)
+  }
+
+  {
+    const r = await api('PATCH', `/movements/${pendingEditMovementId}`, reviewerToken, { parentId: thrusterMovementId })
+    check('T17: set parentId on PENDING movement → 200', 200, r.status)
+    check('T17: parentId set', thrusterMovementId, (r.body.parent as { id: string } | null)?.id)
+  }
+
+  {
+    // pendingMovementId was approved (ACTIVE) in T8 — editing it must fail
+    const r = await api('PATCH', `/movements/${pendingMovementId}`, reviewerToken, { name: `Should-Fail-${TS}` })
+    check('T18: edit ACTIVE movement → 400', 400, r.status)
+  }
+
+  {
+    // Try to rename to an already-existing movement name (thrusterMovementId's name)
+    const r = await api('PATCH', `/movements/${pendingEditMovementId}`, reviewerToken, { name: `Thruster-${TS}` })
+    check('T19: rename to duplicate name → 409', 409, r.status)
+  }
+
+  {
+    const r = await api('PATCH', `/movements/${pendingEditMovementId}`, memberToken, { name: `NonReviewer-${TS}` })
+    check('T20: edit pending as non-reviewer → 403', 403, r.status)
+  }
+
+  {
+    const r = await api('PATCH', `/movements/${pendingEditMovementId}`, undefined, { name: `NoAuth-${TS}` })
+    check('T21: edit pending no auth → 401', 401, r.status)
   }
 }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -351,6 +351,13 @@ export const api = {
     pending: (token?: string) =>
       req<PendingMovement[]>('/api/movements/pending', { token }),
 
+    update: (id: string, data: { name?: string; parentId?: string | null }, token?: string) =>
+      req<PendingMovement>(`/api/movements/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+        token,
+      }),
+
     review: (id: string, status: 'ACTIVE' | 'REJECTED', token?: string) =>
       req<Movement>(`/api/movements/${id}/review`, {
         method: 'PATCH',

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -27,6 +27,14 @@ export default function Settings() {
   const [pendingLoading, setPendingLoading] = useState(false)
   const [reviewingId, setReviewingId] = useState<string | null>(null)
 
+  // Inline edit state
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [mvEditName, setMvEditName] = useState('')
+  const [editParentId, setEditParentId] = useState<string | null>(null)
+  const [parentSearch, setParentSearch] = useState('')
+  const [parentDropdownOpen, setParentDropdownOpen] = useState(false)
+  const [savingEdit, setSavingEdit] = useState(false)
+
   useEffect(() => {
     if (!user?.isMovementReviewer) return
     setPendingLoading(true)
@@ -35,6 +43,35 @@ export default function Settings() {
       .catch(() => {})
       .finally(() => setPendingLoading(false))
   }, [user?.isMovementReviewer])
+
+  function startEditing(m: PendingMovement) {
+    setEditingId(m.id)
+    setMvEditName(m.name)
+    setEditParentId(m.parentId)
+    setParentSearch(m.parentId ? (allMovements.find((a) => a.id === m.parentId)?.name ?? '') : '')
+    setParentDropdownOpen(false)
+  }
+
+  function cancelEditing() {
+    setEditingId(null)
+    setMvEditName('')
+    setEditParentId(null)
+    setParentSearch('')
+    setParentDropdownOpen(false)
+  }
+
+  async function handleSaveEdit(id: string) {
+    setSavingEdit(true)
+    try {
+      const updated = await api.movements.update(id, { name: mvEditName, parentId: editParentId })
+      setPendingMovements((prev) => prev.map((m) => m.id === id ? updated : m))
+      cancelEditing()
+    } catch {
+      // leave form open so user can retry
+    } finally {
+      setSavingEdit(false)
+    }
+  }
 
   async function handleReview(id: string, status: 'ACTIVE' | 'REJECTED') {
     setReviewingId(id)
@@ -333,34 +370,119 @@ export default function Settings() {
 
           {pendingMovements.length > 0 && (
             <div className="space-y-2">
-              {pendingMovements.map((m) => (
-                <div key={m.id} className="flex items-center justify-between px-4 py-3 rounded-lg bg-gray-900">
-                  <div>
-                    <span className="text-sm text-white">{m.name}</span>
-                    {m.parentId && (
-                      <span className="ml-2 text-xs text-gray-500">
-                        variation of {allMovements.find((a) => a.id === m.parentId)?.name ?? 'unknown'}
-                      </span>
-                    )}
+              {pendingMovements.map((m) => {
+                const isEditing = editingId === m.id
+                const parentSearchResults = parentSearch.trim()
+                  ? allMovements
+                      .filter((a) => a.name.toLowerCase().includes(parentSearch.toLowerCase()) && a.id !== m.id)
+                      .slice(0, 8)
+                  : []
+                const selectedParentName = editParentId ? allMovements.find((a) => a.id === editParentId)?.name : null
+
+                if (isEditing) {
+                  return (
+                    <div key={m.id} className="px-4 py-3 rounded-lg bg-gray-900 space-y-3">
+                      <div>
+                        <label className="block text-xs text-gray-400 mb-1">Name</label>
+                        <input
+                          className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white"
+                          value={mvEditName}
+                          onChange={(e) => setMvEditName(e.target.value)}
+                        />
+                      </div>
+                      <div className="relative">
+                        <label className="block text-xs text-gray-400 mb-1">Parent movement (optional)</label>
+                        {selectedParentName ? (
+                          <div className="flex items-center gap-2">
+                            <span className="px-2 py-0.5 rounded-full bg-indigo-600/30 text-indigo-300 text-xs">{selectedParentName}</span>
+                            <button
+                              type="button"
+                              onClick={() => { setEditParentId(null); setParentSearch('') }}
+                              className="text-xs text-gray-500 hover:text-gray-300"
+                            >
+                              ×
+                            </button>
+                          </div>
+                        ) : (
+                          <input
+                            className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white"
+                            placeholder="Search movements…"
+                            value={parentSearch}
+                            onChange={(e) => { setParentSearch(e.target.value); setParentDropdownOpen(true) }}
+                            onFocus={() => setParentDropdownOpen(true)}
+                            onBlur={() => setTimeout(() => setParentDropdownOpen(false), 150)}
+                          />
+                        )}
+                        {parentDropdownOpen && parentSearchResults.length > 0 && (
+                          <ul className="absolute z-10 w-full mt-1 bg-gray-800 border border-gray-700 rounded shadow-lg max-h-48 overflow-y-auto">
+                            {parentSearchResults.map((a) => (
+                              <li
+                                key={a.id}
+                                onMouseDown={() => { setEditParentId(a.id); setParentSearch(a.name); setParentDropdownOpen(false) }}
+                                className="px-3 py-2 text-sm text-white hover:bg-gray-700 cursor-pointer"
+                              >
+                                {a.name}
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
+                      <div className="flex gap-2 pt-1">
+                        <button
+                          onClick={() => handleSaveEdit(m.id)}
+                          disabled={savingEdit || !mvEditName.trim()}
+                          className="px-3 py-1 text-xs rounded bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 transition-colors"
+                        >
+                          {savingEdit ? 'Saving…' : 'Save'}
+                        </button>
+                        <button
+                          onClick={cancelEditing}
+                          disabled={savingEdit}
+                          className="px-3 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 text-gray-300 disabled:opacity-50 transition-colors"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  )
+                }
+
+                return (
+                  <div key={m.id} className="flex items-center justify-between px-4 py-3 rounded-lg bg-gray-900">
+                    <div>
+                      <span className="text-sm text-white">{m.name}</span>
+                      {m.parentId && (
+                        <span className="ml-2 text-xs text-gray-500">
+                          variation of {allMovements.find((a) => a.id === m.parentId)?.name ?? 'unknown'}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => startEditing(m)}
+                        disabled={reviewingId === m.id}
+                        className="px-3 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 text-gray-300 disabled:opacity-50 transition-colors"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => handleReview(m.id, 'ACTIVE')}
+                        disabled={reviewingId === m.id}
+                        className="px-3 py-1 text-xs rounded bg-green-700 hover:bg-green-600 text-white disabled:opacity-50 transition-colors"
+                      >
+                        Approve
+                      </button>
+                      <button
+                        onClick={() => handleReview(m.id, 'REJECTED')}
+                        disabled={reviewingId === m.id}
+                        className="px-3 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 text-gray-300 disabled:opacity-50 transition-colors"
+                      >
+                        Reject
+                      </button>
+                    </div>
                   </div>
-                  <div className="flex gap-2">
-                    <button
-                      onClick={() => handleReview(m.id, 'ACTIVE')}
-                      disabled={reviewingId === m.id}
-                      className="px-3 py-1 text-xs rounded bg-green-700 hover:bg-green-600 text-white disabled:opacity-50 transition-colors"
-                    >
-                      Approve
-                    </button>
-                    <button
-                      onClick={() => handleReview(m.id, 'REJECTED')}
-                      disabled={reviewingId === m.id}
-                      className="px-3 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 text-gray-300 disabled:opacity-50 transition-colors"
-                    >
-                      Reject
-                    </button>
-                  </div>
-                </div>
-              ))}
+                )
+              })}
             </div>
           )}
         </section>

--- a/apps/web/tests/pending-movement-review.spec.ts
+++ b/apps/web/tests/pending-movement-review.spec.ts
@@ -1,0 +1,248 @@
+/**
+ * Playwright E2E tests for PR #72 — Pending movement inline edit.
+ *
+ * Covers the manual verification checklist from the PR:
+ *   T1: Rename a pending movement → save → row shows updated name
+ *   T2: Set parent movement via typeahead → save → row shows "variation of X" tag
+ *   T3: Clear parent → save → "variation of" tag disappears
+ *   T4: Cancel edit → row reverts to its current state (no DB change)
+ *   T5: Approve a pending movement → row disappears from the list
+ *   T6: Reject a pending movement → row disappears from the list
+ *
+ * The reviewer is identified by MOVEMENT_REVIEWER_EMAIL in .env. That user
+ * likely authenticates via Google OAuth and has no password. The test temporarily
+ * sets a passwordHash so the normal login form works, then restores null in afterAll.
+ *
+ * Requires: turbo dev running (API on :3000, web on :5173)
+ * Run: npm run test:e2e --workspace=@berntracker/web
+ */
+
+import { test, expect, type Page, type Cookie } from '@playwright/test'
+import { createRequire } from 'module'
+import bcrypt from 'bcryptjs'
+
+const _require = createRequire(import.meta.url)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const { PrismaClient } = _require('@prisma/client') as any
+const prisma = new PrismaClient()
+
+// ─── Shared state ─────────────────────────────────────────────────────────────
+
+const TS = Date.now()
+const REVIEWER_TEST_PASSWORD = 'TestPass-E2E-1!'
+
+let reviewerUserId = ''
+let originalPasswordHash: string | null = null
+let gymId = ''
+
+let parentMovementName = ''
+
+// Separate pending movements so serial tests don't clobber each other
+let pendingEditId = ''           // T1–T4
+const PENDING_EDIT_ORIGINAL = `Pending-Edit-${TS}`
+
+let pendingApproveId = ''        // T5
+let pendingRejectId = ''         // T6
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// Saved after the first login so subsequent tests can skip re-authenticating.
+// Each test's fresh browser context starts with no cookies; injecting saved
+// cookies lets the auth context call /api/auth/refresh with a valid token
+// instead of requiring a full re-login (which hangs when run back-to-back).
+let savedCookies: Cookie[] = []
+
+async function goToSettings(page: Page) {
+  // addInitScript runs before every full page load on this page object, ensuring
+  // gymId is in localStorage before React's GymContext initializes.
+  await page.addInitScript((id) => localStorage.setItem('gymId', id), gymId)
+
+  if (savedCookies.length === 0) {
+    // First test: do a full password login.
+    const reviewerEmail = process.env.MOVEMENT_REVIEWER_EMAIL!
+    await page.goto('/login')
+    await page.waitForSelector('#email')
+    await page.fill('#email', reviewerEmail)
+    await page.fill('#password', REVIEWER_TEST_PASSWORD)
+    await page.click('button[type="submit"]')
+    await page.waitForURL('**/dashboard')
+  } else {
+    // Subsequent tests: inject the cookies saved after the previous test's
+    // settings page loaded.  The refreshToken cookie is the current valid
+    // token — the auth context will rotate it on this page load.
+    await page.context().addCookies(savedCookies)
+  }
+
+  await page.goto('/settings')
+  await page.waitForSelector('h2:has-text("Pending Movements")')
+  // Save cookies AFTER the auth context has refreshed (settings visible = auth ok).
+  // The new refreshToken here is valid for the next test.
+  savedCookies = await page.context().cookies()
+}
+
+/**
+ * Finds the pending movement row by its visible name text (before editing opens).
+ * The name text is only visible when the row is in display mode — in edit mode
+ * the name lives in an input value, not as visible text.
+ */
+function displayRow(page: Page, name: string) {
+  return page.locator('div.bg-gray-900').filter({ hasText: name }).filter({
+    has: page.getByRole('button', { name: 'Edit' }),
+  })
+}
+
+/**
+ * Returns the row currently open in edit mode (identified by the Save button).
+ * At most one row is in edit mode at a time.
+ */
+function editingRow(page: Page) {
+  return page.locator('div.bg-gray-900').filter({
+    has: page.getByRole('button', { name: 'Save' }),
+  })
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('Pending movement inline edit E2E (#72)', () => {
+  test.beforeAll(async () => {
+    const reviewerEmail = process.env.MOVEMENT_REVIEWER_EMAIL
+    if (!reviewerEmail) throw new Error('MOVEMENT_REVIEWER_EMAIL must be set in .env')
+
+    // Find the reviewer user and save their current passwordHash
+    const reviewer = await prisma.user.findUnique({ where: { email: reviewerEmail } })
+    if (!reviewer) throw new Error(`Reviewer user not found: ${reviewerEmail}`)
+    reviewerUserId = reviewer.id
+    originalPasswordHash = reviewer.passwordHash
+
+    // Temporarily enable password login for the test
+    const testHash = await bcrypt.hash(REVIEWER_TEST_PASSWORD, 10)
+    await prisma.user.update({ where: { id: reviewerUserId }, data: { passwordHash: testHash } })
+
+    // Create a test gym and add the reviewer as OWNER
+    const gym = await prisma.gym.create({
+      data: { name: `E2E Review Gym ${TS}`, slug: `e2e-review-gym-${TS}`, timezone: 'UTC' },
+    })
+    gymId = gym.id
+    await prisma.userGym.create({ data: { userId: reviewerUserId, gymId, role: 'OWNER' } })
+
+    // Active movement used as the parent in T2/T3
+    const parent = await prisma.movement.create({
+      data: { name: `Active-Parent-${TS}`, status: 'ACTIVE' },
+    })
+    parentMovementName = parent.name
+
+    // Three pending movements, one per test group
+    const edit = await prisma.movement.create({
+      data: { name: PENDING_EDIT_ORIGINAL, status: 'PENDING' },
+    })
+    pendingEditId = edit.id
+
+    const approve = await prisma.movement.create({
+      data: { name: `Pending-Approve-${TS}`, status: 'PENDING' },
+    })
+    pendingApproveId = approve.id
+
+    const reject = await prisma.movement.create({
+      data: { name: `Pending-Reject-${TS}`, status: 'PENDING' },
+    })
+    pendingRejectId = reject.id
+
+    // Suppress unused-var warnings — IDs kept for documentation
+    void pendingEditId
+    void pendingApproveId
+    void pendingRejectId
+  })
+
+  test.afterAll(async () => {
+    // Restore the reviewer's original passwordHash (null for Google OAuth users)
+    await prisma.user.update({
+      where: { id: reviewerUserId },
+      data: { passwordHash: originalPasswordHash },
+    }).catch(() => {})
+
+    // Clean up movements created for this test run
+    await prisma.movement.deleteMany({
+      where: { name: { endsWith: `-${TS}` } },
+    }).catch(() => {})
+
+    await prisma.userGym.deleteMany({ where: { gymId } }).catch(() => {})
+    await prisma.gym.delete({ where: { id: gymId } }).catch(() => {})
+
+    await prisma.$disconnect()
+  })
+
+  test('T1: rename a pending movement — row shows updated name after save', async ({ page }) => {
+    await goToSettings(page)
+
+    await displayRow(page, PENDING_EDIT_ORIGINAL).getByRole('button', { name: 'Edit' }).click()
+
+    const form = editingRow(page)
+    await form.locator('input').first().fill(`Renamed-E2E-${TS}`)
+    await form.getByRole('button', { name: 'Save' }).click()
+
+    await expect(page.locator(`text=Renamed-E2E-${TS}`)).toBeVisible()
+    await expect(page.locator(`text=${PENDING_EDIT_ORIGINAL}`)).not.toBeVisible()
+  })
+
+  test('T2: set parent movement via typeahead — row shows "variation of" tag', async ({ page }) => {
+    await goToSettings(page)
+
+    // After T1 the movement was renamed
+    await displayRow(page, `Renamed-E2E-${TS}`).getByRole('button', { name: 'Edit' }).click()
+
+    const form = editingRow(page)
+    await form.locator('input[placeholder="Search movements…"]').fill(parentMovementName.slice(0, 8))
+    await page.locator(`li:has-text("${parentMovementName}")`).click()
+    await form.getByRole('button', { name: 'Save' }).click()
+
+    await expect(page.locator(`text=variation of ${parentMovementName}`)).toBeVisible()
+  })
+
+  test('T3: clear parent — "variation of" tag disappears after save', async ({ page }) => {
+    await goToSettings(page)
+
+    await displayRow(page, `Renamed-E2E-${TS}`).getByRole('button', { name: 'Edit' }).click()
+
+    const form = editingRow(page)
+    // The parent chip shows a × button to clear it
+    await form.locator('button', { hasText: '×' }).click()
+    await form.getByRole('button', { name: 'Save' }).click()
+
+    await expect(page.locator(`text=variation of`)).not.toBeVisible()
+  })
+
+  test('T4: cancel edit — row reverts to its current state unchanged', async ({ page }) => {
+    await goToSettings(page)
+
+    await displayRow(page, `Renamed-E2E-${TS}`).getByRole('button', { name: 'Edit' }).click()
+
+    const form = editingRow(page)
+    await form.locator('input').first().fill('Should-Not-Persist')
+    await form.getByRole('button', { name: 'Cancel' }).click()
+
+    await expect(page.locator(`text=Renamed-E2E-${TS}`)).toBeVisible()
+    await expect(page.locator('text=Should-Not-Persist')).not.toBeVisible()
+  })
+
+  test('T5: approve a pending movement — row disappears from the list', async ({ page }) => {
+    await goToSettings(page)
+
+    const row = displayRow(page, `Pending-Approve-${TS}`)
+    await expect(row).toBeVisible()
+    await row.getByRole('button', { name: 'Approve' }).click()
+
+    await expect(page.locator(`text=Pending-Approve-${TS}`)).not.toBeVisible()
+  })
+
+  test('T6: reject a pending movement — row disappears from the list', async ({ page }) => {
+    await goToSettings(page)
+
+    const row = displayRow(page, `Pending-Reject-${TS}`)
+    await expect(row).toBeVisible()
+    await row.getByRole('button', { name: 'Reject' }).click()
+
+    await expect(page.locator(`text=Pending-Reject-${TS}`)).not.toBeVisible()
+  })
+})

--- a/packages/types/src/movement.ts
+++ b/packages/types/src/movement.ts
@@ -20,7 +20,13 @@ export const ReviewMovementSchema = z.object({
   status: z.enum(['ACTIVE', 'REJECTED']),
 })
 
+export const UpdatePendingMovementSchema = z.object({
+  name: z.string().min(1).optional(),
+  parentId: z.string().nullable().optional(),
+})
+
 export type MovementStatus = z.infer<typeof MovementStatusSchema>
 export type Movement = z.infer<typeof MovementSchema>
 export type SuggestMovementInput = z.infer<typeof SuggestMovementSchema>
 export type ReviewMovementInput = z.infer<typeof ReviewMovementSchema>
+export type UpdatePendingMovementInput = z.infer<typeof UpdatePendingMovementSchema>


### PR DESCRIPTION
## Summary

- Adds \`PATCH /api/movements/:id\` (reviewer-only) to update \`name\` and/or \`parentId\` of PENDING movements
- Settings page gains an **Edit** button on each pending movement row that expands an inline form
- Inline form: name text input (pre-filled) + searchable parent-movement typeahead (single-select, chip display once selected)
- On save, the row updates in place optimistically; on error the form stays open for retry
- Edit button is disabled while a review action (Approve/Reject) is in progress for that row

Closes #66

## Tests

**API integration** (\`apps/api/tests/movements.ts\`, T16–T21):
- T16: rename a PENDING movement → 200, name updated, still PENDING
- T17: set parentId on a PENDING movement → 200, parent relationship returned
- T18: edit an ACTIVE movement → 400 "Only PENDING movements can be edited"
- T19: rename to a name that already exists → 409 conflict
- T20: non-reviewer attempts edit → 403
- T21: unauthenticated edit → 401

**Playwright E2E** (\`apps/web/tests/pending-movement-review.spec.ts\`):
- T1: rename a pending movement → save → row shows updated name
- T2: set parent movement via typeahead → save → row shows "variation of X" tag
- T3: clear parent → save → "variation of" tag disappears
- T4: cancel edit → row reverts to its original state (no change)
- T5: approve a pending movement → row disappears from the list
- T6: reject a pending movement → row disappears from the list

**Not automated / manual verification needed:**
- None