### PR TITLE
chore: rename BernTracker to WODalytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # ─── Database ─────────────────────────────────────────────────────────────────
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/berntracker"
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/wodalytics"
 
 # ─── API ──────────────────────────────────────────────────────────────────────
 PORT=3000
@@ -7,8 +7,8 @@ JWT_SECRET="change-me-in-production"
 JWT_REFRESH_SECRET="also-change-me-in-production"
 NODE_ENV="development"
 # Comma-separated list of origins the API will accept CORS requests from.
-# Docker compose overrides this to include http://local.berntracker.com.
-# In Railway QA / prod, set to the deployed web's origin (e.g. https://berntracker-qa-web.up.railway.app).
+# Docker compose overrides this to include http://local.wodalytics.com.
+# In Railway QA / prod, set to the deployed web's origin (e.g. https://wodalytics-qa-web.up.railway.app).
 ALLOWED_ORIGINS="http://localhost:5173"
 
 # ─── Auth (Slice 2) ────────────────────────────────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-BernTracker is a CrossFit workout tracking tool for gym members and trainers.
+WODalytics is a CrossFit workout tracking tool for gym members and trainers.
 
 ## Tech stack
 
@@ -21,7 +21,7 @@ BernTracker is a CrossFit workout tracking tool for gym members and trainers.
 ## Monorepo structure
 
 ```
-BernTracker/
+WODalytics/
 ├── apps/
 │   ├── api/          # Express API (port 3000)
 │   ├── web/          # Vite admin portal (port 5173)
@@ -53,7 +53,7 @@ npm run db:studio     # open Prisma Studio
 
 ## Worktree development — running dev + tests in parallel
 
-When working in a `git worktree` (e.g. `.claude/worktrees/<branch>`), the default fixed ports (API on 3000, web on 5173) collide with anything already running — the Docker `berntracker-api` container, another worktree's dev stack, or a previous Claude session. **Use the worktree-aware scripts** so each worktree gets its own pair of ports and never blocks another.
+When working in a `git worktree` (e.g. `.claude/worktrees/<branch>`), the default fixed ports (API on 3000, web on 5173) collide with anything already running — the Docker `wodalytics-api` container, another worktree's dev stack, or a previous Claude session. **Use the worktree-aware scripts** so each worktree gets its own pair of ports and never blocks another.
 
 ### Workflow
 
@@ -75,10 +75,10 @@ When working in a `git worktree` (e.g. `.claude/worktrees/<branch>`), the defaul
 3. **Manually invoke the underlying commands** (escape hatch — only when `test:worktree` doesn't fit). Note: `node -p require(...)` does **not** work on `.dev-ports.local` because the `.local` extension isn't registered for JSON. Read it explicitly:
    ```bash
    API_URL="$(node -e 'console.log(JSON.parse(require("fs").readFileSync(".dev-ports.local")).apiUrl + "/api")')" \
-     npm run test --workspace=@berntracker/api
+     npm run test --workspace=@wodalytics/api
 
    WEB_URL="$(node -e 'console.log(JSON.parse(require("fs").readFileSync(".dev-ports.local")).webUrl)')" \
-     npm run test:e2e --workspace=@berntracker/web -- tests/programs.spec.ts
+     npm run test:e2e --workspace=@wodalytics/web -- tests/programs.spec.ts
    ```
 
 ### What Claude must do before saying "all tests pass"
@@ -122,29 +122,29 @@ When an engineer asks for help setting up the project, use the README Getting St
 ### Steps that require manual action from the engineer
 - Installing Homebrew, Node.js, Git, or Docker Desktop — requires system-level install
 - **Starting Docker Desktop** — must be opened as a GUI app before any `docker` commands work; if the engineer sees `dial unix /var/run/docker.sock: no such file or directory`, Docker Desktop is not running
-- **Running `docker run --name berntracker-db ...`** — creates the Postgres container; only needed once. On subsequent sessions: `docker start berntracker-db`
+- **Running `docker run --name wodalytics-db ...`** — creates the Postgres container; only needed once. On subsequent sessions: `docker start wodalytics-db`
 - **Copying `.env.example` → `.env`** — file contains secrets and must be created manually
 - **Adding local DNS entries** — append to `/etc/hosts` so browser requests to the containerised stack resolve to the local nginx proxy. Requires `sudo`:
   ```bash
-  echo "127.0.0.1 local.berntracker.com db-studio.local.berntracker.com" | sudo tee -a /etc/hosts
+  echo "127.0.0.1 local.wodalytics.com db-studio.local.wodalytics.com" | sudo tee -a /etc/hosts
   ```
   Once set, `docker compose up --build` exposes:
-  - Web: `http://local.berntracker.com`
-  - API: `http://local.berntracker.com/api/*` (same origin as web, no CORS)
-  - Prisma Studio: `http://db-studio.local.berntracker.com`
+  - Web: `http://local.wodalytics.com`
+  - API: `http://local.wodalytics.com/api/*` (same origin as web, no CORS)
+  - Prisma Studio: `http://db-studio.local.wodalytics.com`
 - Installing Expo Go on a physical device
 
 ### Common setup errors and fixes
 | Error | Cause | Fix |
 |---|---|---|
 | `dial unix /var/run/docker.sock: no such file or directory` | Docker Desktop not running | Open Docker Desktop and wait for it to start |
-| `Unable to find image 'berntracker-db:latest'` | Ran `docker run berntracker-db` instead of the full command | Run the full `docker run` command with `postgres:16` as the image |
-| `P1001: Can't reach database server at localhost:5432` | Postgres container not running | `docker start berntracker-db` |
+| `Unable to find image 'wodalytics-db:latest'` | Ran `docker run wodalytics-db` instead of the full command | Run the full `docker run` command with `postgres:16` as the image |
+| `P1001: Can't reach database server at localhost:5432` | Postgres container not running | `docker start wodalytics-db` |
 | `Environment variable not found: DATABASE_URL` | `.env` file missing | `cp .env.example .env` from repo root |
 | `command not found: turbo` | Dependencies not installed | `npm install` from repo root |
 | `ConfigError: The expected package.json path: .../apps/mobile/package.json does not exist` | `expo start` run from repo root, or `npm install` not run after adding mobile workspace | Run from `apps/mobile`: `cd apps/mobile && npx expo start`. If new workspace was added, run `npm install` from root first to register the symlink. |
-| `DNS_PROBE_FINISHED_NXDOMAIN` / `This site can't be reached` for `local.berntracker.com` | `/etc/hosts` entries missing | Add the `127.0.0.1 local.berntracker.com db-studio.local.berntracker.com` entry to `/etc/hosts` (see manual steps above) |
-| `Bind for 0.0.0.0:80 failed: port is already allocated` | Port 80 in use by another process | Stop the conflicting process, or change the proxy `ports:` in `docker-compose.yml` from `80:80` to `8080:80` (URLs become `local.berntracker.com:8080`) |
+| `DNS_PROBE_FINISHED_NXDOMAIN` / `This site can't be reached` for `local.wodalytics.com` | `/etc/hosts` entries missing | Add the `127.0.0.1 local.wodalytics.com db-studio.local.wodalytics.com` entry to `/etc/hosts` (see manual steps above) |
+| `Bind for 0.0.0.0:80 failed: port is already allocated` | Port 80 in use by another process | Stop the conflicting process, or change the proxy `ports:` in `docker-compose.yml` from `80:80` to `8080:80` (URLs become `local.wodalytics.com:8080`) |
 
 ## Architecture
 
@@ -216,7 +216,7 @@ Each job is its own Railway service: same image (`apps/api/Dockerfile.jobs`), di
 2. Register it in the dispatcher's `JOBS` map in `src/jobs/index.ts`.
 3. Add a `railway.<name>.toml` (or update `railway.jobs.toml`) with the desired `startCommand` and `cronSchedule`.
 
-**Local invocation:** `npm run build --workspace=@berntracker/api && npm run job --workspace=@berntracker/api -- <name>`.
+**Local invocation:** `npm run build --workspace=@wodalytics/api && npm run job --workspace=@wodalytics/api -- <name>`.
 
 The Express API service does **not** import job code at runtime — the two services share modules under `src/lib/` and `src/db/`, but have separate entrypoints and separate Railway deployments. A job failure cannot affect the user-facing API.
 ## Design system (web)
@@ -316,7 +316,7 @@ Located in `apps/api/tests/`. Each file is a self-contained TypeScript script th
 
 **Run:**
 ```bash
-npm run test --workspace=@berntracker/api
+npm run test --workspace=@wodalytics/api
 # or from apps/api:
 cd apps/api && npx dotenv-cli -e ../../.env -- sh -c 'for f in tests/*.ts; do npx tsx "$f" || exit 1; done'
 ```
@@ -335,7 +335,7 @@ Located in `apps/web/src/**/*.test.tsx`. Each test file lives next to the compon
 
 **Run:**
 ```bash
-npm run test:unit --workspace=@berntracker/web
+npm run test:unit --workspace=@wodalytics/web
 # or from apps/web:
 cd apps/web && npx vitest run
 ```
@@ -365,8 +365,8 @@ Located in `apps/web/tests/`. Each spec file uses Playwright and seeds DB fixtur
 
 **Run:**
 ```bash
-npm run test --workspace=@berntracker/web   # runs unit tests first, then E2E
-npm run test:e2e --workspace=@berntracker/web  # E2E only
+npm run test --workspace=@wodalytics/web   # runs unit tests first, then E2E
+npm run test:e2e --workspace=@wodalytics/web  # E2E only
 # or from apps/web:
 cd apps/web && npx dotenv-cli -e ../../.env -- npx playwright test
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BernTracker
+# WODalytics
 
 A CrossFit workout tracking tool for gym members and trainers.
 
@@ -108,15 +108,15 @@ A containerization tool that packages software and its dependencies into an isol
 
 ```bash
 # First time — start the database (runs in the background)
-docker run --name berntracker-db \
+docker run --name wodalytics-db \
   -e POSTGRES_PASSWORD=postgres \
-  -e POSTGRES_DB=berntracker \
+  -e POSTGRES_DB=wodalytics \
   -p 5432:5432 \
   -d postgres:16
 
 # After the container exists — just start/stop it
-docker start berntracker-db
-docker stop berntracker-db
+docker start wodalytics-db
+docker stop wodalytics-db
 
 # Check if it's running
 docker ps
@@ -129,7 +129,7 @@ docker ps
 ## Monorepo structure
 
 ```
-BernTracker/
+WODalytics/
 ├── apps/
 │   ├── api/          # Express API (port 3000)
 │   ├── web/          # Vite admin portal (port 5173)

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -15,7 +15,7 @@ COPY packages/ ./packages/
 COPY apps/api/ ./apps/api/
 
 RUN npx prisma generate --schema=packages/db/prisma/schema.prisma
-RUN npx turbo build --filter=@berntracker/api
+RUN npx turbo build --filter=@wodalytics/api
 
 # ── Stage 2: runtime ─────────────────────────────────────────────────────────
 FROM node:22-alpine AS runtime

--- a/apps/api/Dockerfile.jobs
+++ b/apps/api/Dockerfile.jobs
@@ -15,7 +15,7 @@ COPY packages/ ./packages/
 COPY apps/api/ ./apps/api/
 
 RUN npx prisma generate --schema=packages/db/prisma/schema.prisma
-RUN npx turbo build --filter=@berntracker/api
+RUN npx turbo build --filter=@wodalytics/api
 
 # ── Stage 2: runtime ─────────────────────────────────────────────────────────
 FROM node:22-alpine AS runtime

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@berntracker/api",
+  "name": "@wodalytics/api",
   "version": "0.0.1",
   "private": true,
   "scripts": {
@@ -10,8 +10,8 @@
     "test": "NODE_OPTIONS='--conditions=source' npx dotenv-cli -e ../../.env -- sh -c 'for f in tests/*.ts; do npx tsx \"$f\" || exit 1; done'"
   },
   "dependencies": {
-    "@berntracker/db": "*",
-    "@berntracker/types": "*",
+    "@wodalytics/db": "*",
+    "@wodalytics/types": "*",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/apps/api/scripts/backfillCrossfitWods.ts
+++ b/apps/api/scripts/backfillCrossfitWods.ts
@@ -15,7 +15,7 @@
  * logs read top-to-bottom).
  */
 
-import { prisma, WorkoutStatus } from '@berntracker/db'
+import { prisma, WorkoutStatus } from '@wodalytics/db'
 import { createLogger } from '../src/lib/logger.js'
 import { fetchCrossfitWod } from '../src/lib/crossfitWodClient.js'
 import { classifyWorkoutType } from '../src/lib/crossfitWodClassifier.js'

--- a/apps/api/src/db/gymDbManager.ts
+++ b/apps/api/src/db/gymDbManager.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@berntracker/db'
+import { prisma } from '@wodalytics/db'
 
 export async function createGymAndAddOwnerMember(
   data: { name: string; slug: string; timezone?: string },

--- a/apps/api/src/db/gymProgramDbManager.ts
+++ b/apps/api/src/db/gymProgramDbManager.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@berntracker/db'
+import { prisma } from '@wodalytics/db'
 
 interface CreateProgramData {
   name: string

--- a/apps/api/src/db/movementDbManager.ts
+++ b/apps/api/src/db/movementDbManager.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@berntracker/db'
+import { prisma } from '@wodalytics/db'
 import Fuse from 'fuse.js'
 
 const movementBaseSelect = {

--- a/apps/api/src/db/namedWorkoutDbManager.ts
+++ b/apps/api/src/db/namedWorkoutDbManager.ts
@@ -1,5 +1,5 @@
-import { prisma } from '@berntracker/db'
-import type { WorkoutCategory, WorkoutType } from '@berntracker/db'
+import { prisma } from '@wodalytics/db'
+import type { WorkoutCategory, WorkoutType } from '@wodalytics/db'
 
 const templateWorkoutSelect = {
   select: {

--- a/apps/api/src/db/programDbManager.ts
+++ b/apps/api/src/db/programDbManager.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@berntracker/db'
+import { prisma } from '@wodalytics/db'
 
 interface UpdateProgramData {
   name?: string

--- a/apps/api/src/db/resultDbManager.ts
+++ b/apps/api/src/db/resultDbManager.ts
@@ -1,5 +1,5 @@
-import { prisma } from '@berntracker/db'
-import type { WorkoutLevel, WorkoutGender, WorkoutType, Prisma } from '@berntracker/db'
+import { prisma } from '@wodalytics/db'
+import type { WorkoutLevel, WorkoutGender, WorkoutType, Prisma } from '@wodalytics/db'
 
 interface CreateResultData {
   userId: string

--- a/apps/api/src/db/userGymDbManager.ts
+++ b/apps/api/src/db/userGymDbManager.ts
@@ -1,5 +1,5 @@
-import { prisma } from '@berntracker/db'
-import type { Role } from '@berntracker/db'
+import { prisma } from '@wodalytics/db'
+import type { Role } from '@wodalytics/db'
 
 export async function findMembersWithProgramSubscriptionsByGymId(gymId: string) {
   const memberships = await prisma.userGym.findMany({

--- a/apps/api/src/db/userProgramDbManager.ts
+++ b/apps/api/src/db/userProgramDbManager.ts
@@ -1,4 +1,4 @@
-import { prisma, ProgramRole } from '@berntracker/db'
+import { prisma, ProgramRole } from '@wodalytics/db'
 
 export async function findProgramById(id: string) {
   return prisma.program.findUnique({ where: { id } })

--- a/apps/api/src/db/workoutDbManager.ts
+++ b/apps/api/src/db/workoutDbManager.ts
@@ -1,6 +1,6 @@
-import { prisma } from '@berntracker/db'
-import { WorkoutStatus } from '@berntracker/db'
-import type { WorkoutType } from '@berntracker/db'
+import { prisma } from '@wodalytics/db'
+import { WorkoutStatus } from '@wodalytics/db'
+import type { WorkoutType } from '@wodalytics/db'
 
 interface CreateWorkoutData {
   programId?: string

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,7 +1,7 @@
 import express, { type Request, type Response, type NextFunction } from 'express'
 import cors from 'cors'
 import cookieParser from 'cookie-parser'
-import { prisma } from '@berntracker/db'
+import { prisma } from '@wodalytics/db'
 import { authRouter } from './routes/auth.js'
 import gymsRouter from './routes/gyms'
 import programsRouter from './routes/programs'

--- a/apps/api/src/jobs/crossfitWod.ts
+++ b/apps/api/src/jobs/crossfitWod.ts
@@ -1,4 +1,4 @@
-import { WorkoutStatus } from '@berntracker/db'
+import { WorkoutStatus } from '@wodalytics/db'
 import { createLogger } from '../lib/logger.js'
 import {
   fetchCrossfitWod,

--- a/apps/api/src/jobs/index.ts
+++ b/apps/api/src/jobs/index.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@berntracker/db'
+import { prisma } from '@wodalytics/db'
 import { createLogger } from '../lib/logger.js'
 import { runCrossfitWodJob } from './crossfitWod.js'
 

--- a/apps/api/src/lib/crossfitWodClassifier.ts
+++ b/apps/api/src/lib/crossfitWodClassifier.ts
@@ -1,4 +1,4 @@
-import type { WorkoutType } from '@berntracker/db'
+import type { WorkoutType } from '@wodalytics/db'
 
 /**
  * Best-effort classification of a free-form WOD description into a

--- a/apps/api/src/lib/crossfitWodClient.ts
+++ b/apps/api/src/lib/crossfitWodClient.ts
@@ -67,7 +67,7 @@ export async function fetchCrossfitWod(
     res = await fetchImpl(url, {
       headers: {
         Accept: 'application/json',
-        'User-Agent': 'BernTracker/1.0 (+https://github.com/chuckmag/BernTracker)',
+        'User-Agent': 'WODalytics/1.0 (+https://github.com/chuckmag/WODalytics)',
       },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     })

--- a/apps/api/src/lib/jwt.ts
+++ b/apps/api/src/lib/jwt.ts
@@ -1,5 +1,5 @@
 import jwt from 'jsonwebtoken'
-import type { Role } from '@berntracker/db'
+import type { Role } from '@wodalytics/db'
 
 const ACCESS_EXPIRY = '15m'
 const REFRESH_EXPIRY = '7d'

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from 'express'
-import type { Role } from '@berntracker/db'
-import { prisma } from '@berntracker/db'
+import type { Role } from '@wodalytics/db'
+import { prisma } from '@wodalytics/db'
 import { verifyAccessToken } from '../lib/jwt.js'
 import { createLogger } from '../lib/logger.js'
 

--- a/apps/api/src/middleware/program.ts
+++ b/apps/api/src/middleware/program.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express'
-import type { Role } from '@berntracker/db'
+import type { Role } from '@wodalytics/db'
 import { findProgramWithGymIds } from '../db/programDbManager.js'
 import { findGymMembershipByUserAndGym } from '../db/userGymDbManager.js'
 import { createLogger } from '../lib/logger.js'

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,8 +1,8 @@
 import { Router } from 'express'
 import bcrypt from 'bcryptjs'
 import { OAuth2Client } from 'google-auth-library'
-import { prisma } from '@berntracker/db'
-import { LoginSchema, RegisterSchema } from '@berntracker/types'
+import { prisma } from '@wodalytics/db'
+import { LoginSchema, RegisterSchema } from '@wodalytics/types'
 import { signTokenPair, verifyRefreshToken } from '../lib/jwt.js'
 import { requireAuth } from '../middleware/auth.js'
 

--- a/apps/api/src/routes/movements.ts
+++ b/apps/api/src/routes/movements.ts
@@ -9,7 +9,7 @@ import {
   updatePendingMovementById,
   detectMovementsInText,
 } from '../db/movementDbManager.js'
-import { SuggestMovementSchema, ReviewMovementSchema, UpdatePendingMovementSchema } from '@berntracker/types'
+import { SuggestMovementSchema, ReviewMovementSchema, UpdatePendingMovementSchema } from '@wodalytics/types'
 
 const router = Router()
 

--- a/apps/api/src/routes/namedWorkouts.ts
+++ b/apps/api/src/routes/namedWorkouts.ts
@@ -7,7 +7,7 @@ import {
   createNamedWorkoutWithOptionalTemplate,
   updateNamedWorkoutById,
 } from '../db/namedWorkoutDbManager.js'
-import { CreateNamedWorkoutSchema, UpdateNamedWorkoutSchema } from '@berntracker/types'
+import { CreateNamedWorkoutSchema, UpdateNamedWorkoutSchema } from '@wodalytics/types'
 
 const router = Router()
 

--- a/apps/api/src/routes/programs.ts
+++ b/apps/api/src/routes/programs.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import type { Request, Response } from 'express'
-import { ProgramRole } from '@berntracker/db'
-import { CreateProgramSchema, UpdateProgramSchema } from '@berntracker/types'
+import { ProgramRole } from '@wodalytics/db'
+import { CreateProgramSchema, UpdateProgramSchema } from '@wodalytics/types'
 import { requireAuth } from '../middleware/auth.js'
 import {
   validateGymExists,

--- a/apps/api/src/routes/results.ts
+++ b/apps/api/src/routes/results.ts
@@ -3,8 +3,8 @@ import type { Request, Response } from 'express'
 import { requireAuth } from '../middleware/auth.js'
 import { createResult, findLeaderboardByWorkout, findResultHistoryByUser, updateResultByOwner, deleteResultByOwner } from '../db/resultDbManager.js'
 import { expandMovementIdsWithVariations } from '../db/movementDbManager.js'
-import { CreateResultSchema, UpdateResultSchema } from '@berntracker/types'
-import type { WorkoutLevel, WorkoutGender } from '@berntracker/db'
+import { CreateResultSchema, UpdateResultSchema } from '@wodalytics/types'
+import type { WorkoutLevel, WorkoutGender } from '@wodalytics/db'
 
 const router = Router()
 

--- a/apps/api/src/routes/workouts.ts
+++ b/apps/api/src/routes/workouts.ts
@@ -23,8 +23,8 @@ import { expandMovementIdsWithVariations } from '../db/movementDbManager.js'
 import {
   findGymMembershipByUserAndGym
 } from '../db/userGymDbManager.js'
-import { CreateWorkoutSchema, UpdateWorkoutSchema } from '@berntracker/types'
-import { Role } from '@berntracker/db'
+import { CreateWorkoutSchema, UpdateWorkoutSchema } from '@wodalytics/types'
+import { Role } from '@wodalytics/db'
 
 const router = Router()
 

--- a/apps/api/src/types/express.d.ts
+++ b/apps/api/src/types/express.d.ts
@@ -1,4 +1,4 @@
-import type { Role } from '@berntracker/db'
+import type { Role } from '@wodalytics/db'
 declare global {
   namespace Express {
     interface Request {

--- a/apps/api/tests/crossfit-wod-job.ts
+++ b/apps/api/tests/crossfit-wod-job.ts
@@ -6,7 +6,7 @@
  * Run as part of `npm test` from apps/api (or directly via tsx).
  */
 
-import { prisma } from '@berntracker/db'
+import { prisma } from '@wodalytics/db'
 import { runCrossfitWodJob } from '../src/jobs/crossfitWod.js'
 import type { NormalizedCrossfitWod } from '../src/lib/crossfitWodClient.js'
 

--- a/apps/api/tests/feed.ts
+++ b/apps/api/tests/feed.ts
@@ -10,7 +10,7 @@
  * Run: cd apps/api && npm test
  */
 
-import { prisma, ProgramRole } from '@berntracker/db'
+import { prisma, ProgramRole } from '@wodalytics/db'
 import { signTokenPair } from '../src/lib/jwt.js'
 
 const BASE = process.env.API_URL ?? 'http://localhost:3000/api'

--- a/apps/api/tests/movements.ts
+++ b/apps/api/tests/movements.ts
@@ -6,7 +6,7 @@
  * Run: cd apps/api && npx tsx tests/movements.ts
  */
 
-import { prisma, ProgramRole } from '@berntracker/db'
+import { prisma, ProgramRole } from '@wodalytics/db'
 import { signTokenPair } from '../src/lib/jwt.js'
 
 const BASE = process.env.API_URL ?? 'http://localhost:3000/api'

--- a/apps/api/tests/named-workouts.ts
+++ b/apps/api/tests/named-workouts.ts
@@ -10,7 +10,7 @@
  * Teardown runs in a finally block so the DB stays clean on failure.
  */
 
-import { prisma, ProgramRole } from '@berntracker/db'
+import { prisma, ProgramRole } from '@wodalytics/db'
 import { signTokenPair } from '../src/lib/jwt.js'
 
 const BASE = process.env.API_URL ?? 'http://localhost:3000/api'

--- a/apps/api/tests/programs.ts
+++ b/apps/api/tests/programs.ts
@@ -5,7 +5,7 @@
  * Run: cd apps/api && npx tsx tests/programs.ts
  */
 
-import { prisma } from '@berntracker/db'
+import { prisma } from '@wodalytics/db'
 import { signTokenPair } from '../src/lib/jwt.js'
 
 const BASE = process.env.API_URL ?? 'http://localhost:3000/api'

--- a/apps/api/tests/results.ts
+++ b/apps/api/tests/results.ts
@@ -8,7 +8,7 @@
  * drive assertions through the live API, clean up in a finally block.
  */
 
-import { prisma } from '@berntracker/db'
+import { prisma } from '@wodalytics/db'
 import { signTokenPair } from '../src/lib/jwt.js'
 
 const BASE = process.env.API_URL ?? 'http://localhost:3000/api'

--- a/apps/api/tests/workouts.ts
+++ b/apps/api/tests/workouts.ts
@@ -9,7 +9,7 @@
  * Teardown runs in a finally block so the DB stays clean on failure.
  */
 
-import { prisma, ProgramRole } from '@berntracker/db'
+import { prisma, ProgramRole } from '@wodalytics/db'
 import { signTokenPair } from '../src/lib/jwt.js'
 
 const BASE = process.env.API_URL ?? 'http://localhost:3000/api'

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "BernTracker",
-    "slug": "berntracker",
+    "name": "WODalytics",
+    "slug": "wodalytics",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -13,10 +13,10 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.berntracker.app"
+      "bundleIdentifier": "com.wodalytics.app"
     },
     "android": {
-      "package": "com.berntracker.app",
+      "package": "com.wodalytics.app",
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/android-icon-foreground.png",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@berntracker/mobile",
+  "name": "@wodalytics/mobile",
   "version": "1.0.0",
   "main": "index.ts",
   "scripts": {

--- a/apps/mobile/src/screens/FeedScreen.tsx
+++ b/apps/mobile/src/screens/FeedScreen.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, Text, View } from 'react-native'
 export default function FeedScreen() {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>BernTracker</Text>
+      <Text style={styles.title}>WODalytics</Text>
       <Text style={styles.subtitle}>Today's WOD coming soon</Text>
     </View>
   )

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -17,7 +17,7 @@ RUN npm ci
 COPY packages/ ./packages/
 COPY apps/web/ ./apps/web/
 
-RUN npx turbo build --filter=@berntracker/web
+RUN npx turbo build --filter=@wodalytics/web
 
 # ── Stage 2: serve ───────────────────────────────────────────────────────────
 FROM nginx:alpine AS runtime

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,7 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BernTracker Admin</title>
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#030712" />
+    <title>WODalytics</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@berntracker/web",
+  "name": "@wodalytics/web",
   "version": "0.0.1",
   "private": true,
   "type": "module",

--- a/apps/web/public/README.md
+++ b/apps/web/public/README.md
@@ -1,0 +1,40 @@
+# Web static assets
+
+Files placed here are served by Vite at the site root (e.g. `public/favicon.ico` → `https://yourdomain/favicon.ico`).
+
+## Favicon set — drop these files in here
+
+The `<link>` tags in `apps/web/index.html` already reference the names below. Once you drop the files into this folder and redeploy, browsers pick them up automatically.
+
+| Filename | Size (px) | Format | Purpose |
+|---|---|---|---|
+| `favicon.ico` | 32×32 (multi-res ok: 16/32/48) | ICO | Legacy browsers, Windows tabs |
+| `favicon.svg` | scalable | SVG | Modern browsers (Chrome, Firefox, Safari) — preferred |
+| `apple-touch-icon.png` | 180×180 | PNG | iOS home screen icon |
+| `android-chrome-192x192.png` | 192×192 | PNG | Android home screen / PWA |
+| `android-chrome-512x512.png` | 512×512 | PNG | Android splash / PWA install |
+
+Already wired up:
+- `site.webmanifest` references both Android PNGs and is linked from `index.html`.
+- `<meta name="theme-color">` in `index.html` is set to `#030712` (the app's `bg-gray-950`); update it there if the brand colour changes.
+
+## Mobile app icons (separate folder)
+
+The Expo mobile app reads its icons from `apps/mobile/assets/`, not from here. Replace the existing files in place — keep the same filenames so `apps/mobile/app.json` does not need to change:
+
+| Filename | Size (px) | Notes |
+|---|---|---|
+| `icon.png` | 1024×1024 | Master app icon (App Store / Play Store) |
+| `splash-icon.png` | 1242×2688 (or square 1024×1024) | Splash screen |
+| `favicon.png` | 48×48 | Expo web export favicon |
+| `android-icon-foreground.png` | 432×432 | Adaptive icon, foreground (keep important content within centre 264×264 safe zone) |
+| `android-icon-background.png` | 432×432 | Adaptive icon, background |
+| `android-icon-monochrome.png` | 432×432 | Themed icon (Android 13+) |
+
+## Generating the set
+
+If you have a single source SVG/PNG, [realfavicongenerator.net](https://realfavicongenerator.net) produces the entire web set (everything in the table above) for free. For the mobile set, Expo's [adaptive icon docs](https://docs.expo.dev/develop/user-interface/app-icons/) cover sizes and safe zones.
+
+## Where to host
+
+Free path (recommended): commit the files to this folder. Vite ships them with the build and Railway serves them from the same origin as the app — no extra service, no CDN config, no extra cost. For favicons specifically, same-origin is also the most compatible across browsers.

--- a/apps/web/public/site.webmanifest
+++ b/apps/web/public/site.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "WODalytics",
+  "short_name": "WODalytics",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#030712",
+  "background_color": "#030712",
+  "display": "standalone"
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -34,7 +34,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
   const navContent = (
     <>
       <div className="px-6 py-5 border-b border-gray-800 flex items-center justify-between">
-        <span className="text-lg font-bold tracking-tight">BernTracker</span>
+        <span className="text-lg font-bold tracking-tight">WODalytics</span>
         <button
           onClick={onClose}
           className="md:hidden text-gray-500 hover:text-white text-xl leading-none"

--- a/apps/web/tests/calendar-multi-workout.spec.ts
+++ b/apps/web/tests/calendar-multi-workout.spec.ts
@@ -12,7 +12,7 @@
  *   T8: COACH role does not see ↑/↓ reorder buttons
  *
  * Requires: turbo dev running (API on :3000, web on :5173)
- * Run: npm run test --workspace=@berntracker/web
+ * Run: npm run test --workspace=@wodalytics/web
  *   or: cd apps/web && npx dotenv-cli -e ../../.env -- npx playwright test
  */
 

--- a/apps/web/tests/feed-wod-detail.spec.ts
+++ b/apps/web/tests/feed-wod-detail.spec.ts
@@ -14,7 +14,7 @@
  *   T12: WOD Detail renders movement chips and does not crash when workoutMovements is present
  *
  * Requires: turbo dev running (API on :3000, web on :5173)
- * Run: npm run test --workspace=@berntracker/web
+ * Run: npm run test --workspace=@wodalytics/web
  *   or: cd apps/web && npx dotenv-cli -e ../../.env -- npx playwright test
  */
 

--- a/apps/web/tests/gym-context.spec.ts
+++ b/apps/web/tests/gym-context.spec.ts
@@ -12,7 +12,7 @@
  *   T8: WodDetail loads normally with no gymId in localStorage
  *
  * Requires: turbo dev running (API on :3000, web on :5173)
- * Run: npm run test --workspace=@berntracker/web
+ * Run: npm run test --workspace=@wodalytics/web
  *   or: cd apps/web && npx dotenv-cli -e ../../.env -- npx playwright test
  */
 

--- a/apps/web/tests/pending-movement-review.spec.ts
+++ b/apps/web/tests/pending-movement-review.spec.ts
@@ -14,7 +14,7 @@
  * sets a passwordHash so the normal login form works, then restores null in afterAll.
  *
  * Requires: turbo dev running (API on :3000, web on :5173)
- * Run: npm run test:e2e --workspace=@berntracker/web
+ * Run: npm run test:e2e --workspace=@wodalytics/web
  */
 
 import { test, expect, type Page, type Cookie } from '@playwright/test'

--- a/apps/web/tests/result-logging.spec.ts
+++ b/apps/web/tests/result-logging.spec.ts
@@ -12,7 +12,7 @@
  * Note: 409 duplicate-log path is covered by apps/api/tests/results.ts.
  *
  * Requires: turbo dev running (API on :3000, web on :5173)
- * Run: npm run test --workspace=@berntracker/web
+ * Run: npm run test --workspace=@wodalytics/web
  *   or: cd apps/web && npx dotenv-cli -e ../../.env -- npx playwright test
  */
 

--- a/apps/web/tests/workout-autosave-markdown.spec.ts
+++ b/apps/web/tests/workout-autosave-markdown.spec.ts
@@ -10,7 +10,7 @@
  *   T6: WOD Detail renders markdown bold, headings, and lists
  *
  * Requires: turbo dev running (API on :3000, web on :5173)
- * Run: npm run test --workspace=@berntracker/web
+ * Run: npm run test --workspace=@wodalytics/web
  *   or: cd apps/web && npx dotenv-cli -e ../../.env -- npx playwright test workout-autosave-markdown
  */
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   proxy:
     image: nginx:alpine
-    container_name: berntracker-proxy
+    container_name: wodalytics-proxy
     ports:
       - "80:80"
     volumes:
@@ -13,28 +13,28 @@ services:
 
   postgres:
     image: postgres:16
-    container_name: berntracker-db
+    container_name: wodalytics-db
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: berntracker
+      POSTGRES_DB: wodalytics
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
   api:
-    image: berntracker-api:local
+    image: wodalytics-api:local
     build:
       context: .
       dockerfile: apps/api/Dockerfile
-    container_name: berntracker-api
+    container_name: wodalytics-api
     env_file: .env
     environment:
-      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/berntracker
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/wodalytics
       NODE_ENV: development
-      ALLOWED_ORIGINS: http://local.berntracker.com,http://localhost:5173
-      FRONTEND_URL: http://local.berntracker.com
+      ALLOWED_ORIGINS: http://local.wodalytics.com,http://localhost:5173
+      FRONTEND_URL: http://local.wodalytics.com
     depends_on:
       - postgres
 
@@ -42,15 +42,15 @@ services:
     build:
       context: .
       dockerfile: apps/web/Dockerfile
-    container_name: berntracker-web
+    container_name: wodalytics-web
     depends_on:
       - api
 
   studio:
-    image: berntracker-api:local
-    container_name: berntracker-studio
+    image: wodalytics-api:local
+    container_name: wodalytics-studio
     environment:
-      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/berntracker
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/wodalytics
     command: sh -c "npx prisma studio --schema=packages/db/prisma/schema.prisma --port 5555 --browser none --hostname 0.0.0.0"
     depends_on:
       - postgres

--- a/nginx-proxy.conf
+++ b/nginx-proxy.conf
@@ -2,7 +2,7 @@ resolver 127.0.0.11 valid=10s;
 
 server {
     listen 80;
-    server_name local.berntracker.com;
+    server_name local.wodalytics.com;
 
     location /api/ {
         set $backend "api:3000";
@@ -25,7 +25,7 @@ server {
 
 server {
     listen 80;
-    server_name db-studio.local.berntracker.com;
+    server_name db-studio.local.wodalytics.com;
 
     location / {
         set $backend "studio:5555";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "berntracker",
+  "name": "wodalytics",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "berntracker",
+      "name": "wodalytics",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -15,11 +15,11 @@
       }
     },
     "apps/api": {
-      "name": "@berntracker/api",
+      "name": "@wodalytics/api",
       "version": "0.0.1",
       "dependencies": {
-        "@berntracker/db": "*",
-        "@berntracker/types": "*",
+        "@wodalytics/db": "*",
+        "@wodalytics/types": "*",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -42,7 +42,7 @@
       }
     },
     "apps/mobile": {
-      "name": "@berntracker/mobile",
+      "name": "@wodalytics/mobile",
       "version": "1.0.0",
       "dependencies": {
         "expo": "~55.0.5",
@@ -65,7 +65,7 @@
       }
     },
     "apps/web": {
-      "name": "@berntracker/web",
+      "name": "@wodalytics/web",
       "version": "0.0.1",
       "dependencies": {
         "react": "^19.0.0",
@@ -1592,26 +1592,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@berntracker/api": {
-      "resolved": "apps/api",
-      "link": true
-    },
-    "node_modules/@berntracker/db": {
-      "resolved": "packages/db",
-      "link": true
-    },
-    "node_modules/@berntracker/mobile": {
-      "resolved": "apps/mobile",
-      "link": true
-    },
-    "node_modules/@berntracker/types": {
-      "resolved": "packages/types",
-      "link": true
-    },
-    "node_modules/@berntracker/web": {
-      "resolved": "apps/web",
-      "link": true
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -5311,6 +5291,26 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@wodalytics/api": {
+      "resolved": "apps/api",
+      "link": true
+    },
+    "node_modules/@wodalytics/db": {
+      "resolved": "packages/db",
+      "link": true
+    },
+    "node_modules/@wodalytics/mobile": {
+      "resolved": "apps/mobile",
+      "link": true
+    },
+    "node_modules/@wodalytics/types": {
+      "resolved": "packages/types",
+      "link": true
+    },
+    "node_modules/@wodalytics/web": {
+      "resolved": "apps/web",
+      "link": true
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
@@ -15193,7 +15193,7 @@
       }
     },
     "packages/db": {
-      "name": "@berntracker/db",
+      "name": "@wodalytics/db",
       "version": "0.0.1",
       "dependencies": {
         "@prisma/client": "^6.4.1"
@@ -15205,7 +15205,7 @@
       }
     },
     "packages/types": {
-      "name": "@berntracker/types",
+      "name": "@wodalytics/types",
       "version": "0.0.1",
       "dependencies": {
         "zod": "^3.24.1"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "berntracker",
+  "name": "wodalytics",
   "private": true,
   "packageManager": "npm@10.9.0",
   "workspaces": [

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,6 +1,6 @@
-# @berntracker/db — Data Model
+# @wodalytics/db — Data Model
 
-This package owns the Prisma schema and exports a singleton `PrismaClient`. It is the single source of truth for the BernTracker data model.
+This package owns the Prisma schema and exports a singleton `PrismaClient`. It is the single source of truth for the WODalytics data model.
 
 Schema file: [`prisma/schema.prisma`](./prisma/schema.prisma)
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@berntracker/db",
+  "name": "@wodalytics/db",
   "version": "0.0.1",
   "private": true,
   "main": "./dist/index.js",

--- a/packages/db/prisma/seed-movements.ts
+++ b/packages/db/prisma/seed-movements.ts
@@ -5,7 +5,7 @@
  * To add new movements in future iterations: add entries to BASES or VARIATIONS
  * below and rerun. Existing rows will not be duplicated or overwritten.
  *
- * Run: npm run db:seed-movements --workspace=@berntracker/db
+ * Run: npm run db:seed-movements --workspace=@wodalytics/db
  */
 
 import { PrismaClient } from '@prisma/client'

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@berntracker/types",
+  "name": "@wodalytics/types",
   "version": "0.0.1",
   "private": true,
   "main": "./dist/index.js",

--- a/scripts/test-worktree.mjs
+++ b/scripts/test-worktree.mjs
@@ -43,8 +43,8 @@ const env = {
 
 const cmd = 'npm'
 const args = target === 'api'
-  ? ['run', 'test', '--workspace=@berntracker/api']
-  : ['run', 'test:e2e', '--workspace=@berntracker/web', '--', ...extraArgs]
+  ? ['run', 'test', '--workspace=@wodalytics/api']
+  : ['run', 'test:e2e', '--workspace=@wodalytics/web', '--', ...extraArgs]
 
 console.log(`[test:worktree] target=${target} API_URL=${env.API_URL} WEB_URL=${env.WEB_URL}`)
 const child = spawn(cmd, args, { cwd: root, env, stdio: 'inherit' })


### PR DESCRIPTION
## Summary

App rebrand from **BernTracker** → **WODalytics**. One mechanical sweep across every tracked file (60 files, 206/+ 142/-) plus a small favicon-hosting scaffold so the new branding can plug in.

### What changed

- **User-visible copy.** Web tab title is now `WODalytics` (was `BernTracker Admin` — dropped "Admin" per the spec). Sidebar header, mobile feed header, Expo display name, and `mobile/app.json` `name` all updated.
- **Workspace packages.** `@berntracker/{api,db,web,mobile,types}` → `@wodalytics/*`. All ~30 cross-package imports updated; root `package.json` `"name"` is now `wodalytics`. `npm install` regenerates the `node_modules/@wodalytics/*` symlinks; `turbo build` passes for all 4 buildable workspaces.
- **Mobile bundle IDs.** `com.berntracker.app` → `com.wodalytics.app` (iOS + Android). Safe to rename now since the app has not been published to either store.
- **Docker / local dev.** `docker-compose.yml` container names, image names, `POSTGRES_DB`, hostnames in `nginx-proxy.conf` and `.env.example`. Local dev hostname is now `local.wodalytics.com`.
- **User-Agent header.** `apps/api/src/lib/crossfitWodClient.ts` now sends `WODalytics/1.0 (+https://github.com/chuckmag/WODalytics)`.
- **Docs.** `README.md`, `CLAUDE.md`, and `packages/db/README.md` rewritten throughout.

### Favicon hosting

Decision: **commit favicons to `apps/web/public/`** and let Vite/Railway serve them same-origin. Free, zero extra config, and same-origin is the most browser-compatible setup for favicons. (Cloudflare R2/Pages would add complexity for a handful of tiny files — not worth it for now.)

What's already wired up in this PR:
- `apps/web/index.html` has `<link>` tags for `favicon.ico`, `favicon.svg`, `apple-touch-icon.png`, and the PWA manifest, plus a `theme-color` meta of `#030712`.
- `apps/web/public/site.webmanifest` references the two Android Chrome PNGs and is linked from the head.
- `apps/web/public/README.md` documents exactly which filenames + sizes to drop in.

**You'll need to provide the following files** (drop into `apps/web/public/` — names must match):

| Filename | Size (px) | Format |
|---|---|---|
| `favicon.ico` | 32×32 (multi-res ok: 16/32/48) | ICO |
| `favicon.svg` | scalable | SVG |
| `apple-touch-icon.png` | 180×180 | PNG |
| `android-chrome-192x192.png` | 192×192 | PNG |
| `android-chrome-512x512.png` | 512×512 | PNG |

For the **mobile** app, replace the existing PNGs in `apps/mobile/assets/` (keep the same filenames so `apps/mobile/app.json` doesn't need to change):

| Filename | Size (px) |
|---|---|
| `icon.png` | 1024×1024 |
| `splash-icon.png` | 1242×2688 (or square 1024×1024) |
| `favicon.png` | 48×48 |
| `android-icon-foreground.png` | 432×432 (centre 264×264 safe zone) |
| `android-icon-background.png` | 432×432 |
| `android-icon-monochrome.png` | 432×432 |

Tip: drop a single source SVG into [realfavicongenerator.net](https://realfavicongenerator.net) — it produces the entire web set above for free.

### Follow-ups for you (outside this PR)

- [ ] Rename the GitHub repo `chuckmag/BernTracker` → `chuckmag/WODalytics`. GitHub auto-redirects old URLs, so the User-Agent header link will keep resolving.
- [ ] Update local `.env`: change `DATABASE_URL` from `…/berntracker` to `…/wodalytics` **and** rename your local Postgres DB (`docker exec -it wodalytics-db psql -U postgres -c 'ALTER DATABASE berntracker RENAME TO wodalytics;'`), or recreate the docker volume.
- [ ] Update `/etc/hosts` from `local.berntracker.com` → `local.wodalytics.com` (and `db-studio.local.berntracker.com` → `db-studio.local.wodalytics.com`).
- [ ] Drop the favicon files described above into `apps/web/public/` and the mobile assets folder.

## Tests

- **`turbo build`** — all 4 workspaces with build scripts (`@wodalytics/api`, `@wodalytics/db`, `@wodalytics/types`, `@wodalytics/web`) typecheck + bundle clean. This is the canonical typecheck across the monorepo and validates every renamed import.
- **Web unit tests** (`npm run test:unit --workspace=@wodalytics/web`) — 13 files, 67 tests, all pass.
- **Live API integration + Playwright E2E** — **not run.** This is a pure string-rename PR: no logic, no schema, no route shape changes. Build + unit suite cover every affected file, and running the live stack would require recreating the local Postgres container under the new name first (see follow-ups). Calling that out explicitly per CLAUDE.md's guidance to be honest about which suites ran.

**Manual verification needed:**
- [ ] After dropping in favicon files, confirm `<title>WODalytics</title>` and the new icon appear on the deployed web app.
- [ ] After renaming the local DB / `/etc/hosts`, run `npm run dev:worktree` and `npm run test:worktree -- api` / `-- e2e` to re-validate the full stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)