### PR TITLE
ux(web): denser calendar cells + sticky movement-filter sub-header

### DIFF
--- a/apps/web/src/components/CalendarCell.test.tsx
+++ b/apps/web/src/components/CalendarCell.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import CalendarCell from './CalendarCell'
+import { WORKOUT_TYPE_STYLES } from '../lib/workoutTypeStyles'
+import type { Workout, WorkoutType } from '../lib/api'
+
+function makeWorkout(type: WorkoutType, overrides: Partial<Workout> = {}): Workout {
+  return {
+    id: `w-${type}`,
+    title: `${type} workout`,
+    description: null,
+    type,
+    status: 'PUBLISHED',
+    scheduledAt: '2026-04-15T12:00:00.000Z',
+    dayOrder: 0,
+    workoutMovements: [],
+    programId: null,
+    program: null,
+    namedWorkoutId: null,
+    namedWorkout: null,
+    _count: { results: 0 },
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+    ...overrides,
+  } as Workout
+}
+
+const ALL_TYPES: WorkoutType[] = [
+  'STRENGTH', 'POWER_LIFTING', 'WEIGHT_LIFTING', 'BODY_BUILDING', 'MAX_EFFORT',
+  'AMRAP', 'FOR_TIME', 'EMOM', 'METCON', 'TABATA', 'INTERVALS', 'CHIPPER', 'LADDER', 'DEATH_BY',
+  'CARDIO', 'RUNNING', 'ROWING', 'BIKING', 'SWIMMING', 'SKI_ERG', 'MIXED_MONO',
+  'GYMNASTICS', 'WEIGHTLIFTING_TECHNIQUE',
+  'WARMUP', 'MOBILITY', 'COOLDOWN',
+]
+
+describe('CalendarCell', () => {
+  it('renders each workout pill with the type-specific accentBar class', () => {
+    // Render one cell per type so each pill is the only one in its render scope.
+    for (const type of ALL_TYPES) {
+      const onAddClick = vi.fn()
+      const onWorkoutClick = vi.fn()
+      const { unmount } = render(
+        <CalendarCell
+          date={new Date(2026, 3, 15)}
+          isToday={false}
+          workouts={[makeWorkout(type)]}
+          selected={false}
+          onAddClick={onAddClick}
+          onWorkoutClick={onWorkoutClick}
+        />,
+      )
+
+      const pill = screen.getByRole('button', { name: new RegExp(`${type} workout`) })
+      expect(pill.className).toContain('border-l-2')
+      expect(pill.className).toContain(WORKOUT_TYPE_STYLES[type].accentBar)
+      unmount()
+    }
+  })
+
+  it('renders the + button hover-only (opacity-0 default, group-hover:opacity-100)', () => {
+    render(
+      <CalendarCell
+        date={new Date(2026, 3, 15)}
+        isToday={false}
+        workouts={[]}
+        selected={false}
+        onAddClick={vi.fn()}
+        onWorkoutClick={vi.fn()}
+      />,
+    )
+    const addBtn = screen.getByRole('button', { name: 'Add workout' })
+    expect(addBtn.className).toContain('opacity-0')
+    expect(addBtn.className).toContain('group-hover:opacity-100')
+  })
+
+  it('+ button click fires onAddClick', async () => {
+    const user = userEvent.setup()
+    const onAddClick = vi.fn()
+    render(
+      <CalendarCell
+        date={new Date(2026, 3, 15)}
+        isToday={false}
+        workouts={[]}
+        selected={false}
+        onAddClick={onAddClick}
+        onWorkoutClick={vi.fn()}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: 'Add workout' }))
+    expect(onAddClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking the cell background does NOT fire onAddClick', async () => {
+    const user = userEvent.setup()
+    const onAddClick = vi.fn()
+    const { container } = render(
+      <CalendarCell
+        date={new Date(2026, 3, 15)}
+        isToday={false}
+        workouts={[]}
+        selected={false}
+        onAddClick={onAddClick}
+        onWorkoutClick={vi.fn()}
+      />,
+    )
+    // The outermost div is the cell background.
+    const cell = container.firstChild as HTMLElement
+    await user.click(cell)
+    expect(onAddClick).not.toHaveBeenCalled()
+  })
+
+  it('workout pill carries title attribute equal to workout title', () => {
+    render(
+      <CalendarCell
+        date={new Date(2026, 3, 15)}
+        isToday={false}
+        workouts={[makeWorkout('AMRAP', { title: 'Long Workout Name' })]}
+        selected={false}
+        onAddClick={vi.fn()}
+        onWorkoutClick={vi.fn()}
+      />,
+    )
+    const pill = screen.getByRole('button', { name: /Long Workout Name/ })
+    expect(pill).toHaveAttribute('title', 'Long Workout Name')
+  })
+
+  it('shows up to MAX_VISIBLE pills and renders an overflow indicator', () => {
+    const workouts: Workout[] = [
+      makeWorkout('AMRAP',    { id: 'w-1', title: 'WOD A' }),
+      makeWorkout('FOR_TIME', { id: 'w-2', title: 'WOD B' }),
+      makeWorkout('EMOM',     { id: 'w-3', title: 'WOD C' }),
+      makeWorkout('METCON',   { id: 'w-4', title: 'WOD D' }),
+      makeWorkout('STRENGTH', { id: 'w-5', title: 'WOD E' }),
+    ]
+    render(
+      <CalendarCell
+        date={new Date(2026, 3, 15)}
+        isToday={false}
+        workouts={workouts}
+        selected={false}
+        onAddClick={vi.fn()}
+        onWorkoutClick={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('WOD A')).toBeInTheDocument()
+    expect(screen.getByText('WOD B')).toBeInTheDocument()
+    expect(screen.getByText('WOD C')).toBeInTheDocument()
+    expect(screen.queryByText('WOD D')).not.toBeInTheDocument()
+    expect(screen.queryByText('WOD E')).not.toBeInTheDocument()
+    expect(screen.getByText('+2 more')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/CalendarCell.tsx
+++ b/apps/web/src/components/CalendarCell.tsx
@@ -1,7 +1,7 @@
 import { type Workout } from '../lib/api'
 import { WORKOUT_TYPE_STYLES } from '../lib/workoutTypeStyles'
 
-const MAX_VISIBLE = 2
+const MAX_VISIBLE = 3
 
 interface CalendarCellProps {
   date: Date
@@ -18,9 +18,8 @@ export default function CalendarCell({ date, isToday, workouts, selected, onAddC
 
   return (
     <div
-      onClick={onAddClick}
       className={[
-        'bg-gray-950 h-24 p-1.5 cursor-pointer flex flex-col transition-colors',
+        'group bg-gray-950 h-[120px] p-1.5 flex flex-col transition-colors',
         selected ? 'ring-2 ring-inset ring-indigo-500' : 'hover:bg-gray-900',
       ].join(' ')}
     >
@@ -35,8 +34,8 @@ export default function CalendarCell({ date, isToday, workouts, selected, onAddC
           {date.getDate()}
         </span>
         <button
-          onClick={(e) => { e.stopPropagation(); onAddClick() }}
-          className="text-gray-600 hover:text-gray-300 text-sm leading-none w-5 h-5 flex items-center justify-center rounded transition-colors"
+          onClick={onAddClick}
+          className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-500 hover:text-gray-200 hover:bg-gray-800 text-base leading-none w-7 h-7 flex items-center justify-center rounded"
           aria-label="Add workout"
         >
           +
@@ -48,24 +47,25 @@ export default function CalendarCell({ date, isToday, workouts, selected, onAddC
         {visible.map((w) => {
           const styles = WORKOUT_TYPE_STYLES[w.type]
           return (
-          <button
-            key={w.id}
-            onClick={(e) => { e.stopPropagation(); onWorkoutClick(w.id) }}
-            className={`w-full flex items-center gap-1 px-1 py-0.5 rounded text-left hover:bg-gray-800/70 transition-colors border-l-2 ${styles?.accentBar ?? 'border-gray-700'}`}
-          >
-            <span className={['text-[10px] shrink-0', w.status === 'PUBLISHED' ? 'text-green-400' : 'text-yellow-400'].join(' ')}>
-              {w.status === 'PUBLISHED' ? '●' : '○'}
-            </span>
-            <span className="text-[10px] font-mono text-indigo-400 shrink-0 w-4">
-              {styles?.abbr ?? '?'}
-            </span>
-            <span className="text-[10px] text-gray-200 truncate flex-1">{w.title}</span>
-          </button>
+            <button
+              key={w.id}
+              onClick={() => onWorkoutClick(w.id)}
+              title={w.title}
+              className={`w-full flex items-center gap-1 px-1 py-0.5 rounded text-left hover:bg-gray-800/70 transition-colors border-l-2 ${styles?.accentBar ?? 'border-gray-700'}`}
+            >
+              <span className={['text-[11px] shrink-0', w.status === 'PUBLISHED' ? 'text-green-400' : 'text-yellow-400'].join(' ')}>
+                {w.status === 'PUBLISHED' ? '●' : '○'}
+              </span>
+              <span className="text-[11px] font-mono text-indigo-400 shrink-0 w-4">
+                {styles?.abbr ?? '?'}
+              </span>
+              <span className="text-[11px] text-gray-200 truncate flex-1">{w.title}</span>
+            </button>
           )
         })}
       </div>
       {overflow > 0 && (
-        <div className="text-[10px] text-gray-500 pl-1 shrink-0">+{overflow} more</div>
+        <div className="text-[11px] text-gray-500 pl-1 shrink-0">+{overflow} more</div>
       )}
     </div>
   )

--- a/apps/web/src/components/MovementFilterInput.tsx
+++ b/apps/web/src/components/MovementFilterInput.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { Movement } from '../lib/api'
+import Chip from './ui/Chip'
 
 interface Props {
   allMovements: Movement[]
@@ -42,20 +43,14 @@ export default function MovementFilterInput({
     <div className="flex flex-wrap items-center gap-1.5">
       {/* Selected chips */}
       {selectedMovements.map((m) => (
-        <span
+        <Chip
           key={m.id}
-          className="flex items-center gap-1 bg-indigo-600 text-white text-xs px-2.5 py-1 rounded-full"
+          variant="accent"
+          onDismiss={() => remove(m.id)}
+          aria-label={`Remove ${m.name} filter`}
         >
           {m.name}
-          <button
-            type="button"
-            onMouseDown={() => remove(m.id)}
-            className="flex items-center justify-center w-3.5 h-3.5 -mr-0.5 hover:bg-indigo-500 rounded-full transition-colors"
-            aria-label={`Remove ${m.name} filter`}
-          >
-            ×
-          </button>
-        </span>
+        </Chip>
       ))}
 
       {/* Search input + dropdown */}

--- a/apps/web/src/pages/Calendar.tsx
+++ b/apps/web/src/pages/Calendar.tsx
@@ -6,6 +6,7 @@ import CalendarCell from '../components/CalendarCell'
 import WorkoutDrawer from '../components/WorkoutDrawer'
 import MovementFilterInput from '../components/MovementFilterInput'
 import Button from '../components/ui/Button'
+import Chip from '../components/ui/Chip'
 
 function toDateKey(date: Date): string {
   const y = date.getFullYear()
@@ -116,14 +117,32 @@ export default function Calendar() {
         </div>
       </div>
 
-      {/* Movement filter */}
+      {/* Sticky movement-filter sub-header */}
       {allMovements.length > 0 && (
-        <div className="mb-4 px-3 py-2 bg-gray-900 rounded-lg border border-gray-800">
-          <MovementFilterInput
-            allMovements={allMovements}
-            selectedIds={filterMovementIds}
-            onChange={setFilterMovementIds}
-          />
+        <div className="sticky top-0 z-20 -mx-4 px-4 py-2 mb-4 bg-gray-950/90 backdrop-blur supports-[backdrop-filter]:bg-gray-950/70 border-b border-gray-800">
+          {/* Wide layout: full chip row */}
+          <div className="hidden min-[520px]:block">
+            <MovementFilterInput
+              allMovements={allMovements}
+              selectedIds={filterMovementIds}
+              onChange={setFilterMovementIds}
+            />
+          </div>
+          {/* Narrow layout: collapsed details/summary */}
+          <details className="block min-[520px]:hidden">
+            <summary className="list-none cursor-pointer [&::-webkit-details-marker]:hidden inline-block">
+              <Chip variant="neutral">
+                Filters{filterMovementIds.length ? ` (${filterMovementIds.length})` : ''}
+              </Chip>
+            </summary>
+            <div className="mt-2">
+              <MovementFilterInput
+                allMovements={allMovements}
+                selectedIds={filterMovementIds}
+                onChange={setFilterMovementIds}
+              />
+            </div>
+          </details>
         </div>
       )}
 
@@ -148,7 +167,7 @@ export default function Calendar() {
         {weeks.map((week, wi) =>
           week.map((date, di) => {
             if (!date) {
-              return <div key={`empty-${wi}-${di}`} className="bg-gray-950 h-24" />
+              return <div key={`empty-${wi}-${di}`} className="bg-gray-950 h-[120px]" />
             }
             const key = toDateKey(date)
             return (


### PR DESCRIPTION
## Summary

Third of the five PRs from #81. Two related calendar polish items:

1. **Denser, more legible calendar cells** — taller rows, larger text, three workouts visible per day, hover-only `+`, no accidental drawer-on-background-click.
2. **Sticky movement-filter sub-header** — the chip strip stays visible while the grid scrolls, and collapses to a single `Filters (N)` chip on viewports under 520px.

## What changed

### `components/CalendarCell.tsx`

- Height: `h-24` → `h-[120px]`.
- All in-pill text: `text-[10px]` → `text-[11px]`.
- `MAX_VISIBLE`: 2 → 3.
- `+` button: `w-5 h-5` → `w-7 h-7`. Now `opacity-0 group-hover:opacity-100 transition-opacity` (cell wrapper has `group`), so it only appears on hover.
- The cell wrapper's `onClick={onAddClick}` is gone — clicking cell background is a no-op now (reserved for a future day-detail drawer). Only the explicit `+` adds a workout.
- Each pill gets `title={w.title}` so the full title shows when truncated.

### `pages/Calendar.tsx`

- Movement filter is now wrapped in a `sticky top-0 z-20` sub-header below the month nav with a translucent `bg-gray-950/90 backdrop-blur` panel and a bottom border, so the chip strip stays anchored as the user scrolls long months.
- Viewport < 520px (Tailwind arbitrary `min-[520px]` variant): the chip row collapses to a single `Filters (N)` `<Chip>` inside a native `<details>`; clicking it expands to the full `MovementFilterInput`. No new dependency — uses the browser's built-in disclosure semantics.
- Empty-cell placeholder height bumped from `h-24` to `h-[120px]` so the grid stays square.

### `components/MovementFilterInput.tsx`

- Selected-movement chips now use the `Chip` primitive (variant `accent`, `onDismiss`) instead of ad-hoc `bg-indigo-600 …` markup. Keeps the same look — same indigo pill with × — just sourced from the shared component. Both Calendar and History benefit.

## Tests

**Unit** (`apps/web/src/components/CalendarCell.test.tsx`, 6 tests, new):
- Renders one cell per `WorkoutType` and asserts each pill carries the type's expected `accentBar` class (`border-l-2 ${WORKOUT_TYPE_STYLES[t].accentBar}`).
- The `+` button is hover-only — has `opacity-0` and `group-hover:opacity-100` classes by default.
- Clicking the `+` button fires `onAddClick`.
- Clicking the cell background does **not** fire `onAddClick` (verifies the regression is gone).
- Each pill carries a `title` attribute equal to the workout title.
- With 5 workouts, 3 pills render and a `+2 more` overflow indicator shows.

**Existing tests:** all 34 pre-existing web unit tests continue to pass. Total: 9 files, 40/40 pass. `npx turbo lint` clean across the monorepo.

**Not automated / manual verification needed:**
- [x] Eyeball the calendar at a viewport ≥ 520px and confirm the filter chip strip stays visible (sticky) while you scroll a long month.
- [x] Resize the viewport to < 520px (e.g., narrow window or phone preview) and confirm the chip row collapses to a `Filters (N)` chip; click it to expand and add/remove movements.
- [x] Hover an empty calendar cell — the `+` should appear; click it to open the add-workout drawer. Click the empty cell background — nothing should happen.
- [x] Hover a calendar pill whose title is long enough to truncate — the browser tooltip should show the full title.
- [x] Confirm a day with three workouts shows all three pills (not two + overflow).

## Notes

- The Playwright filter-chip e2e is **already covered by #70** per the issue spec ("extend rather than duplicate"); no new e2e in this PR.
- The future day-detail drawer hinted at in the PR description (cell background click → drawer) is intentionally out of scope. Background clicks are a no-op for now.

Part of #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)