### PR TITLE
fix(auth): env-aware cookie options for cross-origin Railway deploys

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -18,10 +18,14 @@ const FRONTEND_URL = process.env.FRONTEND_URL ?? 'http://localhost:5173'
 
 const router = Router()
 
+// Cross-origin setup on hosted environments (Railway gives each service its own
+// subdomain — see #77). SameSite=None is required for the web to receive the
+// cookie after the cross-site auth call, and browsers reject None without Secure.
+const IS_LOCAL_DEV = process.env.NODE_ENV === 'development'
 const COOKIE_OPTIONS = {
   httpOnly: true,
-  secure: process.env.NODE_ENV === 'production',
-  sameSite: 'lax' as const,
+  secure: !IS_LOCAL_DEV,
+  sameSite: (IS_LOCAL_DEV ? 'lax' : 'none') as 'lax' | 'none',
   maxAge: 7 * 24 * 60 * 60 * 1000,
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/berntracker
       NODE_ENV: development
       ALLOWED_ORIGINS: http://local.berntracker.com,http://localhost:5173
+      FRONTEND_URL: http://local.berntracker.com
     depends_on:
       - postgres
 


### PR DESCRIPTION
## Summary

Railway gives each service its own subdomain (web on `berntracker-web-qa.up.railway.app`, API on `berntracker-qa.up.railway.app`), so the auth cookie flow is now cross-origin. `SameSite=Lax` blocks the cookie from being set on the cross-site login response — the web never gets authenticated on Railway.

Closes #77 (short-term / option 1 path).

## Changes

**`apps/api/src/routes/auth.ts`**
- `COOKIE_OPTIONS` is now env-aware:
  - `NODE_ENV=development` → `SameSite=Lax`, `Secure=false` (keeps HTTP localhost / docker-compose working)
  - anything else (`qa`, `production`, ...) → `SameSite=None`, `Secure=true` (browsers require Secure with None)

**`docker-compose.yml`**
- Sets `FRONTEND_URL=http://local.berntracker.com` on the api service so the local OAuth flow redirects to the nginx-proxied web, not the stale `localhost:5173` default. `FRONTEND_URL` is already consumed at `auth.ts:17` and used in the post-OAuth redirect at `auth.ts:202` — this PR just wires it through compose.

## Env vars still to configure on Railway (dashboard, not in this PR)

- API service: `FRONTEND_URL=https://berntracker-web-qa.up.railway.app`, `ALLOWED_ORIGINS=https://berntracker-web-qa.up.railway.app`
- Web service: `VITE_API_URL=https://berntracker-qa.up.railway.app`
- Google Cloud Console: add `https://berntracker-qa.up.railway.app/api/auth/google/callback` to the OAuth client's Authorized redirect URIs.

## Tests

No automated tests added — cookie attribute behavior only surfaces in a real cross-origin browser environment (CORS + cookie jar semantics), which our API integration tests bypass (they drive the API directly with `fetch` from the same process).

**Not automated / manual verification needed:**
- [ ] Local `docker compose up --build` — register/login at `http://local.berntracker.com` still works (same-origin, `SameSite=Lax` path)
- [ ] Existing API integration tests pass (`npm run test --workspace=@berntracker/api`)
- [ ] On QA: register/login via email flow lands the user on the web dashboard with an active session
- [ ] On QA: Google OAuth flow — click Google, consent, redirect lands on the web dashboard with an active session
- [ ] After logout, the refresh-token cookie is cleared (`res.clearCookie` at `auth.ts:135`)

Closes #77
Part of #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)