### PR TITLE
feat(web): segmented level filter w/ viewer-aware default + graded inclusion

### DIFF
--- a/apps/web/src/components/ui/SegmentedControl.test.tsx
+++ b/apps/web/src/components/ui/SegmentedControl.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import SegmentedControl from './SegmentedControl'
+
+const OPTIONS = [
+  { value: 'one',   label: 'One' },
+  { value: 'two',   label: 'Two' },
+  { value: 'three', label: 'Three' },
+] as const
+
+describe('SegmentedControl', () => {
+  it('renders each option as a radio button with its label', () => {
+    render(<SegmentedControl options={[...OPTIONS]} value="one" onChange={vi.fn()} />)
+    expect(screen.getByRole('radio', { name: 'One' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Two' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Three' })).toBeInTheDocument()
+  })
+
+  it('reflects the selected value via aria-checked / aria-pressed', () => {
+    render(<SegmentedControl options={[...OPTIONS]} value="two" onChange={vi.fn()} />)
+    expect(screen.getByRole('radio', { name: 'One' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('radio', { name: 'Two' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('radio', { name: 'Three' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('fires onChange when a segment is clicked', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<SegmentedControl options={[...OPTIONS]} value="one" onChange={onChange} />)
+
+    await user.click(screen.getByRole('radio', { name: 'Three' }))
+    expect(onChange).toHaveBeenCalledWith('three')
+  })
+
+  it('navigates with ArrowRight / ArrowLeft and fires onChange for each step', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<SegmentedControl options={[...OPTIONS]} value="one" onChange={onChange} />)
+
+    const first = screen.getByRole('radio', { name: 'One' })
+    first.focus()
+
+    await user.keyboard('{ArrowRight}')
+    expect(onChange).toHaveBeenLastCalledWith('two')
+
+    await user.keyboard('{ArrowLeft}')
+    // After ArrowLeft from a freshly-focused 'two' segment, wraps to 'one' (idx 0)
+    // Note: handler computes from the rendered focused index, which is now 'two'.
+    expect(onChange).toHaveBeenLastCalledWith('one')
+  })
+
+  it('wraps from the last segment to the first on ArrowRight', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<SegmentedControl options={[...OPTIONS]} value="three" onChange={onChange} />)
+
+    screen.getByRole('radio', { name: 'Three' }).focus()
+    await user.keyboard('{ArrowRight}')
+    expect(onChange).toHaveBeenLastCalledWith('one')
+  })
+
+  it('disables every segment and blocks click + keyboard when disabled', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<SegmentedControl options={[...OPTIONS]} value="one" onChange={onChange} disabled />)
+
+    const two = screen.getByRole('radio', { name: 'Two' })
+    expect(two).toBeDisabled()
+
+    await user.click(two)
+    expect(onChange).not.toHaveBeenCalled()
+
+    screen.getByRole('radio', { name: 'One' }).focus()
+    await user.keyboard('{ArrowRight}')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('only the selected segment has tabIndex 0; others are -1 (roving tabindex)', () => {
+    render(<SegmentedControl options={[...OPTIONS]} value="two" onChange={vi.fn()} />)
+    expect(screen.getByRole('radio', { name: 'One' })).toHaveAttribute('tabindex', '-1')
+    expect(screen.getByRole('radio', { name: 'Two' })).toHaveAttribute('tabindex', '0')
+    expect(screen.getByRole('radio', { name: 'Three' })).toHaveAttribute('tabindex', '-1')
+  })
+})

--- a/apps/web/src/components/ui/SegmentedControl.tsx
+++ b/apps/web/src/components/ui/SegmentedControl.tsx
@@ -1,0 +1,82 @@
+import { useRef, type KeyboardEvent } from 'react'
+
+export interface SegmentedControlOption<T extends string> {
+  value: T
+  label: string
+}
+
+interface SegmentedControlProps<T extends string> {
+  options: SegmentedControlOption<T>[]
+  value: T
+  onChange: (value: T) => void
+  disabled?: boolean
+  'aria-label'?: string
+  className?: string
+}
+
+const FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950'
+
+export default function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+  disabled,
+  'aria-label': ariaLabel,
+  className = '',
+}: SegmentedControlProps<T>) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  function handleKeyDown(e: KeyboardEvent<HTMLButtonElement>, idx: number) {
+    if (disabled) return
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
+    e.preventDefault()
+    const direction = e.key === 'ArrowRight' ? 1 : -1
+    const nextIdx = (idx + direction + options.length) % options.length
+    const nextOpt = options[nextIdx]
+    onChange(nextOpt.value)
+    // Move focus to the new segment so the user can keep arrowing.
+    const buttons = containerRef.current?.querySelectorAll<HTMLButtonElement>('button[role="radio"]')
+    buttons?.[nextIdx]?.focus()
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className={[
+        'inline-flex items-center rounded-lg bg-gray-800 p-0.5 gap-0.5',
+        disabled ? 'opacity-40' : '',
+        className,
+      ].filter(Boolean).join(' ')}
+    >
+      {options.map((opt, idx) => {
+        const isSelected = opt.value === value
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            aria-pressed={isSelected}
+            disabled={disabled}
+            tabIndex={isSelected ? 0 : -1}
+            onClick={() => onChange(opt.value)}
+            onKeyDown={(e) => handleKeyDown(e, idx)}
+            className={[
+              'px-3 py-1 text-xs font-medium rounded transition-colors',
+              FOCUS_RING,
+              isSelected
+                ? 'bg-gray-200 text-gray-900'
+                : 'text-gray-400 hover:text-white',
+              disabled ? 'cursor-not-allowed' : '',
+            ].filter(Boolean).join(' ')}
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/pages/WodDetail.test.tsx
+++ b/apps/web/src/pages/WodDetail.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import WodDetail from './WodDetail'
@@ -113,5 +114,75 @@ describe('WodDetail', () => {
     expect(strong.tagName).toBe('STRONG')
     expect(await screen.findByText('Jumping jacks')).toBeInTheDocument()
     expect(await screen.findByText('Air squats')).toBeInTheDocument()
+  })
+})
+
+// ─── Level filter (segmented control + Show all) ─────────────────────────────
+
+function makeResult(overrides: { id: string; userId: string; name: string; level: 'RX_PLUS' | 'RX' | 'SCALED' | 'MODIFIED'; seconds: number }) {
+  return {
+    id: overrides.id,
+    userId: overrides.userId,
+    user: { id: overrides.userId, name: overrides.name },
+    level: overrides.level,
+    workoutGender: 'OPEN' as const,
+    value: { seconds: overrides.seconds, cappedOut: false },
+    notes: null,
+    createdAt: '2026-04-01T00:00:00.000Z',
+    workout: { id: 'workout-1', type: 'FOR_TIME' as const, scheduledAt: '2026-07-15T12:00:00.000Z', title: 'Test Workout' },
+  }
+}
+
+const MIXED_LEADERBOARD = [
+  makeResult({ id: 'r-1', userId: 'u-1', name: 'RxPlus User',  level: 'RX_PLUS',  seconds: 290 }),
+  makeResult({ id: 'r-2', userId: 'u-2', name: 'Rx User',      level: 'RX',       seconds: 305 }),
+  makeResult({ id: 'r-3', userId: 'u-3', name: 'Scaled User',  level: 'SCALED',   seconds: 330 }),
+  makeResult({ id: 'r-4', userId: 'u-4', name: 'Modified User',level: 'MODIFIED', seconds: 360 }),
+]
+
+describe('WodDetail level filter', () => {
+  beforeEach(() => {
+    vi.mocked(api.workouts.get).mockResolvedValue(makeWorkout())
+    vi.mocked(api.results.leaderboard).mockResolvedValue(MIXED_LEADERBOARD as never)
+  })
+
+  it('shows only RX results by default', async () => {
+    renderPage()
+    expect(await screen.findByText('Rx User')).toBeInTheDocument()
+    expect(screen.queryByText('RxPlus User')).not.toBeInTheDocument()
+    expect(screen.queryByText('Scaled User')).not.toBeInTheDocument()
+    expect(screen.queryByText('Modified User')).not.toBeInTheDocument()
+  })
+
+  it('filters to Scaled when the Scaled segment is clicked', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    // Wait for the page to mount + leaderboard to resolve.
+    await screen.findByText('Rx User')
+
+    await user.click(screen.getByRole('radio', { name: 'Scaled' }))
+
+    expect(await screen.findByText('Scaled User')).toBeInTheDocument()
+    expect(screen.queryByText('Rx User')).not.toBeInTheDocument()
+    expect(screen.queryByText('RxPlus User')).not.toBeInTheDocument()
+    expect(screen.queryByText('Modified User')).not.toBeInTheDocument()
+  })
+
+  it('toggling "Show all levels" reveals every result and disables the segments', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByText('Rx User')
+
+    await user.click(screen.getByRole('checkbox', { name: /show all levels/i }))
+
+    expect(await screen.findByText('RxPlus User')).toBeInTheDocument()
+    expect(screen.getByText('Rx User')).toBeInTheDocument()
+    expect(screen.getByText('Scaled User')).toBeInTheDocument()
+    expect(screen.getByText('Modified User')).toBeInTheDocument()
+
+    // Each segment is disabled while "Show all" is on.
+    for (const label of ['RX+', 'RX', 'Scaled', 'Modified']) {
+      expect(screen.getByRole('radio', { name: label })).toBeDisabled()
+    }
   })
 })

--- a/apps/web/src/pages/WodDetail.test.tsx
+++ b/apps/web/src/pages/WodDetail.test.tsx
@@ -133,42 +133,60 @@ function makeResult(overrides: { id: string; userId: string; name: string; level
   }
 }
 
+// API delivers in non-sorted order on purpose so the level-desc sort is exercised.
 const MIXED_LEADERBOARD = [
-  makeResult({ id: 'r-1', userId: 'u-1', name: 'RxPlus User',  level: 'RX_PLUS',  seconds: 290 }),
-  makeResult({ id: 'r-2', userId: 'u-2', name: 'Rx User',      level: 'RX',       seconds: 305 }),
-  makeResult({ id: 'r-3', userId: 'u-3', name: 'Scaled User',  level: 'SCALED',   seconds: 330 }),
-  makeResult({ id: 'r-4', userId: 'u-4', name: 'Modified User',level: 'MODIFIED', seconds: 360 }),
+  makeResult({ id: 'r-2', userId: 'u-2', name: 'Rx User',       level: 'RX',       seconds: 305 }),
+  makeResult({ id: 'r-4', userId: 'u-4', name: 'Modified User', level: 'MODIFIED', seconds: 360 }),
+  makeResult({ id: 'r-1', userId: 'u-1', name: 'RxPlus User',   level: 'RX_PLUS',  seconds: 290 }),
+  makeResult({ id: 'r-3', userId: 'u-3', name: 'Scaled User',   level: 'SCALED',   seconds: 330 }),
 ]
 
-describe('WodDetail level filter', () => {
+// Returns the body-row athlete names in DOM order so assertions can verify sort.
+function visibleAthleteOrder(): string[] {
+  const cells = Array.from(document.querySelectorAll('tbody tr td:nth-child(2)'))
+  return cells
+    .map((td) => td.textContent ?? '')
+    // Strip the "(you)" suffix added next to the viewer's row.
+    .map((s) => s.replace(/\s*\(you\)\s*$/, '').trim())
+    .filter((s) => s.length > 0)
+}
+
+describe('WodDetail level filter — graded inclusion + ordering', () => {
   beforeEach(() => {
     vi.mocked(api.workouts.get).mockResolvedValue(makeWorkout())
     vi.mocked(api.results.leaderboard).mockResolvedValue(MIXED_LEADERBOARD as never)
   })
 
-  it('shows only RX results by default', async () => {
+  it('defaults to RX when the viewer has no logged result, showing RX + Scaled + Modified ordered by level desc', async () => {
     renderPage()
-    expect(await screen.findByText('Rx User')).toBeInTheDocument()
+    await screen.findByText('Rx User')
+
+    // RX+ excluded, the other three included.
     expect(screen.queryByText('RxPlus User')).not.toBeInTheDocument()
-    expect(screen.queryByText('Scaled User')).not.toBeInTheDocument()
-    expect(screen.queryByText('Modified User')).not.toBeInTheDocument()
+    expect(screen.getByText('Rx User')).toBeInTheDocument()
+    expect(screen.getByText('Scaled User')).toBeInTheDocument()
+    expect(screen.getByText('Modified User')).toBeInTheDocument()
+
+    // Order: RX → Scaled → Modified (harder first).
+    expect(visibleAthleteOrder()).toEqual(['Rx User', 'Scaled User', 'Modified User'])
   })
 
-  it('filters to Scaled when the Scaled segment is clicked', async () => {
+  it('clicking the Scaled segment shows Scaled + Modified only', async () => {
     const user = userEvent.setup()
     renderPage()
-    // Wait for the page to mount + leaderboard to resolve.
     await screen.findByText('Rx User')
 
     await user.click(screen.getByRole('radio', { name: 'Scaled' }))
 
-    expect(await screen.findByText('Scaled User')).toBeInTheDocument()
-    expect(screen.queryByText('Rx User')).not.toBeInTheDocument()
+    await screen.findByText('Scaled User')
     expect(screen.queryByText('RxPlus User')).not.toBeInTheDocument()
-    expect(screen.queryByText('Modified User')).not.toBeInTheDocument()
+    expect(screen.queryByText('Rx User')).not.toBeInTheDocument()
+    expect(screen.getByText('Modified User')).toBeInTheDocument()
+
+    expect(visibleAthleteOrder()).toEqual(['Scaled User', 'Modified User'])
   })
 
-  it('toggling "Show all levels" reveals every result and disables the segments', async () => {
+  it('toggling "Show all levels" reveals every result ordered RX+ → RX → Scaled → Modified and disables the segments', async () => {
     const user = userEvent.setup()
     renderPage()
     await screen.findByText('Rx User')
@@ -176,13 +194,34 @@ describe('WodDetail level filter', () => {
     await user.click(screen.getByRole('checkbox', { name: /show all levels/i }))
 
     expect(await screen.findByText('RxPlus User')).toBeInTheDocument()
-    expect(screen.getByText('Rx User')).toBeInTheDocument()
-    expect(screen.getByText('Scaled User')).toBeInTheDocument()
-    expect(screen.getByText('Modified User')).toBeInTheDocument()
+    expect(visibleAthleteOrder()).toEqual([
+      'RxPlus User', 'Rx User', 'Scaled User', 'Modified User',
+    ])
 
-    // Each segment is disabled while "Show all" is on.
     for (const label of ['RX+', 'RX', 'Scaled', 'Modified']) {
       expect(screen.getByRole('radio', { name: label })).toBeDisabled()
     }
+  })
+
+  it("auto-selects the viewer's own logged level when the leaderboard contains it", async () => {
+    // user-1 is the auth-mocked viewer; give them a Scaled result.
+    const leaderboardWithViewer = [
+      ...MIXED_LEADERBOARD,
+      makeResult({ id: 'r-me', userId: 'user-1', name: 'Test User', level: 'SCALED', seconds: 340 }),
+    ]
+    vi.mocked(api.results.leaderboard).mockResolvedValue(leaderboardWithViewer as never)
+
+    renderPage()
+    // Wait for auto-detect to apply: the Scaled segment becomes pressed.
+    await screen.findByText(/Test User/)
+
+    await screen.findByRole('radio', { name: 'Scaled', checked: true })
+
+    // RxPlus / Rx are hidden; Scaled (self + others) and Modified are shown.
+    expect(screen.queryByText('RxPlus User')).not.toBeInTheDocument()
+    expect(screen.queryByText('Rx User')).not.toBeInTheDocument()
+    expect(screen.getByText('Scaled User')).toBeInTheDocument()
+    expect(screen.getByText('Modified User')).toBeInTheDocument()
+    expect(screen.getByText(/Test User/)).toBeInTheDocument()
   })
 })

--- a/apps/web/src/pages/WodDetail.tsx
+++ b/apps/web/src/pages/WodDetail.tsx
@@ -8,6 +8,7 @@ import MarkdownDescription from '../components/MarkdownDescription.tsx'
 import Button from '../components/ui/Button.tsx'
 import Chip from '../components/ui/Chip.tsx'
 import ChipGroup from '../components/ui/ChipGroup.tsx'
+import SegmentedControl from '../components/ui/SegmentedControl.tsx'
 
 const CATEGORY_LABELS: Record<WorkoutCategory, string> = {
   GIRL_WOD: 'Girl WOD',
@@ -17,7 +18,6 @@ const CATEGORY_LABELS: Record<WorkoutCategory, string> = {
   BENCHMARK: 'Benchmark',
 }
 
-type LevelFilter = WorkoutLevel | 'ALL'
 type GenderFilter = WorkoutGender | 'ALL'
 
 const LEVEL_LABELS: Record<WorkoutLevel, string> = {
@@ -27,7 +27,12 @@ const LEVEL_LABELS: Record<WorkoutLevel, string> = {
   MODIFIED: 'Modified',
 }
 
-const LEVEL_FILTERS: LevelFilter[] = ['ALL', 'RX_PLUS', 'RX', 'SCALED', 'MODIFIED']
+const LEVEL_OPTIONS: { value: WorkoutLevel; label: string }[] = [
+  { value: 'RX_PLUS',  label: 'RX+' },
+  { value: 'RX',       label: 'RX' },
+  { value: 'SCALED',   label: 'Scaled' },
+  { value: 'MODIFIED', label: 'Modified' },
+]
 
 const GENDER_FILTERS: { value: GenderFilter; label: string }[] = [
   { value: 'ALL',    label: 'Open' },
@@ -68,7 +73,8 @@ export default function WodDetail() {
 
   const [workout, setWorkout] = useState<Workout | null>(null)
   const [results, setResults] = useState<WorkoutResult[]>([])
-  const [levelFilter, setLevelFilter] = useState<LevelFilter>('ALL')
+  const [levelFilter, setLevelFilter] = useState<WorkoutLevel>('RX')
+  const [showAllLevels, setShowAllLevels] = useState(false)
   const [genderFilter, setGenderFilter] = useState<GenderFilter>('ALL')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -119,7 +125,7 @@ export default function WodDetail() {
   const myResult = results.find((r) => r.userId === user?.id)
 
   const filteredResults = results
-    .filter((r) => levelFilter === 'ALL' || r.level === levelFilter)
+    .filter((r) => showAllLevels || r.level === levelFilter)
     .filter((r) => genderFilter === 'ALL' || r.workoutGender === genderFilter)
 
   return (
@@ -201,19 +207,25 @@ export default function WodDetail() {
           <hr className="flex-1 border-gray-800" />
         </div>
 
-        {/* Level filter chips */}
-        <ChipGroup className="flex-wrap mb-2">
-          {LEVEL_FILTERS.map((lvl) => (
-            <Chip
-              key={lvl}
-              variant="neutral"
-              toggled={levelFilter === lvl}
-              onToggle={() => setLevelFilter(lvl)}
-            >
-              {lvl === 'ALL' ? 'All' : LEVEL_LABELS[lvl as WorkoutLevel]}
-            </Chip>
-          ))}
-        </ChipGroup>
+        {/* Level filter: segmented control + Show-all checkbox */}
+        <div className="flex flex-wrap items-center gap-3 mb-2">
+          <SegmentedControl
+            options={LEVEL_OPTIONS}
+            value={levelFilter}
+            onChange={setLevelFilter}
+            disabled={showAllLevels}
+            aria-label="Filter results by level"
+          />
+          <label className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={showAllLevels}
+              onChange={(e) => setShowAllLevels(e.target.checked)}
+              className="accent-indigo-500 cursor-pointer"
+            />
+            Show all levels
+          </label>
+        </div>
 
         {/* Gender filter chips */}
         <ChipGroup className="mb-4">

--- a/apps/web/src/pages/WodDetail.tsx
+++ b/apps/web/src/pages/WodDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, Fragment } from 'react'
+import { useState, useEffect, useRef, Fragment } from 'react'
 import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.tsx'
 import { api, type Workout, type WorkoutCategory, type WorkoutResult, type WorkoutLevel, type WorkoutGender } from '../lib/api.ts'
@@ -6,8 +6,6 @@ import { WORKOUT_TYPE_STYLES } from '../lib/workoutTypeStyles.ts'
 import LogResultDrawer from '../components/LogResultDrawer.tsx'
 import MarkdownDescription from '../components/MarkdownDescription.tsx'
 import Button from '../components/ui/Button.tsx'
-import Chip from '../components/ui/Chip.tsx'
-import ChipGroup from '../components/ui/ChipGroup.tsx'
 import SegmentedControl from '../components/ui/SegmentedControl.tsx'
 
 const CATEGORY_LABELS: Record<WorkoutCategory, string> = {
@@ -27,6 +25,15 @@ const LEVEL_LABELS: Record<WorkoutLevel, string> = {
   MODIFIED: 'Modified',
 }
 
+// Difficulty rank used by the graded level filter and the result ordering.
+// Higher rank = harder. Selecting level X shows results with rank ≤ X.
+const LEVEL_RANK: Record<WorkoutLevel, number> = {
+  MODIFIED: 0,
+  SCALED:   1,
+  RX:       2,
+  RX_PLUS:  3,
+}
+
 const LEVEL_OPTIONS: { value: WorkoutLevel; label: string }[] = [
   { value: 'RX_PLUS',  label: 'RX+' },
   { value: 'RX',       label: 'RX' },
@@ -34,7 +41,7 @@ const LEVEL_OPTIONS: { value: WorkoutLevel; label: string }[] = [
   { value: 'MODIFIED', label: 'Modified' },
 ]
 
-const GENDER_FILTERS: { value: GenderFilter; label: string }[] = [
+const GENDER_OPTIONS: { value: GenderFilter; label: string }[] = [
   { value: 'ALL',    label: 'Open' },
   { value: 'MALE',   label: 'Male' },
   { value: 'FEMALE', label: 'Female' },
@@ -80,6 +87,13 @@ export default function WodDetail() {
   const [error, setError] = useState<string | null>(null)
   const [showLogDrawer, setShowLogDrawer] = useState(false)
 
+  // Tracks which workout id has had the auto-detect default applied.
+  // The auto-detect snaps levelFilter to the viewer's own logged level on
+  // first leaderboard load (per workout). After it fires once, manual
+  // segment changes — and re-fetches triggered by logging a result — must
+  // not overwrite the user's selection.
+  const autoDetectAppliedRef = useRef<string | null>(null)
+
   useEffect(() => {
     if (!id) return
     setLoading(true)
@@ -92,6 +106,15 @@ export default function WodDetail() {
       .catch((e) => setError((e as Error).message))
       .finally(() => setLoading(false))
   }, [id])
+
+  useEffect(() => {
+    if (loading) return
+    if (autoDetectAppliedRef.current === id) return
+    autoDetectAppliedRef.current = id ?? null
+    if (!user) return
+    const my = results.find((r) => r.userId === user.id)
+    if (my) setLevelFilter(my.level)
+  }, [id, loading, results, user])
 
   if (loading) {
     return (
@@ -124,9 +147,12 @@ export default function WodDetail() {
 
   const myResult = results.find((r) => r.userId === user?.id)
 
+  // Graded inclusion: selecting level X shows X-and-easier (lower-rank) results.
+  // Sort is stable, so within each level the API's performance ordering is preserved.
   const filteredResults = results
-    .filter((r) => showAllLevels || r.level === levelFilter)
+    .filter((r) => showAllLevels || LEVEL_RANK[r.level] <= LEVEL_RANK[levelFilter])
     .filter((r) => genderFilter === 'ALL' || r.workoutGender === genderFilter)
+    .sort((a, b) => LEVEL_RANK[b.level] - LEVEL_RANK[a.level])
 
   return (
     <>
@@ -227,19 +253,15 @@ export default function WodDetail() {
           </label>
         </div>
 
-        {/* Gender filter chips */}
-        <ChipGroup className="mb-4">
-          {GENDER_FILTERS.map(({ value, label }) => (
-            <Chip
-              key={value}
-              variant="neutral"
-              toggled={genderFilter === value}
-              onToggle={() => setGenderFilter(value)}
-            >
-              {label}
-            </Chip>
-          ))}
-        </ChipGroup>
+        {/* Gender filter */}
+        <div className="mb-4">
+          <SegmentedControl
+            options={GENDER_OPTIONS}
+            value={genderFilter}
+            onChange={setGenderFilter}
+            aria-label="Filter results by gender"
+          />
+        </div>
 
         {filteredResults.length === 0 ? (
           <p className="text-sm text-gray-500">No results yet.</p>


### PR DESCRIPTION
## Summary

Fourth of the five PRs from #81. Replaces the WodDetail level chip row with a segmented control that **defaults to the viewer's own logged level** and treats the four levels as a **graded difficulty ladder** instead of an exclusive filter. Also swaps the gender chip row for the same `SegmentedControl` so the two filter rows on this page look and behave the same.

The segmented control ships as a new primitive (`components/ui/SegmentedControl.tsx`) so #81 PR 5's Today / All-time / Your PRs tabs can reuse it.

## Behavior

### Level filter

- **Default selection** mirrors the viewer's own logged level for this workout. If they logged `SCALED`, the Scaled segment is pre-selected; `RX_PLUS` ⇒ RX+; etc. Falls back to **RX** when the viewer has no result on this workout. Auto-detection runs once per workout id; manual segment changes and re-fetches (e.g., after logging a result) never overwrite the user's selection.
- **Graded inclusion** with rank `MODIFIED < SCALED < RX < RX+`. Selecting a segment includes that level AND every easier one:
  - Modified → Modified only
  - Scaled → Scaled + Modified
  - RX → RX + Scaled + Modified
  - RX+ → all four levels
- **Result ordering** within the table is now level-descending — RX+ on top, then RX, Scaled, Modified. Within each level bucket, JS's stable `Array#sort` preserves the API's existing performance ordering.
- **"Show all levels" checkbox** bypasses the filter entirely (still applies the level-desc sort) and disables the segmented control while checked. Unchecking restores the previous segment selection.

### Gender filter

- Same `SegmentedControl` (Open / Male / Female), no semantic change. Was previously `ChipGroup` + `Chip`, which looked inconsistent next to the level row. The design critique in #81 didn't call this out explicitly — folding it in here for visual coherence.

## What changed

### New: `components/ui/SegmentedControl.tsx`

- Generic over the value type (`<T extends string>`).
- `role="radiogroup"` container; each segment is a `<button role="radio">` with `aria-pressed` AND `aria-checked` reflecting state.
- **Roving tabindex** — only the selected segment is in the document tab order.
- **Keyboard:** `ArrowRight` / `ArrowLeft` navigate; selection wraps at both ends and focus follows the new selection so the user can keep arrowing.
- `disabled` prop dims the whole group (`opacity-40`) and blocks both click and keyboard.
- Shared `focus-visible` ring matches `Button` and `Chip`.

### `pages/WodDetail.tsx`

- New `LEVEL_RANK` map encodes the difficulty ladder.
- `levelFilter` defaults to `'RX'`; a new `useRef`-guarded effect snaps it to the viewer's own logged level on first leaderboard load per workout id.
- `filteredResults` uses graded inclusion + a level-desc stable sort.
- Both filter rows render via `SegmentedControl`; `Chip` and `ChipGroup` imports are gone (no other use on this page).
- The "Show all levels" checkbox sits beside the segmented control and disables it while checked.

## Tests

**Unit** (`apps/web/src/components/ui/SegmentedControl.test.tsx`, 7 tests, new):
- Each option renders as a `radio` with its label.
- `aria-pressed` reflects the selected value.
- Click on a segment fires `onChange`.
- `ArrowRight` / `ArrowLeft` navigate one step at a time and fire `onChange` for each step.
- `ArrowRight` from the last segment wraps to the first.
- `disabled` blocks both click and keyboard.
- Roving tabindex: only the selected segment has `tabindex="0"`.

**Unit** (`apps/web/src/pages/WodDetail.test.tsx`, 4 new tests):
- A leaderboard *without* the viewer renders RX + Scaled + Modified by default, ordered RX → Scaled → Modified.
- Clicking the `Scaled` segment narrows the table to Scaled + Modified, in that order.
- Toggling "Show all levels" reveals all four levels in RX+ → RX → Scaled → Modified order, and disables every segment.
- A leaderboard *with* the viewer (a Scaled result for `user-1`) auto-selects the Scaled segment and narrows the table accordingly.

The level-filter fixture deliberately delivers results in a non-sorted order so the level-desc sort is exercised in every assertion.

**Existing tests:** all 5 pre-existing `WodDetail` tests + all 35 other web unit tests continue to pass. **Total:** 10 files, 51/51 pass. `npx turbo lint` clean across the monorepo.

**Not automated / manual verification needed:**
- [x] Open a `WodDetail` for a workout you've logged at `SCALED` — confirm the Scaled segment is selected on landing and the table shows Scaled + Modified rows only.
- [x] Open a `WodDetail` you haven't logged — RX should be the default, table should show RX + Scaled + Modified.
- [x] Click RX+ — every level should appear, ordered RX+ → RX → Scaled → Modified.
- [x] Tab into the segmented control and arrow left/right — focus should follow the selection visibly.
- [x] Toggle "Show all levels" a few times and confirm the segments dim while checked, and that unchecking restores your previous segment without state loss.
- [x] Spot-check the gender row: switching Male/Female actually filters the table; "Open" shows everything.

## Notes

- `Home` / `End` keys are intentionally not bound (out of scope, easy follow-up if useful).
- The "Open" gender label still maps to `ALL` filter semantics (i.e., "show every gender") — a small label-vs-meaning mismatch we inherited; not changed in this PR.

Part of #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)