### PR TITLE
feat(db): add Workout.externalSourceId for idempotent external ingest

### DIFF
--- a/packages/db/prisma/migrations/20260425164912_workout_external_source_id/migration.sql
+++ b/packages/db/prisma/migrations/20260425164912_workout_external_source_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Workout" ADD COLUMN     "externalSourceId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Workout_externalSourceId_key" ON "Workout"("externalSourceId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -232,6 +232,9 @@ model Workout {
   scheduledAt DateTime
   dayOrder    Int           @default(0)
   namedWorkoutId String?
+  // Stable identifier from an external source (e.g. "crossfit-mainsite:w20260425")
+  // used for idempotent upserts by background ingest jobs. Null for user-authored workouts.
+  externalSourceId String?  @unique
   createdAt   DateTime      @default(now())
   updatedAt   DateTime      @updatedAt
 


### PR DESCRIPTION
## Summary
Additive, nullable, unique column on `Workout` that lets background ingest jobs upsert by a stable external key (e.g. `crossfit-mainsite:w20260425`) without colliding with user-authored rows.

This is **PR1 of 4** for the CrossFit WOD cron work. It's intentionally tiny and ships ahead of the feature code per the CLAUDE.md "Isolate migration PRs" guidance — additive, backwards-compatible, zero risk to existing rows.

## Changes
- `packages/db/prisma/schema.prisma` — `externalSourceId String? @unique` on `Workout`
- `packages/db/prisma/migrations/20260425164912_workout_external_source_id/migration.sql` — `ADD COLUMN` (nullable) + `CREATE UNIQUE INDEX`

## Why this design
- **Nullable**: existing rows (and all future user-authored rows) keep `externalSourceId = NULL`, which doesn't violate the unique constraint in Postgres.
- **Unique**: the upsert path becomes a single O(1) indexed lookup — `prisma.workout.findUnique({ where: { externalSourceId } })` — and survives same-day re-publishes from upstream sources.
- **Namespaced values**: callers will write `"<source>:<external-id>"` (e.g. `"crossfit-mainsite:w20260425"`) so future external sources don't collide.

## Tests
No new tests in this PR — it's a schema-only change with no application code touching the column yet.

**Verified locally:**
- `npx prisma migrate deploy` applied cleanly against the existing dev DB.
- `npx prisma generate` regenerated the client.
- `npm run build --workspace=@berntracker/api` passes (the regenerated client typechecks).
- `npx turbo lint` passes.
- `npx prisma migrate status` reports the schema up to date.

The first reads/writes against this column ship in PR4 of the sequence (job handler + DB managers), where unit and integration tests will cover idempotent upsert behavior.

## Sequencing
- **This PR (PR1)** — schema only. Lands first.
- **PR2** — job dispatcher, Dockerfile, Railway service config (parallel-safe).
- **PR3** — CrossFit JSON client + `WorkoutType` classifier with unit tests (parallel-safe).
- **PR4** — convergence: WOD job wired into dispatcher + DB managers + integration test.

Part of #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)