### PR TITLE
feat(api): auto-create CrossFit Mainsite WOD program on first run

### DIFF
--- a/apps/api/src/db/programDbManager.ts
+++ b/apps/api/src/db/programDbManager.ts
@@ -29,3 +29,10 @@ export async function deleteProgramById(id: string) {
 export async function findProgramByName(name: string) {
   return prisma.program.findFirst({ where: { name } })
 }
+
+// Used by the CrossFit Mainsite ingest job to bootstrap the public program on
+// first run. Program.startDate is required by the schema; defaults to today
+// since the program tracks daily WODs going forward from creation.
+export async function createProgramByName(name: string, startDate: Date = new Date()) {
+  return prisma.program.create({ data: { name, startDate } })
+}

--- a/apps/api/src/jobs/crossfitWod.ts
+++ b/apps/api/src/jobs/crossfitWod.ts
@@ -5,7 +5,7 @@ import {
   type NormalizedCrossfitWod,
 } from '../lib/crossfitWodClient.js'
 import { classifyWorkoutType } from '../lib/crossfitWodClassifier.js'
-import { findProgramByName } from '../db/programDbManager.js'
+import { createProgramByName, findProgramByName } from '../db/programDbManager.js'
 import {
   createWorkoutForProgram,
   findWorkoutByExternalSourceId,
@@ -26,9 +26,11 @@ export interface CrossfitWodJobDeps {
  *
  *   - Idempotent: the unique externalSourceId column means a same-day re-run
  *     short-circuits with a no-op log.
- *   - Soft-fail on upstream issues: if the program isn't seeded yet, or
- *     CrossFit returns a draft / 5xx / malformed payload, the function
- *     resolves cleanly and the next tick retries.
+ *   - Self-bootstrapping: creates the public program on first run if it
+ *     doesn't exist yet, so no manual seed step is required.
+ *   - Soft-fail on upstream issues: if CrossFit returns a draft / 5xx /
+ *     malformed payload, the function resolves cleanly and the next tick
+ *     retries.
  *   - Hard-fail on local issues: DB write errors and unexpected exceptions
  *     propagate so the dispatcher exits non-zero (Railway flags the run).
  *
@@ -38,10 +40,10 @@ export interface CrossfitWodJobDeps {
 export async function runCrossfitWodJob(deps: CrossfitWodJobDeps = {}): Promise<void> {
   const fetchWod = deps.fetchWod ?? fetchCrossfitWod
 
-  const program = await findProgramByName(PROGRAM_NAME)
+  let program = await findProgramByName(PROGRAM_NAME)
   if (!program) {
-    log.warning(`program "${PROGRAM_NAME}" not found — skipping (seed it before enabling the cron)`)
-    return
+    log.info(`program "${PROGRAM_NAME}" not found — creating it`)
+    program = await createProgramByName(PROGRAM_NAME)
   }
 
   const today = todayInPacific()

--- a/apps/api/tests/crossfit-wod-job.ts
+++ b/apps/api/tests/crossfit-wod-job.ts
@@ -165,29 +165,49 @@ async function runTests() {
 }
 
 async function runMissingProgramScenario() {
-  console.log('\n=== runCrossfitWodJob — program not found → no-op (no throw) ===')
-  // Save program name out of the way temporarily so the lookup misses, then
-  // restore. Only safe because this test owns the program (created in setup).
+  console.log('\n=== runCrossfitWodJob — program not found → auto-creates program and proceeds ===')
+  // Hide the existing program by renaming it so the name lookup misses. The
+  // job should then create a fresh program with PROGRAM_NAME and write the
+  // workout into it. Only safe because this test owns the program (setup()
+  // skips this branch when an external program already existed).
   if (createdElsewhere) {
     console.log('  (skipping — program existed before test run)')
     return
   }
   const renamedTo = `__hidden_${SENTINEL}__`
   await prisma.program.update({ where: { id: programId }, data: { name: renamedTo } })
+  let createdProgramId: string | null = null
+  let createdWorkoutId: string | null = null
   try {
+    const payload = fixture({
+      externalId: `w${SENTINEL}-bootstrap`,
+      title: `Test WOD bootstrap ${SENTINEL}`,
+    })
     let threw = false
     try {
-      await runCrossfitWodJob({
-        fetchWod: async () => {
-          throw new Error('should not be called when program is missing')
-        },
-      })
+      await runCrossfitWodJob({ fetchWod: async () => payload })
     } catch {
       threw = true
     }
     check('program-missing case does not throw', false, threw)
-    check('fetchWod was not called', false, threw) // would have thrown if called
+
+    const newProgram = await prisma.program.findFirst({ where: { name: PROGRAM_NAME } })
+    check('job created program with expected name', true, newProgram !== null)
+    createdProgramId = newProgram?.id ?? null
+
+    const w = await prisma.workout.findUnique({
+      where: { externalSourceId: `crossfit-mainsite:${payload.externalId}` },
+    })
+    check('workout created against the new program', true, w !== null)
+    check('workout linked to the auto-created program', createdProgramId, w?.programId)
+    createdWorkoutId = w?.id ?? null
   } finally {
+    if (createdWorkoutId) {
+      await prisma.workout.delete({ where: { id: createdWorkoutId } }).catch(() => {})
+    }
+    if (createdProgramId && createdProgramId !== programId) {
+      await prisma.program.delete({ where: { id: createdProgramId } }).catch(() => {})
+    }
     await prisma.program.update({ where: { id: programId }, data: { name: PROGRAM_NAME } })
   }
 }


### PR DESCRIPTION
## Summary

The CrossFit Mainsite WOD ingest job (`apps/api/src/jobs/crossfitWod.ts`) used to bail with a warning when the public `CrossFit Mainsite WOD` program didn't exist, forcing a manual seed step before the cron could be enabled. It now bootstraps the program inline on first run so the job is self-contained on a fresh DB.

- New manager helper `createProgramByName(name, startDate?)` in `apps/api/src/db/programDbManager.ts` — defaults `startDate` to today since the program tracks daily WODs forward from creation.
- `runCrossfitWodJob` calls `createProgramByName(PROGRAM_NAME)` when `findProgramByName` returns null, then proceeds with the rest of the tick (fetch + classify + create workout).
- Job docstring updated to call out the self-bootstrapping behavior.

## Tests

**API integration** (`apps/api/tests/crossfit-wod-job.ts`):
- Existing happy path / idempotency / null payload / fetcher-throws / different-externalId cases unchanged.
- Rewrote the missing-program scenario: hides the seeded program by renaming it, runs the job with a fixture payload, then asserts:
  - The job did not throw.
  - A program with the expected name now exists in the DB.
  - The workout was created and linked to the auto-created program.
  - Cleanup deletes the auto-created workout + program in `finally` and restores the original program name.

**Build**:
- `npm run build --workspace=@berntracker/api` passes.

**Not automated / manual verification needed:**
- [ ] Run the integration test against a live DB: `npm run test --workspace=@berntracker/api` (requires API on `:3000` + DB).

## Notes for reviewer

`Program.name` has no unique constraint, so two cron ticks racing against an empty DB could each create a duplicate program. At the 15-min cadence this is extremely unlikely, but if we want to harden it, adding `@unique` to `Program.name` would be its own isolated migration PR (per the schema-migration policy in CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)