### PR TITLE
fix(web): bump tsconfig.app target/lib to ES2022

### DIFF
--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary

`npm run build` fails on `main` with:

```
src/pages/Feed.test.tsx(125,62): error TS2550: Property 'at' does
  not exist on type '[gymId: string, …][]'. Do you need to change
  the 'lib' compiler option to 'es2022' or later.
```

`Feed.test.tsx` (added in the programs-slice-2 PR) calls `mock.calls.at(-1)`. `Array.prototype.at` is ES2022, but `apps/web/tsconfig.app.json` had `target: ES2020` / `lib: ES2020`. The latent mismatch only surfaced now because the WODalytics rename PR invalidated turbo's cache and forced a fresh `tsc -b` of `@wodalytics/web` — every prior build replayed cached logs from before `.at()` was introduced.

Fix: bump `target` and `lib` to `ES2022`. This matches `tsconfig.node.json` (already on ES2022/ES2023) and is well-supported across every target browser — `Array.prototype.at` shipped in Chrome 92, Safari 15.4, Firefox 90 (mid-2021 → early 2022).

## Tests

- **`npm run build`** at the monorepo root — all 4 buildable workspaces succeed (`@wodalytics/{api,db,types,web}`), web bundle produces `dist/index.html` + assets.
- **`npm run test:unit --workspace=@wodalytics/web`** — 13 files, 71 tests pass (the 4 new programs-slice-2 tests included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)