### PR TITLE
feat(api): CrossFit Mainsite WOD ingest cron (self-bootstrapping)

### DIFF
--- a/apps/api/src/db/programDbManager.ts
+++ b/apps/api/src/db/programDbManager.ts
@@ -23,9 +23,23 @@ export async function deleteProgramById(id: string) {
   return prisma.program.delete({ where: { id } })
 }
 
-// Used by the CrossFit Mainsite ingest job to find the public program it
-// writes into. Looked up by exact name (Program has no slug column today —
-// switch to slug if/when one is introduced).
-export async function findProgramByName(name: string) {
-  return prisma.program.findFirst({ where: { name } })
+interface EnsureProgramDefaults {
+  startDate: Date
+  description?: string
+}
+
+// Used by the CrossFit Mainsite ingest job: returns the public program it
+// writes into, creating it on first run so the cron is self-bootstrapping.
+// Looked up by exact name (Program has no slug column today — switch to slug
+// if/when one is introduced).
+export async function ensureProgramByName(name: string, defaults: EnsureProgramDefaults) {
+  const existing = await prisma.program.findFirst({ where: { name } })
+  if (existing) return existing
+  return prisma.program.create({
+    data: {
+      name,
+      startDate: defaults.startDate,
+      description: defaults.description,
+    },
+  })
 }

--- a/apps/api/src/jobs/crossfitWod.ts
+++ b/apps/api/src/jobs/crossfitWod.ts
@@ -5,7 +5,7 @@ import {
   type NormalizedCrossfitWod,
 } from '../lib/crossfitWodClient.js'
 import { classifyWorkoutType } from '../lib/crossfitWodClassifier.js'
-import { findProgramByName } from '../db/programDbManager.js'
+import { ensureProgramByName } from '../db/programDbManager.js'
 import {
   createWorkoutForProgram,
   findWorkoutByExternalSourceId,
@@ -26,9 +26,12 @@ export interface CrossfitWodJobDeps {
  *
  *   - Idempotent: the unique externalSourceId column means a same-day re-run
  *     short-circuits with a no-op log.
- *   - Soft-fail on upstream issues: if the program isn't seeded yet, or
- *     CrossFit returns a draft / 5xx / malformed payload, the function
- *     resolves cleanly and the next tick retries.
+ *   - Self-bootstrapping: the destination Program is created on first run if
+ *     it doesn't already exist, so a fresh environment doesn't need a manual
+ *     seed step before the cron is enabled.
+ *   - Soft-fail on upstream issues: if CrossFit returns a draft / 5xx /
+ *     malformed payload, the function resolves cleanly and the next tick
+ *     retries.
  *   - Hard-fail on local issues: DB write errors and unexpected exceptions
  *     propagate so the dispatcher exits non-zero (Railway flags the run).
  *
@@ -38,13 +41,12 @@ export interface CrossfitWodJobDeps {
 export async function runCrossfitWodJob(deps: CrossfitWodJobDeps = {}): Promise<void> {
   const fetchWod = deps.fetchWod ?? fetchCrossfitWod
 
-  const program = await findProgramByName(PROGRAM_NAME)
-  if (!program) {
-    log.warning(`program "${PROGRAM_NAME}" not found — skipping (seed it before enabling the cron)`)
-    return
-  }
-
   const today = todayInPacific()
+  const program = await ensureProgramByName(PROGRAM_NAME, {
+    startDate: today,
+    description: 'Daily Workout of the Day published by CrossFit HQ at crossfit.com.',
+  })
+
   const payload = await fetchWod(today)
   if (!payload) {
     // Client already logged the reason. Nothing to do this tick.

--- a/apps/api/tests/crossfit-wod-job.ts
+++ b/apps/api/tests/crossfit-wod-job.ts
@@ -164,39 +164,46 @@ async function runTests() {
   }
 }
 
-async function runMissingProgramScenario() {
-  console.log('\n=== runCrossfitWodJob — program not found → no-op (no throw) ===')
-  // Save program name out of the way temporarily so the lookup misses, then
-  // restore. Only safe because this test owns the program (created in setup).
+async function runAutoCreateProgramScenario() {
+  console.log('\n=== runCrossfitWodJob — program missing → auto-created ===')
+  // Only safe to delete the program when the test owns it (created in setup).
+  // If a real seeded program existed before the test, leave it alone.
   if (createdElsewhere) {
     console.log('  (skipping — program existed before test run)')
     return
   }
-  const renamedTo = `__hidden_${SENTINEL}__`
-  await prisma.program.update({ where: { id: programId }, data: { name: renamedTo } })
-  try {
-    let threw = false
-    try {
-      await runCrossfitWodJob({
-        fetchWod: async () => {
-          throw new Error('should not be called when program is missing')
-        },
-      })
-    } catch {
-      threw = true
-    }
-    check('program-missing case does not throw', false, threw)
-    check('fetchWod was not called', false, threw) // would have thrown if called
-  } finally {
-    await prisma.program.update({ where: { id: programId }, data: { name: PROGRAM_NAME } })
-  }
+  // Drop the program so the job has to create it. Workouts under it get
+  // programId=null via onDelete: SetNull and are still cleaned up by the
+  // sentinel match in teardown.
+  await prisma.program.delete({ where: { id: programId } })
+  const beforeCount = await prisma.program.count({ where: { name: PROGRAM_NAME } })
+  check('program absent before run', 0, beforeCount)
+
+  const payload = fixture({ externalId: `w${SENTINEL}-autocreate` })
+  await runCrossfitWodJob({ fetchWod: async () => payload })
+
+  const created = await prisma.program.findFirst({ where: { name: PROGRAM_NAME } })
+  check('program auto-created by job', true, created !== null)
+  check(
+    'auto-created program has expected description',
+    'Daily Workout of the Day published by CrossFit HQ at crossfit.com.',
+    created?.description,
+  )
+  const w = await prisma.workout.findUnique({
+    where: { externalSourceId: `crossfit-mainsite:${payload.externalId}` },
+  })
+  check('workout written under auto-created program', created?.id, w?.programId)
+
+  // Reassign so teardown deletes the program the job created (we still "own"
+  // the program for this test — just a fresh row now).
+  if (created) programId = created.id
 }
 
 async function main() {
   try {
     await setup()
     await runTests()
-    await runMissingProgramScenario()
+    await runAutoCreateProgramScenario()
   } finally {
     await teardown()
     await prisma.$disconnect()


### PR DESCRIPTION
## Summary

- Wires the CrossFit Mainsite WOD ingest cron end-to-end: dispatcher entry, JSON client + classifier (already merged via earlier PRs in #17), DB manager extensions, and the `crossfit-wod` job that fetches today's WOD and writes a PUBLISHED `Workout` to the public `CrossFit Mainsite WOD` program. Idempotent on `externalSourceId = "crossfit-mainsite:<wodId>"`.
- **Self-bootstrapping:** the job creates the public `CrossFit Mainsite WOD` program on first run if it doesn't exist (was previously a manual seed prerequisite — first cron tick on a fresh env would log a warning and skip). Auto-created Program gets `startDate=today` and a short description.
- Railway cron config flipped from `noop` to `crossfit-wod` at `*/15 * * * *`.

Refs #17.

## Tests

**API integration** (`apps/api/tests/crossfit-wod-job.ts`):
- Happy path — fetcher returns a payload → one `Workout` is created with the right `externalSourceId`, `programId`, `title`, `description`, classified `type`, and `PUBLISHED` status.
- Idempotent re-run — second invocation with the same payload is a no-op (no second workout row).
- Null payload — fetcher returning `null` (CrossFit 5xx, draft state) is a no-op, no throw.
- Fetcher throws — exception propagates to the dispatcher (so Railway flags the run non-zero).
- Distinct `externalId` — different payload creates a separate workout; AMRAP description classifies as `AMRAP`.
- **Auto-create program (new in this PR):** when the program is absent at run time, the job creates it with the expected description and writes the workout under the newly created program.

**Not automated / manual verification needed:**
- [ ] One-time live tick against crossfit.com after deploy — confirm the first cron run on the Railway service writes today's WOD into the auto-created program.