### PR TITLE
feat(infra): Dockerize API + web for Railway QA deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+**/node_modules
+**/dist
+.env
+.env.*
+!.env.example
+apps/mobile
+.git
+.claude
+.turbo
+**/.turbo
+apps/web/test-results
+apps/web/playwright-report

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 node_modules
 **/node_modules
 **/dist
+**/*.tsbuildinfo
 .env
 .env.*
 !.env.example

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ PORT=3000
 JWT_SECRET="change-me-in-production"
 JWT_REFRESH_SECRET="also-change-me-in-production"
 NODE_ENV="development"
+# Comma-separated list of origins the API will accept CORS requests from.
+# Docker compose overrides this to include http://local.berntracker.com.
+# In Railway QA / prod, set to the deployed web's origin (e.g. https://berntracker-qa-web.up.railway.app).
+ALLOWED_ORIGINS="http://localhost:5173"
 
 # ─── Auth (Slice 2) ────────────────────────────────────────────────────────────
 # Google OAuth — server-side (web client)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ When an engineer asks for help setting up the project, use the README Getting St
 - **Starting Docker Desktop** — must be opened as a GUI app before any `docker` commands work; if the engineer sees `dial unix /var/run/docker.sock: no such file or directory`, Docker Desktop is not running
 - **Running `docker run --name berntracker-db ...`** — creates the Postgres container; only needed once. On subsequent sessions: `docker start berntracker-db`
 - **Copying `.env.example` → `.env`** — file contains secrets and must be created manually
-- **Adding local DNS entries** — append to `/etc/hosts` so browser requests to the containerised stack resolve to the local Traefik proxy. Requires `sudo`:
+- **Adding local DNS entries** — append to `/etc/hosts` so browser requests to the containerised stack resolve to the local nginx proxy. Requires `sudo`:
   ```bash
   echo "127.0.0.1 local.berntracker.com db-studio.local.berntracker.com" | sudo tee -a /etc/hosts
   ```
@@ -72,7 +72,6 @@ When an engineer asks for help setting up the project, use the README Getting St
   - Web: `http://local.berntracker.com`
   - API: `http://local.berntracker.com/api/*` (same origin as web, no CORS)
   - Prisma Studio: `http://db-studio.local.berntracker.com`
-  - Traefik dashboard: `http://localhost:8080`
 - Installing Expo Go on a physical device
 
 ### Common setup errors and fixes
@@ -85,7 +84,7 @@ When an engineer asks for help setting up the project, use the README Getting St
 | `command not found: turbo` | Dependencies not installed | `npm install` from repo root |
 | `ConfigError: The expected package.json path: .../apps/mobile/package.json does not exist` | `expo start` run from repo root, or `npm install` not run after adding mobile workspace | Run from `apps/mobile`: `cd apps/mobile && npx expo start`. If new workspace was added, run `npm install` from root first to register the symlink. |
 | `DNS_PROBE_FINISHED_NXDOMAIN` / `This site can't be reached` for `local.berntracker.com` | `/etc/hosts` entries missing | Add the `127.0.0.1 local.berntracker.com db-studio.local.berntracker.com` entry to `/etc/hosts` (see manual steps above) |
-| `Bind for 0.0.0.0:80 failed: port is already allocated` | Port 80 in use by another process | Stop the conflicting process, or change Traefik's `ports:` in `docker-compose.yml` from `80:80` to `8080:80` (URLs become `local.berntracker.com:8080`) |
+| `Bind for 0.0.0.0:80 failed: port is already allocated` | Port 80 in use by another process | Stop the conflicting process, or change the proxy `ports:` in `docker-compose.yml` from `80:80` to `8080:80` (URLs become `local.berntracker.com:8080`) |
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,15 @@ When an engineer asks for help setting up the project, use the README Getting St
 - **Starting Docker Desktop** — must be opened as a GUI app before any `docker` commands work; if the engineer sees `dial unix /var/run/docker.sock: no such file or directory`, Docker Desktop is not running
 - **Running `docker run --name berntracker-db ...`** — creates the Postgres container; only needed once. On subsequent sessions: `docker start berntracker-db`
 - **Copying `.env.example` → `.env`** — file contains secrets and must be created manually
+- **Adding local DNS entries** — append to `/etc/hosts` so browser requests to the containerised stack resolve to the local Traefik proxy. Requires `sudo`:
+  ```bash
+  echo "127.0.0.1 local.berntracker.com db-studio.local.berntracker.com" | sudo tee -a /etc/hosts
+  ```
+  Once set, `docker compose up --build` exposes:
+  - Web: `http://local.berntracker.com`
+  - API: `http://local.berntracker.com/api/*` (same origin as web, no CORS)
+  - Prisma Studio: `http://db-studio.local.berntracker.com`
+  - Traefik dashboard: `http://localhost:8080`
 - Installing Expo Go on a physical device
 
 ### Common setup errors and fixes
@@ -75,6 +84,8 @@ When an engineer asks for help setting up the project, use the README Getting St
 | `Environment variable not found: DATABASE_URL` | `.env` file missing | `cp .env.example .env` from repo root |
 | `command not found: turbo` | Dependencies not installed | `npm install` from repo root |
 | `ConfigError: The expected package.json path: .../apps/mobile/package.json does not exist` | `expo start` run from repo root, or `npm install` not run after adding mobile workspace | Run from `apps/mobile`: `cd apps/mobile && npx expo start`. If new workspace was added, run `npm install` from root first to register the symlink. |
+| `DNS_PROBE_FINISHED_NXDOMAIN` / `This site can't be reached` for `local.berntracker.com` | `/etc/hosts` entries missing | Add the `127.0.0.1 local.berntracker.com db-studio.local.berntracker.com` entry to `/etc/hosts` (see manual steps above) |
+| `Bind for 0.0.0.0:80 failed: port is already allocated` | Port 80 in use by another process | Stop the conflicting process, or change Traefik's `ports:` in `docker-compose.yml` from `80:80` to `8080:80` (URLs become `local.berntracker.com:8080`) |
 
 ## Architecture
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: build ──────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+COPY package.json package-lock.json turbo.json ./
+COPY packages/db/package.json ./packages/db/
+COPY packages/types/package.json ./packages/types/
+COPY apps/api/package.json ./apps/api/
+
+RUN npm ci
+
+COPY packages/ ./packages/
+COPY apps/api/ ./apps/api/
+
+RUN npx prisma generate --schema=packages/db/prisma/schema.prisma
+RUN npx turbo build --filter=@berntracker/api
+
+# ── Stage 2: runtime ─────────────────────────────────────────────────────────
+FROM node:22-alpine AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Full node_modules is copied (not `npm ci --omit=dev`) because `prisma` is a
+# devDependency of packages/db and is needed at container start for `migrate deploy`.
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/packages ./packages
+COPY --from=builder /app/apps/api/package.json ./apps/api/
+COPY --from=builder /app/apps/api/dist ./apps/api/dist
+
+EXPOSE 3000
+
+CMD ["sh", "-c", "npx prisma migrate deploy --schema=packages/db/prisma/schema.prisma && node apps/api/dist/index.js"]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -4,7 +4,7 @@
 FROM node:22-alpine AS builder
 WORKDIR /app
 
-COPY package.json package-lock.json turbo.json ./
+COPY package.json package-lock.json turbo.json tsconfig.json ./
 COPY packages/db/package.json ./packages/db/
 COPY packages/types/package.json ./packages/types/
 COPY apps/api/package.json ./apps/api/

--- a/apps/api/nodemon.json
+++ b/apps/api/nodemon.json
@@ -9,5 +9,8 @@
   "ignore": [
     "dist",
     "node_modules"
-  ]
+  ],
+  "env": {
+    "NODE_OPTIONS": "--conditions=source"
+  }
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
     "dev": "../../node_modules/.bin/nodemon",
     "build": "tsc",
     "start": "node --env-file=../../.env dist/index.js",
-    "test": "npx dotenv-cli -e ../../.env -- sh -c 'for f in tests/*.ts; do npx tsx \"$f\" || exit 1; done'"
+    "test": "NODE_OPTIONS='--conditions=source' npx dotenv-cli -e ../../.env -- sh -c 'for f in tests/*.ts; do npx tsx \"$f\" || exit 1; done'"
   },
   "dependencies": {
     "@berntracker/db": "*",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -31,7 +31,11 @@ process.on('unhandledRejection', (reason) => {
 const app = express()
 const port = process.env.PORT ?? 3000
 
-app.use(cors({ origin: 'http://localhost:5173', credentials: true }))
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:5173')
+  .split(',')
+  .map((o) => o.trim())
+  .filter(Boolean)
+app.use(cors({ origin: allowedOrigins, credentials: true }))
 app.use(express.json())
 app.use(cookieParser())
 app.use(requestLogger)

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 ARG VITE_API_URL
 ENV VITE_API_URL=$VITE_API_URL
 
-COPY package.json package-lock.json turbo.json ./
+COPY package.json package-lock.json turbo.json tsconfig.json ./
 COPY packages/db/package.json ./packages/db/
 COPY packages/types/package.json ./packages/types/
 COPY apps/web/package.json ./apps/web/

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: build ──────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+ARG VITE_API_URL
+ENV VITE_API_URL=$VITE_API_URL
+
+COPY package.json package-lock.json turbo.json ./
+COPY packages/db/package.json ./packages/db/
+COPY packages/types/package.json ./packages/types/
+COPY apps/web/package.json ./apps/web/
+
+RUN npm ci
+
+COPY packages/ ./packages/
+COPY apps/web/ ./apps/web/
+
+RUN npx turbo build --filter=@berntracker/web
+
+# ── Stage 2: serve ───────────────────────────────────────────────────────────
+FROM nginx:alpine AS runtime
+
+COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,12 +17,13 @@ import Feed from './pages/Feed.tsx'
 import WodDetail from './pages/WodDetail.tsx'
 import History from './pages/History.tsx'
 
-export function PageErrorFallback({ error, resetErrorBoundary }: { error: Error; resetErrorBoundary: () => void }) {
+export function PageErrorFallback({ error, resetErrorBoundary }: { error: unknown; resetErrorBoundary: () => void }) {
   const navigate = useNavigate()
+  const message = error instanceof Error ? error.message : String(error)
   return (
     <div className="flex flex-col items-center justify-center h-full gap-4 text-center px-4">
       <p className="text-gray-400 text-sm">Something went wrong on this page.</p>
-      <p className="text-gray-600 text-xs font-mono">{error.message}</p>
+      <p className="text-gray-600 text-xs font-mono">{message}</p>
       <div className="flex gap-3">
         <button
           onClick={resetErrorBoundary}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: berntracker-db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: berntracker
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    container_name: berntracker-api
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/berntracker
+      NODE_ENV: development
+    ports:
+      - "3000:3000"
+    depends_on:
+      - postgres
+
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+      args:
+        VITE_API_URL: http://localhost:3000
+    container_name: berntracker-web
+    ports:
+      - "5173:80"
+    depends_on:
+      - api
+
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,18 @@
 services:
+  traefik:
+    image: traefik:v3.2
+    container_name: berntracker-traefik
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+      - --api.insecure=true
+    ports:
+      - "80:80"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
   postgres:
     image: postgres:16
     container_name: berntracker-db
@@ -12,6 +26,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
 
   api:
+    image: berntracker-api:local
     build:
       context: .
       dockerfile: apps/api/Dockerfile
@@ -20,22 +35,43 @@ services:
     environment:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/berntracker
       NODE_ENV: development
-    ports:
-      - "3000:3000"
     depends_on:
       - postgres
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.api.rule=Host(`local.berntracker.com`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.api.entrypoints=web"
+      - "traefik.http.services.api.loadbalancer.server.port=3000"
 
   web:
     build:
       context: .
       dockerfile: apps/web/Dockerfile
-      args:
-        VITE_API_URL: http://localhost:3000
     container_name: berntracker-web
-    ports:
-      - "5173:80"
     depends_on:
       - api
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.web.rule=Host(`local.berntracker.com`)"
+      - "traefik.http.routers.web.entrypoints=web"
+      - "traefik.http.services.web.loadbalancer.server.port=80"
+
+  studio:
+    image: berntracker-api:local
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    container_name: berntracker-studio
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/berntracker
+    command: sh -c "npx prisma studio --schema=packages/db/prisma/schema.prisma --port 5555 --browser none --hostname 0.0.0.0"
+    depends_on:
+      - postgres
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.studio.rule=Host(`db-studio.local.berntracker.com`)"
+      - "traefik.http.routers.studio.entrypoints=web"
+      - "traefik.http.services.studio.loadbalancer.server.port=5555"
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,15 @@
 services:
-  traefik:
-    image: traefik:v3.2
-    container_name: berntracker-traefik
-    command:
-      - --providers.docker=true
-      - --providers.docker.exposedbydefault=false
-      - --entrypoints.web.address=:80
-      - --api.insecure=true
+  proxy:
+    image: nginx:alpine
+    container_name: berntracker-proxy
     ports:
       - "80:80"
-      - "8080:8080"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./nginx-proxy.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - api
+      - web
+      - studio
 
   postgres:
     image: postgres:16
@@ -37,11 +35,6 @@ services:
       NODE_ENV: development
     depends_on:
       - postgres
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.api.rule=Host(`local.berntracker.com`) && PathPrefix(`/api`)"
-      - "traefik.http.routers.api.entrypoints=web"
-      - "traefik.http.services.api.loadbalancer.server.port=3000"
 
   web:
     build:
@@ -50,28 +43,16 @@ services:
     container_name: berntracker-web
     depends_on:
       - api
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.web.rule=Host(`local.berntracker.com`)"
-      - "traefik.http.routers.web.entrypoints=web"
-      - "traefik.http.services.web.loadbalancer.server.port=80"
 
   studio:
     image: berntracker-api:local
-    build:
-      context: .
-      dockerfile: apps/api/Dockerfile
     container_name: berntracker-studio
     environment:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/berntracker
     command: sh -c "npx prisma studio --schema=packages/db/prisma/schema.prisma --port 5555 --browser none --hostname 0.0.0.0"
     depends_on:
       - postgres
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.studio.rule=Host(`db-studio.local.berntracker.com`)"
-      - "traefik.http.routers.studio.entrypoints=web"
-      - "traefik.http.services.studio.loadbalancer.server.port=5555"
+      - api
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     environment:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/berntracker
       NODE_ENV: development
+      ALLOWED_ORIGINS: http://local.berntracker.com,http://localhost:5173
     depends_on:
       - postgres
 

--- a/nginx-proxy.conf
+++ b/nginx-proxy.conf
@@ -1,0 +1,40 @@
+resolver 127.0.0.11 valid=10s;
+
+server {
+    listen 80;
+    server_name local.berntracker.com;
+
+    location /api/ {
+        set $backend "api:3000";
+        proxy_pass http://$backend$request_uri;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        set $backend "web:80";
+        proxy_pass http://$backend$request_uri;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+server {
+    listen 80;
+    server_name db-studio.local.berntracker.com;
+
+    location / {
+        set $backend "studio:5555";
+        proxy_pass http://$backend$request_uri;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "berntracker",
   "private": true,
+  "packageManager": "npm@10.9.0",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -2,8 +2,15 @@
   "name": "@berntracker/db",
   "version": "0.0.1",
   "private": true,
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
   "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "db:generate": "dotenv -e ../../.env -- prisma generate",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,8 +2,15 @@
   "name": "@berntracker/types",
   "version": "0.0.1",
   "private": true,
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
   "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit"

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,8 @@
+[build]
+dockerfilePath = "apps/api/Dockerfile"
+buildCommand = ""
+
+[deploy]
+startCommand = ""
+healthcheckPath = "/api/health"
+healthcheckTimeout = 30


### PR DESCRIPTION
## Summary

Adds Docker configuration so the API and web apps can run locally via `docker compose up --build` and deploy to Railway for the QA environment. Local development uses an nginx reverse proxy and custom hostnames that mirror the eventual production shape.

### Local URLs (after `/etc/hosts` setup)
- Web: `http://local.berntracker.com`
- API: `http://local.berntracker.com/api/*`  (same origin as web → no CORS)
- Prisma Studio: `http://db-studio.local.berntracker.com`  (separate subdomain — Studio doesn't support a path prefix)

### New / modified files
- `apps/api/Dockerfile` — multi-stage Node build; CMD chains `prisma migrate deploy` before `node dist/index.js` (one startup path for local and Railway).
- `apps/web/Dockerfile` + `apps/web/nginx.conf` — Vite bundle served by nginx with SPA fallback for React Router.
- `docker-compose.yml` — orchestrates nginx proxy + postgres + api + web + Prisma Studio. Studio reuses the API image (Node + Prisma CLI + schema already baked in).
- `nginx-proxy.conf` — static reverse-proxy config. Uses Docker's embedded DNS resolver with variable-based `proxy_pass` for reliable startup.
- `railway.toml` — Railway reads `apps/api/Dockerfile`; healthcheck on `/api/health`.
- `.dockerignore` — trims build context (excludes `.git`, `.claude`, `node_modules`, turbo cache, tsbuildinfo, Playwright artifacts).
- `CLAUDE.md` — documents `/etc/hosts` setup and adds setup-error rows.
- `apps/api/src/index.ts` — CORS `ALLOWED_ORIGINS` is now env-driven so QA / prod can add their deployed origins without a code change.

### Supporting production-mode fixes
`node apps/api/dist/index.js` (the production runtime path) previously couldn't resolve workspace packages because their `main` pointed at unbuilt `.ts` source:
- `packages/db`, `packages/types`: `main` → `dist/index.js`, plus an `exports` field with a `source` condition so dev still resolves TS source.
- `apps/api/nodemon.json` + test script: `NODE_OPTIONS=--conditions=source` so `npm run dev` and `npm run test` continue to hot-load TypeScript via tsx.
- Root `package.json`: added `"packageManager": "npm@10.9.0"` required by Turbo 2.x.
- `apps/web/src/App.tsx`: fixed pre-existing `react-error-boundary` type mismatch (FallbackProps.error is `unknown` in v6).
- `apps/web/vite.config.ts`: `import { defineConfig } from 'vitest/config'` so the `test` block is typed.

### Reverse-proxy choice (nginx, not Traefik)
Initial implementation used Traefik with Docker-label auto-discovery, but Traefik's Docker API client defaults to v1.24 and Docker Engine 29.x requires ≥ v1.44. Pinning `DOCKER_API_VERSION` and adding a socket-proxy sidecar both failed to override the negotiation. Pivoted to nginx: static config, no Docker API dependency, deterministic. One less moving part.

### Deviations from the issue #63 spec
- API runtime stage copies the full `node_modules` from the build stage (not `npm ci --omit=dev`) because `prisma` is a devDep of `packages/db` but is needed at container start for `migrate deploy`.
- API build uses `npx turbo build --filter=@berntracker/api` so `packages/db` and `packages/types` are compiled to `dist/` before the API build (required now that `main` points at dist).
- Compose uses nginx as a reverse proxy with static config; no host port bindings on api/web (db still exposes 5432 for GUI clients).

## Tests

No automated tests added — this PR is infrastructure configuration with no application code paths to unit-test.

**Not automated / manual verification needed:**
- [ ] Append `/etc/hosts` entries:  `echo "127.0.0.1 local.berntracker.com db-studio.local.berntracker.com" | sudo tee -a /etc/hosts`
- [ ] `docker compose up --build` starts nginx proxy + postgres + api + web + studio with no errors
- [ ] `curl http://local.berntracker.com/api/health` returns 200
- [ ] Web admin loads at `http://local.berntracker.com` and successfully calls the API (same-origin)
- [ ] Prisma Studio loads at `http://db-studio.local.berntracker.com`
- [ ] CORS: request from `http://localhost:5173` or `http://local.berntracker.com` gets `Access-Control-Allow-Origin` echoed; requests from other origins do not
- [ ] `docker compose down -v && docker compose up --build` (full reset) runs Prisma migrations and the API starts cleanly
- [ ] Existing `npm run dev` still hot-reloads when editing `packages/db/src` or `packages/types/src` (tsx + `--conditions=source`)
- [ ] Existing `npm run test --workspace=@berntracker/api` still passes
- [ ] Railway deploys the API via `apps/api/Dockerfile` and `railway.toml` — healthcheck passes at `/api/health`
- [ ] No secrets or `.env` files are present in any image layer (`docker history` audit)

### Known local-dev caveats
- HTTP only — HTTPS would need a local CA (mkcert) and per-subdomain certs; out of scope here.
- Google OAuth redirect URIs that were configured for `localhost:5173` will need `http://local.berntracker.com` added in Google Console if you want to test OAuth against the custom hostname.
- Port 80 must be free on the host; if taken, flip the proxy's `80:80` to `8080:80` in `docker-compose.yml` (URLs become `local.berntracker.com:8080`).

Closes #63
Part of #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)