### PR TITLE
fix(api): workout auth derives from gym roles; UserProgram fallback for unaffiliated programs

### DIFF
--- a/apps/api/src/db/workoutDbManager.ts
+++ b/apps/api/src/db/workoutDbManager.ts
@@ -133,11 +133,16 @@ export async function findWorkoutById(id: string) {
   })
 }
 
-// Lightweight query for auth middleware — returns only programId
-export async function findWorkoutProgramId(id: string) {
+// Lightweight query for auth middleware — returns the workout's programId plus
+// the program's linked gymIds (empty array when the program is unaffiliated,
+// e.g. the public CrossFit Mainsite program created by the ingest job).
+export async function findWorkoutWithProgramGyms(id: string) {
   return prisma.workout.findUnique({
     where: { id },
-    select: { programId: true },
+    select: {
+      programId: true,
+      program: { select: { gyms: { select: { gymId: true } } } },
+    },
   })
 }
 

--- a/apps/api/src/middleware/gym.ts
+++ b/apps/api/src/middleware/gym.ts
@@ -1,17 +1,11 @@
 import type { Request, Response, NextFunction } from 'express'
 import { findGymById } from '../db/gymDbManager.js'
 import { findGymMembershipByUserAndGym } from '../db/userGymDbManager.js'
-import { findWorkoutProgramId } from '../db/workoutDbManager.js'
-import { findUserProgramMembership } from '../db/userProgramDbManager.js'
-import { createLogger } from '../lib/logger.js'
 
-const log = createLogger('gym')
-
-const writeAccessRoles = ['OWNER', 'PROGRAMMER', 'COACH'];
+const writeAccessRoles = ['OWNER', 'PROGRAMMER', 'COACH']
 
 function checkMembershipHasWriteAccessRoles(membership: any): boolean {
-  const hasWriteAccessRoles = membership && writeAccessRoles.includes(membership.role)
-  return hasWriteAccessRoles
+  return Boolean(membership) && writeAccessRoles.includes(membership.role)
 }
 
 export async function validateGymExists(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -56,53 +50,5 @@ export async function requireGymWriteAccess(req: Request, res: Response, next: N
   next()
 }
 
-/** Requires the authenticated user to have any UserProgram subscription for the workout's program (read access). */
-export async function requireWorkoutProgramMembership(req: Request, res: Response, next: NextFunction): Promise<void> {
-  const workoutId = req.params.id as string
-  const userId = req.user?.id
-  if (!userId) {
-    res.status(401).json({ error: 'Unauthorized' })
-    return
-  }
-  const workout = await findWorkoutProgramId(workoutId)
-  if (!workout) {
-    res.status(404).json({ error: 'Workout not found' })
-    return
-  }
-  if (!workout.programId) {
-    res.status(403).json({ error: 'Forbidden' })
-    return
-  }
-  const membership = await findUserProgramMembership(userId, workout.programId)
-  if (!membership) {
-    res.status(403).json({ error: 'Forbidden' })
-    return
-  }
-  next()
-}
-
-/** Requires the authenticated user to have PROGRAMMER role in the workout's program (write access). */
-export async function requireWorkoutProgramWriteAccess(req: Request, res: Response, next: NextFunction): Promise<void> {
-  const workoutId = req.params.id as string
-  const userId = req.user?.id
-  if (!userId) {
-    res.status(401).json({ error: 'Unauthorized' })
-    return
-  }
-  const workout = await findWorkoutProgramId(workoutId)
-  if (!workout) {
-    res.status(404).json({ error: 'Workout not found' })
-    return
-  }
-  if (!workout.programId) {
-    res.status(403).json({ error: 'Forbidden' })
-    return
-  }
-  const membership = await findUserProgramMembership(userId, workout.programId)
-  if (!checkMembershipHasWriteAccessRoles(membership)) {
-    log.warning(req, `requireWorkoutProgramWriteAccess: insufficient role — ${req.method} ${req.path} — userId=${req.user?.id ?? 'none'} role=${membership?.role ?? 'none'}`, membership)
-    res.status(403).json({ error: 'Forbidden' })
-    return
-  }
-  next()
-}
+// Workout-scoped auth lives in `middleware/workout.ts` — see
+// `requireWorkoutReadAccess` / `requireWorkoutWriteAccess`.

--- a/apps/api/src/middleware/workout.ts
+++ b/apps/api/src/middleware/workout.ts
@@ -1,0 +1,122 @@
+import type { Request, Response, NextFunction } from 'express'
+import type { Role } from '@wodalytics/db'
+import { ProgramRole } from '@wodalytics/db'
+import { findWorkoutWithProgramGyms } from '../db/workoutDbManager.js'
+import { findGymMembershipByUserAndGym } from '../db/userGymDbManager.js'
+import { findUserProgramMembership } from '../db/userProgramDbManager.js'
+import { createLogger } from '../lib/logger.js'
+
+const log = createLogger('workout')
+
+const writeGymRoles: Role[] = ['OWNER', 'PROGRAMMER', 'COACH']
+
+// Authorization for /api/workouts/:id is derived from the workout's program.
+// A program is either gym-linked (one or more `GymProgram` rows) or unaffiliated
+// (no `GymProgram` rows — e.g. the public CrossFit Mainsite program seeded by
+// the ingest job). The two cases need different gates:
+//
+//   gym-linked    → read  = any UserGym membership in any linked gym
+//                          OR any UserProgram row (subscriber);
+//                   write = OWNER/PROGRAMMER/COACH in any linked gym.
+//                          UserProgram never grants write here — staff who
+//                          created the program have no automatic subscription
+//                          row, and a subscription role is a feed-visibility
+//                          marker, not a staff-write gate.
+//   unaffiliated  → read  = any UserProgram row;
+//                   write = UserProgram.role = PROGRAMMER.
+type AccessContext =
+  | { kind: 'not-found' }
+  | { kind: 'no-program' }
+  | { kind: 'gym-linked'; gymRoles: Role[]; programRole: ProgramRole | null }
+  | { kind: 'unaffiliated'; programRole: ProgramRole | null }
+
+async function loadWorkoutAccess(workoutId: string, userId: string): Promise<AccessContext> {
+  const workout = await findWorkoutWithProgramGyms(workoutId)
+  if (!workout) return { kind: 'not-found' }
+  if (!workout.programId || !workout.program) return { kind: 'no-program' }
+
+  const gymIds = workout.program.gyms.map((g) => g.gymId)
+  if (gymIds.length > 0) {
+    const [memberships, sub] = await Promise.all([
+      Promise.all(gymIds.map((gymId) => findGymMembershipByUserAndGym(userId, gymId))),
+      findUserProgramMembership(userId, workout.programId),
+    ])
+    const gymRoles = memberships
+      .map((m) => m?.role)
+      .filter((r): r is Role => Boolean(r))
+    return { kind: 'gym-linked', gymRoles, programRole: sub?.role ?? null }
+  }
+
+  const sub = await findUserProgramMembership(userId, workout.programId)
+  return { kind: 'unaffiliated', programRole: sub?.role ?? null }
+}
+
+/** Read access to a workout in `:id`. See AccessContext above for the rule. */
+export async function requireWorkoutReadAccess(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const userId = req.user?.id
+  if (!userId) {
+    res.status(401).json({ error: 'Unauthorized' })
+    return
+  }
+  const ctx = await loadWorkoutAccess(req.params.id as string, userId)
+
+  if (ctx.kind === 'not-found') {
+    res.status(404).json({ error: 'Workout not found' })
+    return
+  }
+  if (ctx.kind === 'no-program') {
+    log.warning(req, `requireWorkoutReadAccess: workout has no program — ${req.method} ${req.path} — userId=${userId}`)
+    res.status(403).json({ error: 'Forbidden' })
+    return
+  }
+  if (ctx.kind === 'gym-linked') {
+    if (ctx.gymRoles.length === 0 && !ctx.programRole) {
+      log.warning(req, `requireWorkoutReadAccess: not a member of any linked gym and not a subscriber — ${req.method} ${req.path} — userId=${userId}`)
+      res.status(403).json({ error: 'Forbidden' })
+      return
+    }
+    next()
+    return
+  }
+  if (!ctx.programRole) {
+    log.warning(req, `requireWorkoutReadAccess: no UserProgram for unaffiliated program — ${req.method} ${req.path} — userId=${userId}`)
+    res.status(403).json({ error: 'Forbidden' })
+    return
+  }
+  next()
+}
+
+/** Write access to a workout in `:id`. See AccessContext above for the rule. */
+export async function requireWorkoutWriteAccess(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const userId = req.user?.id
+  if (!userId) {
+    res.status(401).json({ error: 'Unauthorized' })
+    return
+  }
+  const ctx = await loadWorkoutAccess(req.params.id as string, userId)
+
+  if (ctx.kind === 'not-found') {
+    res.status(404).json({ error: 'Workout not found' })
+    return
+  }
+  if (ctx.kind === 'no-program') {
+    log.warning(req, `requireWorkoutWriteAccess: workout has no program — ${req.method} ${req.path} — userId=${userId}`)
+    res.status(403).json({ error: 'Forbidden' })
+    return
+  }
+  if (ctx.kind === 'gym-linked') {
+    if (!ctx.gymRoles.some((r) => writeGymRoles.includes(r))) {
+      log.warning(req, `requireWorkoutWriteAccess: insufficient gym role — ${req.method} ${req.path} — userId=${userId} roles=${ctx.gymRoles.join('|') || 'none'}`)
+      res.status(403).json({ error: 'Forbidden' })
+      return
+    }
+    next()
+    return
+  }
+  if (ctx.programRole !== ProgramRole.PROGRAMMER) {
+    log.warning(req, `requireWorkoutWriteAccess: unaffiliated program requires UserProgram.PROGRAMMER — ${req.method} ${req.path} — userId=${userId} role=${ctx.programRole ?? 'none'}`)
+    res.status(403).json({ error: 'Forbidden' })
+    return
+  }
+  next()
+}

--- a/apps/api/src/routes/workouts.ts
+++ b/apps/api/src/routes/workouts.ts
@@ -5,9 +5,11 @@ import {
   validateGymExists,
   requireGymMembership,
   requireGymWriteAccess,
-  requireWorkoutProgramMembership,
-  requireWorkoutProgramWriteAccess,
 } from '../middleware/gym.js'
+import {
+  requireWorkoutReadAccess,
+  requireWorkoutWriteAccess,
+} from '../middleware/workout.js'
 import {
   createWorkoutForProgram as createWorkoutForProgramDb,
   countWorkoutsOnSameDay,
@@ -43,19 +45,19 @@ router.post('/gyms/:gymId/workouts', requireAuth, validateGymExists, requireGymW
 router.post('/gyms/:gymId/workouts/publish', requireAuth, validateGymExists, requireGymWriteAccess, batchPublishWorkoutsForGym)
 
 // GET  /api/workouts/:id
-router.get('/workouts/:id', requireAuth, requireWorkoutProgramMembership, getWorkoutById)
+router.get('/workouts/:id', requireAuth, requireWorkoutReadAccess, getWorkoutById)
 
 // PATCH /api/workouts/:id
-router.patch('/workouts/:id', requireAuth, requireWorkoutProgramWriteAccess, patchWorkout)
+router.patch('/workouts/:id', requireAuth, requireWorkoutWriteAccess, patchWorkout)
 
 // POST /api/workouts/:id/publish
-router.post('/workouts/:id/publish', requireAuth, requireWorkoutProgramWriteAccess, publishSingleWorkout)
+router.post('/workouts/:id/publish', requireAuth, requireWorkoutWriteAccess, publishSingleWorkout)
 
 // POST /api/workouts/:id/apply-template
-router.post('/workouts/:id/apply-template', requireAuth, requireWorkoutProgramWriteAccess, applyTemplate)
+router.post('/workouts/:id/apply-template', requireAuth, requireWorkoutWriteAccess, applyTemplate)
 
 // DELETE /api/workouts/:id
-router.delete('/workouts/:id', requireAuth, requireWorkoutProgramWriteAccess, deleteWorkoutById)
+router.delete('/workouts/:id', requireAuth, requireWorkoutWriteAccess, deleteWorkoutById)
 
 export default router
 

--- a/apps/api/tests/workouts.ts
+++ b/apps/api/tests/workouts.ts
@@ -313,6 +313,173 @@ async function runTests() {
     check('Re-subscribe MEMBER as PROGRAMMER → 201', 201, r.status)
     check('Re-subscribe → role promoted to PROGRAMMER', 'PROGRAMMER', r.body.role)
   }
+
+  // ── Workout auth: gym-linked program (#118) ────────────────────────────────
+  // Regression coverage for the bug where workout write access ran the caller's
+  // UserProgram.role through the gym-role allowlist. The fix derives write
+  // access for gym-linked programs from gym roles only; UserProgram is for
+  // subscribers (read access) and the unaffiliated-program fallback.
+  console.log('\n=== Workout auth: gym-linked program (#118) ===')
+
+  // Fresh program + workout owned by a brand-new gym OWNER who has NO
+  // UserProgram row — this is the exact path a gym OWNER takes after
+  // POST /api/gyms/:gymId/programs and is the bug repro.
+  const ownerNoSub = await prisma.user.create({ data: { email: `at-owner-nosub-${TS}@test.com` } })
+  const coachNoSub = await prisma.user.create({ data: { email: `at-coach-nosub-${TS}@test.com` } })
+  const memberSubProgrammer = await prisma.user.create({ data: { email: `at-mem-progsub-${TS}@test.com` } })
+  await prisma.userGym.createMany({
+    data: [
+      { userId: ownerNoSub.id, gymId, role: 'OWNER' },
+      { userId: coachNoSub.id, gymId, role: 'COACH' },
+      { userId: memberSubProgrammer.id, gymId, role: 'MEMBER' },
+    ],
+  })
+  // memberSubProgrammer has UserProgram.PROGRAMMER but only MEMBER gym role —
+  // they must NOT be able to write under the new rule.
+  await prisma.userProgram.create({
+    data: { userId: memberSubProgrammer.id, programId, role: ProgramRole.PROGRAMMER },
+  })
+  const ownerNoSubToken = signTokenPair(ownerNoSub.id, 'OWNER').accessToken
+  const coachNoSubToken = signTokenPair(coachNoSub.id, 'COACH').accessToken
+  const memberSubProgrammerToken = signTokenPair(memberSubProgrammer.id, 'MEMBER').accessToken
+
+  const ownerWorkout = await prisma.workout.create({
+    data: {
+      programId,
+      title: 'Owner-created workout',
+      description: 'created via gym OWNER without UserProgram subscription',
+      type: 'FOR_TIME',
+      scheduledAt: new Date('2026-04-05T10:00:00Z'),
+    },
+  })
+
+  {
+    const r = await api('GET', `/workouts/${ownerWorkout.id}`, ownerNoSubToken)
+    check('Gym OWNER (no UserProgram) → GET 200', 200, r.status)
+  }
+
+  {
+    const r = await api('PATCH', `/workouts/${ownerWorkout.id}`, ownerNoSubToken, { title: 'Renamed by owner' })
+    check('Gym OWNER (no UserProgram) → PATCH 200', 200, r.status)
+    check('Gym OWNER PATCH → title applied', 'Renamed by owner', r.body.title)
+  }
+
+  {
+    const r = await api('POST', `/workouts/${ownerWorkout.id}/publish`, ownerNoSubToken)
+    check('Gym OWNER (no UserProgram) → publish 200', 200, r.status)
+    check('Gym OWNER publish → status PUBLISHED', 'PUBLISHED', r.body.status)
+  }
+
+  {
+    const r = await api('GET', `/workouts/${ownerWorkout.id}`, coachNoSubToken)
+    check('Gym COACH (no UserProgram) → GET 200', 200, r.status)
+  }
+
+  {
+    // Create a second draft to delete with COACH so we can verify write access
+    const w = await prisma.workout.create({
+      data: {
+        programId,
+        title: 'Coach delete target',
+        description: 'd',
+        type: 'EMOM',
+        scheduledAt: new Date('2026-04-06T10:00:00Z'),
+      },
+    })
+    const r = await api('DELETE', `/workouts/${w.id}`, coachNoSubToken)
+    check('Gym COACH (no UserProgram) → DELETE 204', 204, r.status)
+  }
+
+  {
+    const r = await api('PATCH', `/workouts/${ownerWorkout.id}`, memberSubProgrammerToken, { title: 'Should fail' })
+    check('Gym MEMBER + UserProgram.PROGRAMMER → PATCH 403', 403, r.status)
+  }
+
+  {
+    // MEMBER gym role with UserProgram subscription can still READ (subscriber)
+    const r = await api('GET', `/workouts/${ownerWorkout.id}`, memberSubProgrammerToken)
+    check('Gym MEMBER + UserProgram subscriber → GET 200', 200, r.status)
+  }
+
+  {
+    // Bystander outside the gym with no UserProgram → 403 on GET
+    const stranger = await prisma.user.create({ data: { email: `at-stranger-${TS}@test.com` } })
+    const strangerToken = signTokenPair(stranger.id, 'MEMBER').accessToken
+    const r = await api('GET', `/workouts/${ownerWorkout.id}`, strangerToken)
+    check('Stranger (no gym, no UserProgram) → GET 403', 403, r.status)
+    await prisma.user.delete({ where: { id: stranger.id } })
+  }
+
+  await prisma.workout.delete({ where: { id: ownerWorkout.id } }).catch(() => {})
+  await prisma.userProgram.deleteMany({ where: { userId: memberSubProgrammer.id } })
+  await prisma.user.deleteMany({
+    where: { id: { in: [ownerNoSub.id, coachNoSub.id, memberSubProgrammer.id] } },
+  })
+
+  // ── Workout auth: unaffiliated program (UserProgram fallback) (#118) ───────
+  // Programs with zero GymProgram rows (e.g. the public CrossFit Mainsite
+  // program seeded by the ingest job) fall back to UserProgram for both read
+  // (any subscription) and write (PROGRAMMER subscription).
+  console.log('\n=== Workout auth: unaffiliated program (#118) ===')
+
+  const orphanProgram = await prisma.program.create({
+    data: { name: `Orphan Program ${TS}`, startDate: new Date('2026-04-01') },
+  })
+  const orphanWorkout = await prisma.workout.create({
+    data: {
+      programId: orphanProgram.id,
+      title: 'Orphan program workout',
+      description: 'no gym link',
+      type: 'CARDIO',
+      scheduledAt: new Date('2026-04-10T10:00:00Z'),
+    },
+  })
+
+  const orphanProgrammer = await prisma.user.create({ data: { email: `at-orph-prog-${TS}@test.com` } })
+  const orphanMember = await prisma.user.create({ data: { email: `at-orph-mem-${TS}@test.com` } })
+  await prisma.userProgram.createMany({
+    data: [
+      { userId: orphanProgrammer.id, programId: orphanProgram.id, role: ProgramRole.PROGRAMMER },
+      { userId: orphanMember.id, programId: orphanProgram.id, role: ProgramRole.MEMBER },
+    ],
+  })
+  const orphanProgrammerToken = signTokenPair(orphanProgrammer.id, 'MEMBER').accessToken
+  const orphanMemberToken = signTokenPair(orphanMember.id, 'MEMBER').accessToken
+
+  {
+    const r = await api('GET', `/workouts/${orphanWorkout.id}`, orphanMemberToken)
+    check('Unaffiliated program: UserProgram.MEMBER → GET 200', 200, r.status)
+  }
+
+  {
+    const r = await api('PATCH', `/workouts/${orphanWorkout.id}`, orphanMemberToken, { title: 'denied' })
+    check('Unaffiliated program: UserProgram.MEMBER → PATCH 403', 403, r.status)
+  }
+
+  {
+    const r = await api('PATCH', `/workouts/${orphanWorkout.id}`, orphanProgrammerToken, { title: 'orphan renamed' })
+    check('Unaffiliated program: UserProgram.PROGRAMMER → PATCH 200', 200, r.status)
+    check('Unaffiliated program PATCH → title applied', 'orphan renamed', r.body.title)
+  }
+
+  {
+    const r = await api('POST', `/workouts/${orphanWorkout.id}/publish`, orphanProgrammerToken)
+    check('Unaffiliated program: UserProgram.PROGRAMMER → publish 200', 200, r.status)
+  }
+
+  {
+    // Even a gym OWNER (in a different gym) has no claim on an unaffiliated
+    // program — only UserProgram applies.
+    const r = await api('GET', `/workouts/${orphanWorkout.id}`, programmerToken)
+    check('Unaffiliated program: gym staff with no UserProgram → GET 403', 403, r.status)
+  }
+
+  await prisma.workout.delete({ where: { id: orphanWorkout.id } })
+  await prisma.userProgram.deleteMany({ where: { programId: orphanProgram.id } })
+  await prisma.program.delete({ where: { id: orphanProgram.id } })
+  await prisma.user.deleteMany({
+    where: { id: { in: [orphanProgrammer.id, orphanMember.id] } },
+  })
 }
 
 // ─── Teardown ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #118

## Summary

`requireWorkoutProgramWriteAccess` checked the caller's `UserProgram.role` (the `ProgramRole` enum — `MEMBER` | `PROGRAMMER`) against the gym `Role` allowlist `['OWNER', 'PROGRAMMER', 'COACH']` — two unrelated enums sharing one string by accident. Net effect: a gym `OWNER` who created a program could not publish workouts in it because creating a program never inserts a `UserProgram` row for the creator. The same flaw blocked `PATCH /workouts/:id`, `DELETE /workouts/:id`, `POST /workouts/:id/apply-template`, and `GET /workouts/:id`.

The fix moves workout-scoped auth into a new `apps/api/src/middleware/workout.ts` and derives access from the workout's program → its linked gyms, falling back to `UserProgram` only when the program has no `GymProgram` rows (e.g. the public CrossFit Mainsite program seeded by the ingest job).

| Program shape | Read | Write |
|---|---|---|
| Gym-linked (≥1 `GymProgram` row) | Any `UserGym` membership in any linked gym **OR** any `UserProgram` row | `OWNER` / `PROGRAMMER` / `COACH` in any linked gym |
| Unaffiliated (no `GymProgram` rows) | Any `UserProgram` row | `UserProgram.role = PROGRAMMER` |

This aligns workout auth with the program-CRUD auth in `middleware/program.ts` (which already used gym roles correctly) and matches the slice 4 (#87) plan that read access is the OR of gym staff role and `UserProgram` subscription.

## Behavioral changes

- Gym `OWNER` / `PROGRAMMER` / `COACH` now have full write access on workouts in any program linked to their gym, **without** needing a `UserProgram` row. (Previously: 403 — the bug.)
- Gym `MEMBER` who happens to hold `UserProgram.PROGRAMMER` no longer gets write access on a gym-linked program. The subscription `PROGRAMMER` role is a feed-visibility marker, not a staff-write gate. (Previously: write access by accident of the enum collision.)
- For unaffiliated programs, behavior is unchanged: `UserProgram.PROGRAMMER` is still required for write, any `UserProgram` row for read.

## Files

- `apps/api/src/middleware/workout.ts` — **new**. `requireWorkoutReadAccess` / `requireWorkoutWriteAccess` with the contextual rule above.
- `apps/api/src/middleware/gym.ts` — removed `requireWorkoutProgramMembership` / `requireWorkoutProgramWriteAccess` and their now-unused imports. Left a one-line comment pointing to the new file.
- `apps/api/src/db/workoutDbManager.ts` — replaced `findWorkoutProgramId` with `findWorkoutWithProgramGyms` (single query that returns `programId` + linked `gymIds`).
- `apps/api/src/routes/workouts.ts` — rewired `/workouts/:id` (GET / PATCH / POST publish / POST apply-template / DELETE) to the new middleware.
- `apps/api/tests/workouts.ts` — added 16 regression assertions across two new sections.

## Tests

**API integration** (`apps/api/tests/workouts.ts`):
- All 37 pre-existing assertions still pass — including `GET as MEMBER subscriber → 200` (read access via `UserProgram` still works) and `PATCH as MEMBER → 403` (gym MEMBER without staff role still denied).
- **Workout auth: gym-linked program (#118)** — new section:
  - Gym `OWNER` (no `UserProgram`) → `GET 200`, `PATCH 200`, `publish 200`. **The bug repro.**
  - Gym `COACH` (no `UserProgram`) → `GET 200`, `DELETE 204`. (Previously denied.)
  - Gym `MEMBER` + `UserProgram.PROGRAMMER` → `PATCH 403`. (Previously allowed by enum collision.)
  - Gym `MEMBER` + `UserProgram` subscriber → `GET 200`.
  - Stranger (no gym, no `UserProgram`) → `GET 403`.
- **Workout auth: unaffiliated program (#118)** — new section:
  - `UserProgram.MEMBER` → `GET 200`, `PATCH 403`.
  - `UserProgram.PROGRAMMER` → `PATCH 200`, `publish 200`.
  - Gym staff (with no `UserProgram` on this program) → `GET 403`. Confirms the gym-staff bypass does not leak into unaffiliated programs.

**Suite result:** `=== Results: 53 passed, 0 failed ===` for `tests/workouts.ts`. Full `npm run test --workspace=@wodalytics/api` (all 9 spec files) is green.

**Not automated / manual verification needed:**
- [ ] Smoke-test the original repro in the web UI: log in as a gym OWNER, create a program, create a workout under it, click Publish — should now succeed.