### PR TITLE
fix(web): centralize auth calls through api.ts

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -156,11 +156,15 @@ router.get('/me', requireAuth, async (req, res) => {
   })
 })
 
-// GET /google — redirect to Google consent screen
-router.get('/google', (_req, res) => {
+// GET /google — redirect to Google consent screen.
+// Accepts ?prompt=select_account (or other Google prompt values) so the sign-up
+// flow can force the account picker instead of silently reusing the last session.
+router.get('/google', (req, res) => {
+  const prompt = typeof req.query.prompt === 'string' ? req.query.prompt : undefined
   const url = googleClient().generateAuthUrl({
     access_type: 'offline',
     scope: ['openid', 'email', 'profile'],
+    ...(prompt ? { prompt } : {}),
   })
   res.redirect(url)
 })

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -1,18 +1,7 @@
 import { createContext, useContext, useEffect, useRef, useState } from 'react'
-import { setUnauthorizedHandler, setAccessToken as setApiToken } from '../lib/api'
+import { api, setUnauthorizedHandler, setAccessToken as setApiToken, type AuthUser } from '../lib/api'
 
-const BASE_URL = import.meta.env.VITE_API_URL ?? ''
-
-export type IdentifiedGender = 'FEMALE' | 'MALE' | 'NON_BINARY' | 'PREFER_NOT_TO_SAY' | null
-
-interface AuthUser {
-  id: string
-  email: string
-  name: string
-  role: string
-  identifiedGender: IdentifiedGender
-  isMovementReviewer: boolean
-}
+export type { IdentifiedGender } from '../lib/api'
 
 interface AuthState {
   user: AuthUser | null
@@ -44,20 +33,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (didFetch.current) return
     didFetch.current = true
 
-    fetch(`${BASE_URL}/api/auth/refresh`, { method: 'POST', credentials: 'include' })
-      .then(async (r) => {
-        if (r.ok) {
-          const data = await r.json()
-          setAccessToken(data.accessToken)
-          setApiToken(data.accessToken)
-          const me = await fetch(`${BASE_URL}/api/auth/me`, {
-            headers: { Authorization: `Bearer ${data.accessToken}` },
-            credentials: 'include',
-          })
-          if (me.ok) setUser(await me.json())
+    api.auth.refresh()
+      .then(async (refreshed) => {
+        if (!refreshed) return
+        setAccessToken(refreshed.accessToken)
+        setApiToken(refreshed.accessToken)
+        try {
+          const me = await api.auth.me(refreshed.accessToken)
+          setUser(me)
+        } catch {
+          // me failed — treat as unauthenticated; unauthorized handler will redirect if needed
         }
       })
-      .catch(() => {})
       .finally(() => setIsLoading(false))
   }, [])
 
@@ -68,7 +55,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }
 
   async function logout() {
-    await fetch(`${BASE_URL}/api/auth/logout`, { method: 'POST', credentials: 'include' }).catch(() => {})
+    await api.auth.logout().catch(() => {})
     setAccessToken(null)
     setApiToken(null)
     setUser(null)

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -199,7 +199,63 @@ export interface GymProgram {
   program: Program
 }
 
+export type IdentifiedGender = 'FEMALE' | 'MALE' | 'NON_BINARY' | 'PREFER_NOT_TO_SAY' | null
+
+export interface AuthUser {
+  id: string
+  email: string
+  name: string
+  role: Role
+  identifiedGender: IdentifiedGender
+  isMovementReviewer: boolean
+}
+
+export interface AuthResponse {
+  accessToken: string
+  user: AuthUser
+}
+
+// Auth endpoints bypass `req()` because their 401s mean "wrong credentials"
+// or "no session yet" — not "session expired" (which would trigger the
+// unauthorized handler + refresh retry that `req()` does).
+async function authPost<T>(path: string, body?: unknown, failMsg = 'Request failed'): Promise<T> {
+  const res = await fetchWithTimeout(`${BASE_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  if (res.status === 204) return undefined as T
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error((data as { error?: string }).error ?? failMsg)
+  return data as T
+}
+
 export const api = {
+  auth: {
+    // Full URL for the Google OAuth start endpoint. Not a fetch — the button
+    // navigates to it with window.location / window.open.
+    googleAuthUrl: (opts?: { prompt?: 'select_account' | 'consent' | 'none' }): string => {
+      const params = new URLSearchParams()
+      if (opts?.prompt) params.set('prompt', opts.prompt)
+      const qs = params.toString()
+      return `${BASE_URL}/api/auth/google${qs ? `?${qs}` : ''}`
+    },
+    register: (data: { name: string; email: string; password: string }) =>
+      authPost<AuthResponse>('/api/auth/register', data, 'Registration failed'),
+    login: (data: { email: string; password: string }) =>
+      authPost<AuthResponse>('/api/auth/login', data, 'Login failed'),
+    logout: () => authPost<void>('/api/auth/logout'),
+    refresh: async (): Promise<{ accessToken: string } | null> => {
+      try {
+        return await authPost<{ accessToken: string }>('/api/auth/refresh')
+      } catch {
+        return null
+      }
+    },
+    me: (token: string) => req<AuthUser>('/api/auth/me', { token }),
+  },
+
   me: {
     gyms: () => req<MyGym[]>('/api/me/gyms'),
   },

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import { useState, type FormEvent } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.tsx'
+import { api } from '../lib/api'
 
 export default function Login() {
   const { login } = useAuth()
@@ -15,21 +16,11 @@ export default function Login() {
     setError(null)
     setSubmitting(true)
     try {
-      const res = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ email, password }),
-      })
-      const data = await res.json()
-      if (!res.ok) {
-        setError(data.error ?? 'Login failed')
-        return
-      }
+      const data = await api.auth.login({ email, password })
       login(data.accessToken, data.user)
       navigate('/dashboard', { replace: true })
-    } catch {
-      setError('Network error — is the API running?')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Network error — is the API running?')
     } finally {
       setSubmitting(false)
     }
@@ -96,7 +87,7 @@ export default function Login() {
 
           <button
             type="button"
-            onClick={() => { window.open(`${import.meta.env.VITE_API_URL ?? ''}/api/auth/google`, '_self') }}
+            onClick={() => { window.open(api.auth.googleAuthUrl(), '_self') }}
             className="w-full rounded-md border border-gray-700 py-2 text-sm font-medium text-gray-200 hover:bg-gray-800"
           >
             Sign in with Google

--- a/apps/web/src/pages/Register.tsx
+++ b/apps/web/src/pages/Register.tsx
@@ -1,6 +1,7 @@
 import { useState, type FormEvent } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.tsx'
+import { api } from '../lib/api'
 
 export default function Register() {
   const { login } = useAuth()
@@ -16,21 +17,11 @@ export default function Register() {
     setError(null)
     setSubmitting(true)
     try {
-      const res = await fetch('/api/auth/register', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ name, email, password }),
-      })
-      const data = await res.json()
-      if (!res.ok) {
-        setError(data.error ?? 'Registration failed')
-        return
-      }
+      const data = await api.auth.register({ name, email, password })
       login(data.accessToken, data.user)
       navigate('/dashboard', { replace: true })
-    } catch {
-      setError('Network error — is the API running?')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Network error — is the API running?')
     } finally {
       setSubmitting(false)
     }
@@ -113,7 +104,7 @@ export default function Register() {
 
         <button
           type="button"
-          onClick={() => { window.open(`${import.meta.env.VITE_API_URL ?? ''}/api/auth/google`, '_self') }}
+          onClick={() => { window.open(api.auth.googleAuthUrl({ prompt: 'select_account' }), '_self') }}
           className="w-full rounded-md border border-gray-700 py-2 text-sm font-medium text-gray-200 hover:bg-gray-800"
         >
           Sign up with Google


### PR DESCRIPTION
## Summary

On the cross-origin Railway deploy, `Register` and `Login` pages were sending their form submissions to the web origin instead of the API — POST `/api/auth/register` hit nginx (405 Method Not Allowed) instead of Express. Root cause: those pages hand-rolled `fetch('/api/auth/...')` with a relative URL, bypassing the `VITE_API_URL` prefix that `api.ts` handles for every other endpoint.

This PR routes **all** auth calls through `api.ts` so the URL prefix, credentials handling, and error behavior live in one place. Also adds `prompt=select_account` to the "Sign up with Google" button so signups always show the account picker.

Closes the last cross-origin inconsistency flagged by the QA OAuth testing (part of #32, #77).

## Changes

### `apps/web/src/lib/api.ts` — new `api.auth.*` surface
- `googleAuthUrl(opts?)` — returns the OAuth start URL; optional `prompt` param.
- `login`, `register` — POST-with-credentials through an **auth-aware** helper (`authPost`) that **bypasses `req()`'s 401-retry logic**. The reason the pages skipped `api.ts` originally: `req()` treats 401 as "session expired" and calls the unauthorized handler + triggers refresh. For login/register, 401 means "bad password" or "no session yet" — completely different semantics. `authPost` handles that correctly.
- `refresh` — returns `null` on failure (matches how AuthContext bootstraps).
- `me`, `logout` — straightforward wrappers.
- Moves `AuthUser` / `IdentifiedGender` types here so state layer (AuthContext) and wire-format layer (api.ts) share them.

### `apps/web/src/context/AuthContext.tsx`
Drops local `BASE_URL` const and three raw fetch calls. Uses `api.auth.refresh/me/logout`. Re-exports `IdentifiedGender` for existing import sites (`LogResultDrawer.tsx`).

### `apps/web/src/pages/Login.tsx` and `Register.tsx`
Use `api.auth.login()` / `api.auth.register()`. The Google button on Register now uses `api.auth.googleAuthUrl({ prompt: 'select_account' })` so new signups always see Google's account picker — prevents the footgun of silently creating an account under the wrong Google identity. Login's button has no prompt (fast path for returning users).

### `apps/api/src/routes/auth.ts`
`GET /api/auth/google` now accepts `?prompt=select_account` (or other Google prompt values) and forwards to `generateAuthUrl`. Default (no param) preserves existing auto-select behavior.

## Tests

No automated tests added — this is a refactor of call sites, not new behavior. The semantics are covered by existing flows:
- API integration tests at `apps/api/tests/` exercise `/auth/*` endpoints.
- Web unit tests don't cover auth pages currently (separate gap).

**Not automated / manual verification needed:**
- [ ] Local `docker compose up --build`: email register + login still works at `http://local.berntracker.com`
- [ ] Local Google sign-in button redirects correctly
- [ ] Local Google sign-up button redirects and shows Google's account picker (even if already signed in)
- [ ] On QA after redeploy: email register / login works at `https://berntracker-web-qa.up.railway.app` (fixes the 405)
- [ ] On QA: Google sign-up shows the account picker; Google sign-in auto-selects the last account
- [ ] On QA: refresh (page reload with active session) restores user
- [ ] On QA: logout clears the cookie and session
- [ ] Existing API integration tests pass (`npm run test --workspace=@berntracker/api`)
- [ ] TypeScript: `turbo lint` passes (the AuthUser type narrowed from `{role: string}` to `{role: Role}` — any consumer comparing `user.role` to an invalid value would now surface)

Part of #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)