### PR TITLE
feat(api): wire CrossFit Mainsite WOD ingest cron

### DIFF
--- a/apps/api/railway.jobs.toml
+++ b/apps/api/railway.jobs.toml
@@ -1,13 +1,12 @@
-# Railway service config for the background jobs runner.
+# Railway service config for the CrossFit Mainsite WOD ingest cron.
 #
 # One image (Dockerfile.jobs) backs many Railway services — each service
 # overrides startCommand with a different job name. Add a new service per job;
 # all of them share the same image and dispatcher.
 #
-# In this PR (the dispatcher infra slice), startCommand points at the built-in
-# `noop` handler so the service can be smoke-tested end to end. The CrossFit
-# WOD service is wired up in the convergence PR by changing startCommand to
-# `crossfit-wod` once that handler is registered in src/jobs/index.ts.
+# Prerequisite: a Program named "CrossFit Mainsite WOD" must exist in the DB
+# before this service does anything useful. Until then the job logs a warning
+# and exits 0 each tick.
 
 [build]
 dockerfilePath = "apps/api/Dockerfile.jobs"
@@ -17,4 +16,4 @@ buildCommand = ""
 # Railway cron syntax — every 15 minutes. Cadence lives in this file; changing
 # it is a config edit, not a code change.
 cronSchedule = "*/15 * * * *"
-startCommand = "noop"
+startCommand = "crossfit-wod"

--- a/apps/api/src/db/programDbManager.ts
+++ b/apps/api/src/db/programDbManager.ts
@@ -22,3 +22,10 @@ export async function updateProgramById(id: string, data: UpdateProgramData) {
 export async function deleteProgramById(id: string) {
   return prisma.program.delete({ where: { id } })
 }
+
+// Used by the CrossFit Mainsite ingest job to find the public program it
+// writes into. Looked up by exact name (Program has no slug column today —
+// switch to slug if/when one is introduced).
+export async function findProgramByName(name: string) {
+  return prisma.program.findFirst({ where: { name } })
+}

--- a/apps/api/src/db/workoutDbManager.ts
+++ b/apps/api/src/db/workoutDbManager.ts
@@ -11,6 +11,10 @@ interface CreateWorkoutData {
   dayOrder?: number
   movementIds?: string[]
   namedWorkoutId?: string
+  // External ingest jobs (e.g. CrossFit Mainsite cron) set these. The unique
+  // constraint on externalSourceId makes the upsert path idempotent.
+  externalSourceId?: string
+  status?: WorkoutStatus
 }
 
 interface UpdateWorkoutData {
@@ -133,6 +137,10 @@ export async function findWorkoutProgramId(id: string) {
     where: { id },
     select: { programId: true },
   })
+}
+
+export async function findWorkoutByExternalSourceId(externalSourceId: string) {
+  return prisma.workout.findUnique({ where: { externalSourceId } })
 }
 
 export async function updateWorkout(id: string, data: UpdateWorkoutData) {

--- a/apps/api/src/jobs/crossfitWod.ts
+++ b/apps/api/src/jobs/crossfitWod.ts
@@ -1,0 +1,96 @@
+import { WorkoutStatus } from '@berntracker/db'
+import { createLogger } from '../lib/logger.js'
+import {
+  fetchCrossfitWod,
+  type NormalizedCrossfitWod,
+} from '../lib/crossfitWodClient.js'
+import { classifyWorkoutType } from '../lib/crossfitWodClassifier.js'
+import { findProgramByName } from '../db/programDbManager.js'
+import {
+  createWorkoutForProgram,
+  findWorkoutByExternalSourceId,
+} from '../db/workoutDbManager.js'
+
+const log = createLogger('jobs.crossfit-wod')
+
+const PROGRAM_NAME = 'CrossFit Mainsite WOD'
+const EXTERNAL_SOURCE_PREFIX = 'crossfit-mainsite:'
+
+export interface CrossfitWodJobDeps {
+  fetchWod?: (date: Date) => Promise<NormalizedCrossfitWod | null>
+}
+
+/**
+ * Fetches today's CrossFit Mainsite WOD and upserts it into the public
+ * "CrossFit Mainsite WOD" program. Designed for a 15-minute cron tick:
+ *
+ *   - Idempotent: the unique externalSourceId column means a same-day re-run
+ *     short-circuits with a no-op log.
+ *   - Soft-fail on upstream issues: if the program isn't seeded yet, or
+ *     CrossFit returns a draft / 5xx / malformed payload, the function
+ *     resolves cleanly and the next tick retries.
+ *   - Hard-fail on local issues: DB write errors and unexpected exceptions
+ *     propagate so the dispatcher exits non-zero (Railway flags the run).
+ *
+ * `deps.fetchWod` lets tests inject a stub so this can run against a real DB
+ * without hitting crossfit.com. Defaults to the real `fetchCrossfitWod`.
+ */
+export async function runCrossfitWodJob(deps: CrossfitWodJobDeps = {}): Promise<void> {
+  const fetchWod = deps.fetchWod ?? fetchCrossfitWod
+
+  const program = await findProgramByName(PROGRAM_NAME)
+  if (!program) {
+    log.warning(`program "${PROGRAM_NAME}" not found — skipping (seed it before enabling the cron)`)
+    return
+  }
+
+  const today = todayInPacific()
+  const payload = await fetchWod(today)
+  if (!payload) {
+    // Client already logged the reason. Nothing to do this tick.
+    return
+  }
+
+  const externalSourceId = `${EXTERNAL_SOURCE_PREFIX}${payload.externalId}`
+
+  const existing = await findWorkoutByExternalSourceId(externalSourceId)
+  if (existing) {
+    log.info(`${externalSourceId} already saved — no-op`)
+    return
+  }
+
+  const type = classifyWorkoutType(payload.descriptionRaw)
+  await createWorkoutForProgram({
+    programId: program.id,
+    title: payload.title,
+    description: payload.descriptionRaw,
+    type,
+    scheduledAt: new Date(payload.scheduledAt),
+    status: WorkoutStatus.PUBLISHED,
+    externalSourceId,
+  })
+  log.info(`saved ${externalSourceId} (${type})`)
+}
+
+/**
+ * Returns midnight of "today" in America/Los_Angeles, expressed as a UTC Date.
+ * The job uses this to ask the upstream API for today's WOD on Pacific time —
+ * which is when the CrossFit team posts.
+ *
+ * Uses Intl.DateTimeFormat (no Temporal / dayjs dep) — extracts y/m/d in PT,
+ * then constructs a UTC Date from those components. Downstream consumers only
+ * read getUTC*() so the absolute instant is irrelevant.
+ */
+function todayInPacific(now: Date = new Date()): Date {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(now)
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? ''
+  const y = Number(get('year'))
+  const m = Number(get('month'))
+  const d = Number(get('day'))
+  return new Date(Date.UTC(y, m - 1, d))
+}

--- a/apps/api/src/jobs/index.ts
+++ b/apps/api/src/jobs/index.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@berntracker/db'
 import { createLogger } from '../lib/logger.js'
+import { runCrossfitWodJob } from './crossfitWod.js'
 
 const log = createLogger('jobs')
 
@@ -13,6 +14,7 @@ const JOBS: Record<string, JobHandler> = {
   noop: async () => {
     log.info('noop job ran')
   },
+  'crossfit-wod': () => runCrossfitWodJob(),
 }
 
 async function main(): Promise<number> {

--- a/apps/api/tests/crossfit-wod-job.ts
+++ b/apps/api/tests/crossfit-wod-job.ts
@@ -1,0 +1,212 @@
+/**
+ * Integration test for runCrossfitWodJob — exercises the real DB but stubs
+ * the upstream HTTP fetcher.
+ *
+ * Requires: DB accessible via DATABASE_URL.
+ * Run as part of `npm test` from apps/api (or directly via tsx).
+ */
+
+import { prisma } from '@berntracker/db'
+import { runCrossfitWodJob } from '../src/jobs/crossfitWod.js'
+import type { NormalizedCrossfitWod } from '../src/lib/crossfitWodClient.js'
+
+const PROGRAM_NAME = 'CrossFit Mainsite WOD'
+const TS = Date.now()
+// Sentinel string baked into both the externalSourceId and the workout title
+// so this run's rows are easy to clean up even if a previous run died mid-test.
+const SENTINEL = `it-${TS}`
+
+let pass = 0
+let fail = 0
+
+function check(label: string, expected: unknown, actual: unknown) {
+  if (String(expected) === String(actual)) {
+    console.log(`  ✓ ${label}`)
+    pass++
+  } else {
+    console.log(`  ✗ ${label}  [expected=${expected} actual=${actual}]`)
+    fail++
+  }
+}
+
+function fixture(overrides: Partial<NormalizedCrossfitWod> = {}): NormalizedCrossfitWod {
+  return {
+    externalId: `w${SENTINEL}`,
+    title: `Test WOD ${SENTINEL}`,
+    descriptionRaw: 'For time:\n400-meter run\n50 burpees',
+    descriptionHtml: '<p>For time:<br />...</p>',
+    scheduledAt: '2026-04-25T15:00:00+00:00',
+    canonicalUrl: '/test',
+    previousUrl: null,
+    ...overrides,
+  }
+}
+
+let programId = ''
+let createdElsewhere = false
+
+async function setup() {
+  console.log('\n=== Setup ===')
+  // Reuse the public program if it already exists (e.g. seeded by PR0); else
+  // create it for the duration of the test and tear it down at the end.
+  const existing = await prisma.program.findFirst({ where: { name: PROGRAM_NAME } })
+  if (existing) {
+    programId = existing.id
+    createdElsewhere = true
+    console.log(`  reusing existing program ${programId}`)
+  } else {
+    const program = await prisma.program.create({
+      data: { name: PROGRAM_NAME, startDate: new Date('2026-01-01') },
+    })
+    programId = program.id
+    console.log(`  created program ${programId}`)
+  }
+}
+
+async function teardown() {
+  console.log('\n=== Teardown ===')
+  // Only delete workouts created by this test run (matched by sentinel in
+  // externalSourceId), so rows from other tests / real ingest stay put.
+  await prisma.workout.deleteMany({
+    where: { externalSourceId: { contains: SENTINEL } },
+  })
+  if (!createdElsewhere) {
+    await prisma.program.delete({ where: { id: programId } }).catch(() => {})
+  }
+  console.log('  cleaned up')
+}
+
+async function runTests() {
+  console.log('\n=== runCrossfitWodJob — happy path: creates a Workout ===')
+  {
+    const payload = fixture()
+    let calls = 0
+    await runCrossfitWodJob({
+      fetchWod: async () => {
+        calls++
+        return payload
+      },
+    })
+    check('fetchWod called once', 1, calls)
+    const expectedExternalSourceId = `crossfit-mainsite:${payload.externalId}`
+    const w = await prisma.workout.findUnique({
+      where: { externalSourceId: expectedExternalSourceId },
+    })
+    check('workout created', true, w !== null)
+    check('workout has correct externalSourceId', expectedExternalSourceId, w?.externalSourceId)
+    check('workout linked to program', programId, w?.programId)
+    check('workout title preserved', payload.title, w?.title)
+    check('workout description preserved', payload.descriptionRaw, w?.description)
+    check('workout type classified as FOR_TIME', 'FOR_TIME', w?.type)
+    check('workout published (not draft)', 'PUBLISHED', w?.status)
+  }
+
+  console.log('\n=== runCrossfitWodJob — second run with same payload is a no-op ===')
+  {
+    const payload = fixture()
+    const before = await prisma.workout.count({
+      where: { externalSourceId: { contains: SENTINEL } },
+    })
+    await runCrossfitWodJob({ fetchWod: async () => payload })
+    const after = await prisma.workout.count({
+      where: { externalSourceId: { contains: SENTINEL } },
+    })
+    check('no second workout created (idempotent)', before, after)
+  }
+
+  console.log('\n=== runCrossfitWodJob — null payload (e.g. CrossFit 5xx, draft) is a no-op ===')
+  {
+    const before = await prisma.workout.count({
+      where: { externalSourceId: { contains: SENTINEL } },
+    })
+    let threw = false
+    try {
+      await runCrossfitWodJob({ fetchWod: async () => null })
+    } catch {
+      threw = true
+    }
+    check('does not throw on null payload', false, threw)
+    const after = await prisma.workout.count({
+      where: { externalSourceId: { contains: SENTINEL } },
+    })
+    check('no workout created on null payload', before, after)
+  }
+
+  console.log('\n=== runCrossfitWodJob — fetcher throws → exception propagates ===')
+  {
+    let caught: unknown = null
+    try {
+      await runCrossfitWodJob({
+        fetchWod: async () => {
+          throw new Error('upstream broken')
+        },
+      })
+    } catch (err) {
+      caught = err
+    }
+    check('exception from fetcher propagates to caller', true, caught instanceof Error)
+    check('exception message preserved', 'upstream broken', (caught as Error)?.message)
+  }
+
+  console.log('\n=== runCrossfitWodJob — different externalId creates a separate workout ===')
+  {
+    const otherPayload = fixture({
+      externalId: `w${SENTINEL}-other`,
+      title: `Test WOD other ${SENTINEL}`,
+      descriptionRaw: 'AMRAP 12:\n10 pull-ups\n20 push-ups',
+    })
+    await runCrossfitWodJob({ fetchWod: async () => otherPayload })
+    const w = await prisma.workout.findUnique({
+      where: { externalSourceId: `crossfit-mainsite:${otherPayload.externalId}` },
+    })
+    check('second workout created with different externalId', true, w !== null)
+    check('AMRAP description classified as AMRAP', 'AMRAP', w?.type)
+  }
+}
+
+async function runMissingProgramScenario() {
+  console.log('\n=== runCrossfitWodJob — program not found → no-op (no throw) ===')
+  // Save program name out of the way temporarily so the lookup misses, then
+  // restore. Only safe because this test owns the program (created in setup).
+  if (createdElsewhere) {
+    console.log('  (skipping — program existed before test run)')
+    return
+  }
+  const renamedTo = `__hidden_${SENTINEL}__`
+  await prisma.program.update({ where: { id: programId }, data: { name: renamedTo } })
+  try {
+    let threw = false
+    try {
+      await runCrossfitWodJob({
+        fetchWod: async () => {
+          throw new Error('should not be called when program is missing')
+        },
+      })
+    } catch {
+      threw = true
+    }
+    check('program-missing case does not throw', false, threw)
+    check('fetchWod was not called', false, threw) // would have thrown if called
+  } finally {
+    await prisma.program.update({ where: { id: programId }, data: { name: PROGRAM_NAME } })
+  }
+}
+
+async function main() {
+  try {
+    await setup()
+    await runTests()
+    await runMissingProgramScenario()
+  } finally {
+    await teardown()
+    await prisma.$disconnect()
+  }
+  console.log(`\n=== Results: ${pass} passed, ${fail} failed ===\n`)
+  if (fail > 0) process.exit(1)
+}
+
+main().catch(async (err) => {
+  console.error('test runner crashed:', err)
+  await prisma.$disconnect().catch(() => {})
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
The convergence PR — composes the schema column (#100), dispatcher infra (#102), and JSON client + classifier (#103) into a working cron tick. The Railway service flips from `noop` to the real `crossfit-wod` handler.

This is **PR4 of 4** for issue #17. With this merged, every 15 minutes Railway will fetch today's CrossFit Mainsite WOD and idempotently publish it as a Workout in the public **CrossFit Mainsite WOD** program.

## Changes

**New files**
- `apps/api/src/jobs/crossfitWod.ts` — `runCrossfitWodJob({ fetchWod? })`.
  1. Look up the program by name (`"CrossFit Mainsite WOD"`). If missing → log warn + return.
  2. Compute today in `America/Los_Angeles` via `Intl.DateTimeFormat` (CrossFit posts on PT).
  3. Call `fetchCrossfitWod(today)`. If `null` → return (client already logged the reason).
  4. Build `externalSourceId = "crossfit-mainsite:" + payload.externalId`.
  5. `findWorkoutByExternalSourceId` → if exists, log no-op + return.
  6. `classifyWorkoutType(descriptionRaw)`.
  7. `createWorkoutForProgram({ ..., status: PUBLISHED, externalSourceId })`.

  The `fetchWod` injection point exists solely so the integration test can run against a real DB without hitting crossfit.com. Production callers (the dispatcher) pass nothing and the real fetch is used.

- `apps/api/tests/crossfit-wod-job.ts` — DB-backed integration test, 17 assertions:
  - happy path → one Workout created with the right `externalSourceId`, `programId`, `title`, `description`, `type=FOR_TIME`, `status=PUBLISHED`
  - second run with same payload → no-op (count unchanged)
  - null payload (CrossFit 5xx / draft / parse failure) → no throw, no row
  - fetcher throws → exception propagates (so the dispatcher exits non-zero)
  - distinct `externalId` → second Workout created, classifier picks AMRAP correctly
  - program missing → no throw, fetcher never called

**Modified**
- `apps/api/src/jobs/index.ts` — `crossfit-wod` registered in `JOBS` alongside `noop`.
- `apps/api/src/db/workoutDbManager.ts` — `findWorkoutByExternalSourceId`; `CreateWorkoutData` now accepts optional `externalSourceId` and `status`.
- `apps/api/src/db/programDbManager.ts` — `findProgramByName` for the public-program lookup. (`Program` has no `slug` column today; switch to slug if/when one's introduced.)
- `apps/api/railway.jobs.toml` — `startCommand` flipped from `noop` to `crossfit-wod`. Comment now documents the program-seed prerequisite.

## Soft-fail vs hard-fail (matches #17 spec)
| Condition | Behaviour |
|---|---|
| Program not seeded yet | log warn, exit 0 — next tick retries |
| Upstream HTTP / parse / draft (`null` payload) | client already logged, job exits 0 |
| WOD already saved (idempotent re-run) | log info no-op, exit 0 |
| DB write error / unexpected exception | propagates → dispatcher exits non-zero → Railway flags the run |

## Tests

**Unit** (existed pre-PR, re-verified — 30 cases):
- `apps/api/tests/crossfit-wod-classifier.ts` — 11 cases.
- `apps/api/tests/crossfit-wod-client.ts` — 19 cases.

**Integration — new** (`apps/api/tests/crossfit-wod-job.ts` — 17 assertions):
- Happy path: Workout created with correct externalSourceId, programId, title, description, type=FOR_TIME, status=PUBLISHED.
- Second run with same payload is a no-op (idempotent on unique constraint).
- Null payload from fetcher → no throw, no row created.
- Fetcher throws → exception propagates.
- Different externalId → second Workout created, AMRAP description classified as AMRAP.
- Program missing → no throw, fetcher not called.

Test discovers/uses the existing `tests/*.ts` glob in `npm test --workspace=@berntracker/api`. It seeds and tears down its own program/workouts; if a real `"CrossFit Mainsite WOD"` program already exists (e.g. seeded by an admin), the test reuses it and only deletes workouts whose `externalSourceId` matches its sentinel.

**Run:**
```bash
npm test --workspace=@berntracker/api   # all tests, requires API running on :3000 + DB
# or just this file:
cd apps/api && npx dotenv-cli -e ../../.env -- npx tsx tests/crossfit-wod-job.ts
```

**Verified locally:**
- `npm run build --workspace=@berntracker/api` clean
- `npx turbo lint` clean
- `tests/crossfit-wod-job.ts`: 17/17 passing
- `tests/crossfit-wod-classifier.ts`: 11/11 passing
- `tests/crossfit-wod-client.ts`: 19/19 passing
- Dispatcher smoke against empty DB: `node dist/jobs/index.js crossfit-wod` → logs `"program not found — skipping"`, exits 0.

## Operational notes
- **Required before the cron does anything in prod:** create a `Program` row with `name = "CrossFit Mainsite WOD"`. Until then every tick is a clean no-op. Easiest path is via the new Programs UI from #95 (or directly in Prisma Studio).
- **Cadence change is config-only:** edit `cronSchedule` in `apps/api/railway.jobs.toml`, no code change needed.
- **Adding a future job:** drop a handler under `apps/api/src/jobs/`, register it in the `JOBS` map, add a Railway service that points at the same `Dockerfile.jobs` with a different `startCommand`. The pattern's documented in CLAUDE.md's "Background jobs" section.

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)