### PR TITLE
feat(api): CrossFit WOD JSON client + WorkoutType classifier

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,8 @@
     "express": "^4.21.2",
     "fuse.js": "^7.3.0",
     "google-auth-library": "^10.6.1",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/apps/api/src/lib/crossfitWodClassifier.ts
+++ b/apps/api/src/lib/crossfitWodClassifier.ts
@@ -1,0 +1,22 @@
+import type { WorkoutType } from '@berntracker/db'
+
+/**
+ * Best-effort classification of a free-form WOD description into a
+ * `WorkoutType`. Order of checks matters — first match wins:
+ *
+ *   AMRAP keyword         → AMRAP
+ *   EMOM / "every N min"  → EMOM
+ *   "for time"            → FOR_TIME
+ *   else                  → METCON   (catch-all conditioning)
+ *
+ * Intentionally conservative. Anything we can't confidently categorize falls
+ * through to METCON so a human reviewing the workout can re-tag it later.
+ */
+export function classifyWorkoutType(descriptionRaw: string): WorkoutType {
+  if (/\bAMRAP\b/i.test(descriptionRaw)) return 'AMRAP'
+  if (/\bEMOM\b/i.test(descriptionRaw) || /every\s+\d+\s+(minutes?|min)\b/i.test(descriptionRaw)) {
+    return 'EMOM'
+  }
+  if (/\bfor\s+time\b/i.test(descriptionRaw)) return 'FOR_TIME'
+  return 'METCON'
+}

--- a/apps/api/src/lib/crossfitWodClient.ts
+++ b/apps/api/src/lib/crossfitWodClient.ts
@@ -1,0 +1,123 @@
+import { z } from 'zod'
+import { createLogger } from './logger.js'
+
+const log = createLogger('crossfit-wod-client')
+
+const FETCH_TIMEOUT_MS = 10_000
+
+const CrossfitWodPayloadSchema = z.object({
+  wods: z.object({
+    id: z.string(),
+    cleanID: z.string(),
+    title: z.string(),
+    wodRaw: z.string(),
+    wodHtml: z.string(),
+    publishingState: z.string(),
+    publishingDate: z.string(),
+    url: z.string(),
+    topicId: z.string(),
+    previous: z
+      .union([z.object({ url: z.string() }), z.literal(false)])
+      .optional(),
+  }),
+})
+
+export interface NormalizedCrossfitWod {
+  externalId: string
+  title: string
+  descriptionRaw: string
+  descriptionHtml: string
+  scheduledAt: string
+  canonicalUrl: string
+  previousUrl: string | null
+}
+
+export type FetchImpl = (input: string, init?: RequestInit) => Promise<Response>
+
+function buildUrl(date: Date): string {
+  const yyyy = date.getUTCFullYear().toString()
+  const mm = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(date.getUTCDate()).padStart(2, '0')
+  return `https://www.crossfit.com/workout/${yyyy}/${mm}/${dd}`
+}
+
+/**
+ * Fetches the CrossFit Mainsite WOD for the given date from the undocumented
+ * JSON endpoint the crossfit.com SPA uses.
+ *
+ * Returns a normalized payload on success, or `null` for any failure mode the
+ * caller should treat as "skip this tick":
+ *   - HTTP non-200 (4xx / 5xx / 429)
+ *   - non-JSON content-type
+ *   - JSON shape mismatch (Zod parse failure)
+ *   - publishingState !== "published" (drafts)
+ *   - network timeout / fetch error
+ *
+ * The optional `fetchImpl` parameter lets tests inject a stub. Defaults to
+ * the global `fetch`.
+ */
+export async function fetchCrossfitWod(
+  date: Date,
+  fetchImpl: FetchImpl = fetch,
+): Promise<NormalizedCrossfitWod | null> {
+  const url = buildUrl(date)
+
+  let res: Response
+  try {
+    res = await fetchImpl(url, {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'BernTracker/1.0 (+https://github.com/chuckmag/BernTracker)',
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+  } catch (err) {
+    log.warning(`fetch failed: ${url} — ${err instanceof Error ? err.message : err}`)
+    return null
+  }
+
+  if (!res.ok) {
+    log.warning(`non-OK response: ${url} — status=${res.status}`)
+    return null
+  }
+
+  const contentType = res.headers.get('content-type') ?? ''
+  if (!contentType.includes('application/json')) {
+    log.warning(`unexpected content-type: ${url} — ${contentType}`)
+    return null
+  }
+
+  let raw: unknown
+  try {
+    raw = await res.json()
+  } catch (err) {
+    log.warning(`json parse failed: ${url} — ${err instanceof Error ? err.message : err}`)
+    return null
+  }
+
+  const parsed = CrossfitWodPayloadSchema.safeParse(raw)
+  if (!parsed.success) {
+    log.warning(`schema mismatch: ${url} — ${parsed.error.message}`)
+    return null
+  }
+
+  const wod = parsed.data.wods
+
+  if (wod.publishingState !== 'published') {
+    log.info(`skipping non-published wod: ${wod.id} state=${wod.publishingState}`)
+    return null
+  }
+
+  const previousUrl =
+    wod.previous && typeof wod.previous === 'object' ? wod.previous.url : null
+
+  return {
+    externalId: wod.id,
+    title: wod.title,
+    descriptionRaw: wod.wodRaw,
+    descriptionHtml: wod.wodHtml,
+    scheduledAt: wod.publishingDate,
+    canonicalUrl: wod.url,
+    previousUrl,
+  }
+}

--- a/apps/api/tests/crossfit-wod-classifier.ts
+++ b/apps/api/tests/crossfit-wod-classifier.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for the CrossFit WOD WorkoutType classifier.
+ *
+ * Pure-logic tests — no API or DB required.
+ * Run via `npm test` from apps/api (along with the integration tests).
+ */
+
+import { classifyWorkoutType } from '../src/lib/crossfitWodClassifier.js'
+
+let pass = 0
+let fail = 0
+
+function check(label: string, expected: unknown, actual: unknown) {
+  if (String(expected) === String(actual)) {
+    console.log(`  ✓ ${label}`)
+    pass++
+  } else {
+    console.log(`  ✗ ${label}  [expected=${expected} actual=${actual}]`)
+    fail++
+  }
+}
+
+console.log('classifyWorkoutType')
+
+// ── AMRAP ────────────────────────────────────────────────────────────────────
+check('detects AMRAP keyword', 'AMRAP', classifyWorkoutType('AMRAP 12:\n10 pull-ups\n20 push-ups'))
+check('detects AMRAP case-insensitive', 'AMRAP', classifyWorkoutType('amrap 20 of: ...'))
+
+// ── EMOM ─────────────────────────────────────────────────────────────────────
+check('detects EMOM keyword', 'EMOM', classifyWorkoutType('EMOM 10:\n10 deadlifts'))
+check('detects "every N minutes" phrasing', 'EMOM', classifyWorkoutType('Every 2 minutes for 20 minutes:\n5 cleans'))
+check('detects "every N min" phrasing', 'EMOM', classifyWorkoutType('Every 90 min, complete...'))
+
+// ── FOR_TIME ─────────────────────────────────────────────────────────────────
+check('detects "For time:"', 'FOR_TIME', classifyWorkoutType('For time:\n400m run\n50 burpees'))
+check('detects "for time" mid-sentence', 'FOR_TIME', classifyWorkoutType('Complete the following for time, with a partner:\n...'))
+
+// ── METCON fallback ──────────────────────────────────────────────────────────
+check('falls through to METCON when unknown', 'METCON', classifyWorkoutType('5 rounds:\n10 power cleans @ 135/95'))
+check('falls through to METCON for empty string', 'METCON', classifyWorkoutType(''))
+check('falls through to METCON for narrative-only text', 'METCON', classifyWorkoutType('Workout dedicated to the memory of...'))
+
+// ── Precedence: AMRAP wins over "for time" if both keywords are present ──────
+check('AMRAP wins over for time when both keywords present', 'AMRAP', classifyWorkoutType('AMRAP 15 — score for time'))
+
+console.log(`\n${pass} passed, ${fail} failed`)
+if (fail > 0) process.exit(1)

--- a/apps/api/tests/crossfit-wod-client.ts
+++ b/apps/api/tests/crossfit-wod-client.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for the CrossFit WOD JSON client.
+ *
+ * Pure-logic tests — no live API or DB required. The client is exercised
+ * with a stub `fetch` that returns canned `Response` objects, plus a
+ * captured fixture for the happy path.
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { fetchCrossfitWod, type FetchImpl } from '../src/lib/crossfitWodClient.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const fixturePath = join(__dirname, 'fixtures', 'crossfit-wod-260425.json')
+const fixtureRaw = readFileSync(fixturePath, 'utf8')
+const fixturePayload = JSON.parse(fixtureRaw)
+
+let pass = 0
+let fail = 0
+
+function check(label: string, expected: unknown, actual: unknown) {
+  if (String(expected) === String(actual)) {
+    console.log(`  ✓ ${label}`)
+    pass++
+  } else {
+    console.log(`  ✗ ${label}  [expected=${expected} actual=${actual}]`)
+    fail++
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+// Sample date: April 25, 2026 (matches the fixture).
+const D = new Date(Date.UTC(2026, 3, 25))
+
+async function main() {
+  console.log('fetchCrossfitWod — happy path')
+  {
+    let calledUrl: string | null = null
+    const stub: FetchImpl = async (url) => {
+      calledUrl = url
+      return jsonResponse(fixturePayload)
+    }
+    const result = await fetchCrossfitWod(D, stub)
+    check('returns non-null', true, result !== null)
+    check('hits the date-formatted URL', 'https://www.crossfit.com/workout/2026/04/25', calledUrl)
+    check('externalId from wods.id', 'w20260425', result?.externalId)
+    check('title preserved', 'Saturday 260425', result?.title)
+    check('descriptionRaw preserved', fixturePayload.wods.wodRaw, result?.descriptionRaw)
+    check('descriptionHtml preserved', fixturePayload.wods.wodHtml, result?.descriptionHtml)
+    check('scheduledAt is publishingDate', '2026-04-24T23:55:00+00:00', result?.scheduledAt)
+    check('canonicalUrl from wods.url', '/260425', result?.canonicalUrl)
+    check('previousUrl extracted', '/260424', result?.previousUrl)
+  }
+
+  console.log('\nfetchCrossfitWod — draft / non-published')
+  {
+    const draft = { ...fixturePayload, wods: { ...fixturePayload.wods, publishingState: 'draft' } }
+    const stub: FetchImpl = async () => jsonResponse(draft)
+    const result = await fetchCrossfitWod(D, stub)
+    check('returns null for draft state', null, result)
+  }
+
+  console.log('\nfetchCrossfitWod — HTTP errors')
+  {
+    const stub500: FetchImpl = async () => new Response('boom', { status: 500 })
+    check('returns null for HTTP 500', null, await fetchCrossfitWod(D, stub500))
+
+    const stub429: FetchImpl = async () => new Response('rate', { status: 429 })
+    check('returns null for HTTP 429', null, await fetchCrossfitWod(D, stub429))
+
+    const stub404: FetchImpl = async () => new Response('not found', { status: 404 })
+    check('returns null for HTTP 404', null, await fetchCrossfitWod(D, stub404))
+  }
+
+  console.log('\nfetchCrossfitWod — non-JSON content-type')
+  {
+    const stub: FetchImpl = async () =>
+      new Response('<html>oops</html>', { status: 200, headers: { 'content-type': 'text/html' } })
+    check('returns null when content-type is not JSON', null, await fetchCrossfitWod(D, stub))
+  }
+
+  console.log('\nfetchCrossfitWod — malformed JSON')
+  {
+    const stub: FetchImpl = async () =>
+      new Response('{not json', { status: 200, headers: { 'content-type': 'application/json' } })
+    check('returns null when JSON parse fails', null, await fetchCrossfitWod(D, stub))
+  }
+
+  console.log('\nfetchCrossfitWod — schema mismatch')
+  {
+    const broken = { wods: { id: 123, title: 'wrong types' } }
+    const stub: FetchImpl = async () => jsonResponse(broken)
+    check('returns null when Zod validation fails', null, await fetchCrossfitWod(D, stub))
+  }
+
+  console.log('\nfetchCrossfitWod — fetch throws')
+  {
+    const stub: FetchImpl = async () => {
+      throw new Error('network down')
+    }
+    check('returns null when fetch throws', null, await fetchCrossfitWod(D, stub))
+  }
+
+  console.log('\nfetchCrossfitWod — previous: false')
+  {
+    const noPrev = { ...fixturePayload, wods: { ...fixturePayload.wods, previous: false as const } }
+    const stub: FetchImpl = async () => jsonResponse(noPrev)
+    const result = await fetchCrossfitWod(D, stub)
+    check('handles previous: false (returns previousUrl null)', null, result?.previousUrl)
+    check('still returns the workout', 'w20260425', result?.externalId)
+  }
+
+  console.log(`\n${pass} passed, ${fail} failed`)
+  if (fail > 0) process.exit(1)
+}
+
+main().catch((err) => {
+  console.error('test runner crashed:', err)
+  process.exit(1)
+})

--- a/apps/api/tests/fixtures/crossfit-wod-260425.json
+++ b/apps/api/tests/fixtures/crossfit-wod-260425.json
@@ -1,0 +1,15 @@
+{
+  "wods": {
+    "id": "w20260425",
+    "cleanID": "20260425",
+    "title": "Saturday 260425",
+    "wodRaw": "For time:\r\n400-meter bear crawl\r\n100 push-ups\r\n50 toes-to-bars\r\n30 thrusters",
+    "wodHtml": "<p>For time:<br />400-meter bear crawl<br />100 push-ups<br />50 toes-to-bars<br />30 thrusters</p>",
+    "publishingState": "published",
+    "publishingDate": "2026-04-24T23:55:00+00:00",
+    "url": "/260425",
+    "topicId": "mainsite.20260425",
+    "previous": { "url": "/260424" },
+    "next": false
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "express": "^4.21.2",
         "fuse.js": "^7.3.0",
         "google-auth-library": "^10.6.1",
-        "jsonwebtoken": "^9.0.2"
+        "jsonwebtoken": "^9.0.2",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
@@ -1776,6 +1777,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1793,6 +1795,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1810,6 +1813,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1827,6 +1831,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1844,6 +1849,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1861,6 +1867,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1878,6 +1885,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1895,6 +1903,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1912,6 +1921,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1929,6 +1939,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1946,6 +1957,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1963,6 +1975,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1980,6 +1993,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1997,6 +2011,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2014,6 +2029,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2031,6 +2047,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2048,6 +2065,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2065,6 +2083,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2082,6 +2101,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2099,6 +2119,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2116,6 +2137,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2133,6 +2155,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2150,6 +2173,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2167,6 +2191,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2184,6 +2209,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2201,6 +2227,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -14677,6 +14704,8 @@
     },
     "node_modules/zod": {
       "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
## Summary
Pure-logic primitives the upcoming CrossFit Mainsite WOD job will compose: the JSON client that talks to crossfit.com, and the best-effort `WorkoutType` classifier. No DB or job wiring in this PR — that's PR4 (the convergence slice).

This is **PR3 of 4** for the CrossFit WOD cron work, parallel-safe with PR1 (#100, schema migration) and PR2 (#102, dispatcher infra) — none of these PRs share files.

## Changes

**New files**
- `apps/api/src/lib/crossfitWodClient.ts` — `fetchCrossfitWod(date, fetchImpl?)`. Calls the undocumented JSON endpoint at `crossfit.com/workout/{YYYY}/{MM}/{DD}` with a 10 s `AbortSignal.timeout`, validates the response with Zod, and returns `null` for every failure mode the caller should treat as "skip this tick":
  - HTTP non-2xx (4xx / 5xx / 429)
  - non-JSON content-type
  - JSON parse failure
  - Zod schema mismatch
  - `publishingState !== "published"` (drafts)
  - fetch throws (network down, abort, etc.)

  The optional `fetchImpl` param lets tests inject a stub. Defaults to global `fetch`.

- `apps/api/src/lib/crossfitWodClassifier.ts` — `classifyWorkoutType(descriptionRaw)`. Pure function, first-match-wins keyword logic:
  - `AMRAP` keyword → `AMRAP`
  - `EMOM` or "every N min(utes)" phrasing → `EMOM`
  - "for time" → `FOR_TIME`
  - else → `METCON` (catch-all)

- `apps/api/tests/fixtures/crossfit-wod-260425.json` — captured response shape from the network-inspection session that confirmed the endpoint exists. Used by the client unit test.

**Modified**
- `apps/api/package.json` — adds `zod` as a direct dep of `@berntracker/api`. Previously available transitively via `@berntracker/types`; declaring it directly makes the dependency explicit.
- `package-lock.json` — npm-resolved zod entry for the api workspace.

## Why this shape
- **Optional `fetchImpl` parameter** instead of stubbing global `fetch` so tests are deterministic and can inspect the URL the client built without monkey-patching globals.
- **Inline Zod schema** (not in `@berntracker/types`) because the CrossFit response shape is an external API contract used only by this client — putting it in the shared types package would bloat web/mobile bundles with API-only schema.
- **Return `null`, don't throw** for all expected failure modes. The job's contract is "do work or no-op cleanly"; it should only exit non-zero on truly unexpected DB / runtime errors so Railway's retry semantics work as intended.

## Tests

**Unit** (`apps/api/tests/crossfit-wod-client.ts`) — 19 cases:
- Happy path against the fixture: returns non-null, hits the date-formatted URL, `externalId` from `wods.id`, title / descriptionRaw / descriptionHtml / scheduledAt / canonicalUrl all preserved, `previousUrl` extracted.
- `publishingState: "draft"` → `null`.
- HTTP 500 / 429 / 404 → `null`.
- Non-JSON content-type → `null`.
- Malformed JSON → `null`.
- Zod schema mismatch (wrong types / missing required) → `null`.
- Fetch throws → `null`.
- `previous: false` (no prior WOD) → still returns the workout, with `previousUrl: null`.

**Unit** (`apps/api/tests/crossfit-wod-classifier.ts`) — 11 cases:
- AMRAP keyword detection (incl. case-insensitive).
- EMOM keyword + "every N minutes" / "every N min" phrasings.
- "For time:" detection (start-of-string and mid-sentence).
- METCON fallback for unknown / empty / narrative-only text.
- Precedence: AMRAP wins over "for time" when both keywords are present.

**Run:**
```bash
cd apps/api && npx tsx tests/crossfit-wod-client.ts
cd apps/api && npx tsx tests/crossfit-wod-classifier.ts
```
Both also run as part of `npm test --workspace=@berntracker/api` (no live API or DB needed for these two — they're pure unit tests sharing the existing `tests/*.ts` glob).

**Verified locally:**
- `npm run build --workspace=@berntracker/api` clean
- `npx turbo lint` clean
- 30/30 unit tests passing

## Sequencing
- PR1 (#100) — schema (`Workout.externalSourceId`). Independent.
- PR2 (#102) — dispatcher infra. Independent.
- **This PR (PR3)** — client + classifier. Independent.
- PR4 — convergence: `crossfit-wod` job composes these primitives, registered in dispatcher's `JOBS` map, plus DB managers and integration test. Depends on PR1 + PR2 + PR3.

Part of #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)