### PR TITLE
feat(db): onboarding schema — User profile, EmergencyContact, GymMembershipRequest

### DIFF
--- a/packages/db/prisma/migrations/20260427182610_onboarding_profile_emergency_contact_membership_request/migration.sql
+++ b/packages/db/prisma/migrations/20260427182610_onboarding_profile_emergency_contact_membership_request/migration.sql
@@ -1,0 +1,89 @@
+-- CreateEnum
+CREATE TYPE "MembershipRequestDirection" AS ENUM ('STAFF_INVITED', 'USER_REQUESTED');
+
+-- CreateEnum
+CREATE TYPE "MembershipRequestStatus" AS ENUM ('PENDING', 'APPROVED', 'DECLINED', 'REVOKED', 'EXPIRED');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "avatarUrl" TEXT,
+ADD COLUMN     "birthday" DATE,
+ADD COLUMN     "firstName" TEXT,
+ADD COLUMN     "lastName" TEXT,
+ADD COLUMN     "onboardedAt" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "EmergencyContact" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "relationship" TEXT,
+    "phone" TEXT NOT NULL,
+    "email" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EmergencyContact_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GymMembershipRequest" (
+    "id" TEXT NOT NULL,
+    "gymId" TEXT NOT NULL,
+    "direction" "MembershipRequestDirection" NOT NULL,
+    "status" "MembershipRequestStatus" NOT NULL DEFAULT 'PENDING',
+    "email" TEXT,
+    "userId" TEXT,
+    "roleToGrant" "Role" NOT NULL DEFAULT 'MEMBER',
+    "invitedById" TEXT,
+    "decidedById" TEXT,
+    "decidedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GymMembershipRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "EmergencyContact_userId_idx" ON "EmergencyContact"("userId");
+
+-- CreateIndex
+CREATE INDEX "GymMembershipRequest_gymId_status_idx" ON "GymMembershipRequest"("gymId", "status");
+
+-- CreateIndex
+CREATE INDEX "GymMembershipRequest_userId_status_idx" ON "GymMembershipRequest"("userId", "status");
+
+-- CreateIndex
+CREATE INDEX "GymMembershipRequest_email_status_idx" ON "GymMembershipRequest"("email", "status");
+
+-- AddForeignKey
+ALTER TABLE "EmergencyContact" ADD CONSTRAINT "EmergencyContact_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GymMembershipRequest" ADD CONSTRAINT "GymMembershipRequest_gymId_fkey" FOREIGN KEY ("gymId") REFERENCES "Gym"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GymMembershipRequest" ADD CONSTRAINT "GymMembershipRequest_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GymMembershipRequest" ADD CONSTRAINT "GymMembershipRequest_invitedById_fkey" FOREIGN KEY ("invitedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GymMembershipRequest" ADD CONSTRAINT "GymMembershipRequest_decidedById_fkey" FOREIGN KEY ("decidedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Backfill firstName / lastName from existing User.name (best-effort split on first whitespace).
+-- Single-token names land entirely in firstName; multi-token names put the first token in
+-- firstName and the rest (preserving middle names) in lastName.
+UPDATE "User"
+SET
+  "firstName" = CASE
+    WHEN "name" IS NULL OR btrim("name") = '' THEN NULL
+    WHEN position(' ' in btrim("name")) = 0 THEN btrim("name")
+    ELSE split_part(btrim("name"), ' ', 1)
+  END,
+  "lastName" = CASE
+    WHEN "name" IS NULL OR btrim("name") = '' THEN NULL
+    WHEN position(' ' in btrim("name")) = 0 THEN NULL
+    ELSE btrim(substring(btrim("name") from position(' ' in btrim("name"))))
+  END
+WHERE "firstName" IS NULL AND "lastName" IS NULL;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -97,31 +97,56 @@ enum ProgramRole {
   PROGRAMMER
 }
 
+// Direction of a pending gym membership request.
+// STAFF_INVITED = staff invited a user (by email) to join the gym.
+// USER_REQUESTED = a user asked to join the gym; staff approves.
+enum MembershipRequestDirection {
+  STAFF_INVITED
+  USER_REQUESTED
+}
+
+enum MembershipRequestStatus {
+  PENDING
+  APPROVED
+  DECLINED
+  REVOKED
+  EXPIRED
+}
+
 enum WorkoutCategory {
-  GIRL_WOD    // e.g. Fran, Cindy, Grace
-  HERO_WOD    // e.g. Murph, Badger, DT
-  OPEN_WOD    // e.g. 22.1, 23.3
-  GAMES_WOD   // individual/team events from the Games
-  BENCHMARK   // other common benchmarks (Fight Gone Bad, etc.)
+  GIRL_WOD // e.g. Fran, Cindy, Grace
+  HERO_WOD // e.g. Murph, Badger, DT
+  OPEN_WOD // e.g. 22.1, 23.3
+  GAMES_WOD // individual/team events from the Games
+  BENCHMARK // other common benchmarks (Fight Gone Bad, etc.)
 }
 
 // ─── Models ───────────────────────────────────────────────────────────────────
 
 model User {
-  id           String   @id @default(cuid())
-  email        String   @unique
-  name         String?
-  role             Role     @default(MEMBER)
+  id               String    @id @default(cuid())
+  email            String    @unique
+  name             String?
+  firstName        String?
+  lastName         String?
+  birthday         DateTime? @db.Date
+  avatarUrl        String?
+  onboardedAt      DateTime?
+  role             Role      @default(MEMBER)
   identifiedGender Gender?
   passwordHash     String?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
 
-  oauthAccounts OAuthAccount[]
-  refreshTokens RefreshToken[]
-  gyms          UserGym[]
-  programs      UserProgram[]
-  results       Result[]
+  oauthAccounts         OAuthAccount[]
+  refreshTokens         RefreshToken[]
+  gyms                  UserGym[]
+  programs              UserProgram[]
+  results               Result[]
+  emergencyContacts     EmergencyContact[]
+  membershipRequests    GymMembershipRequest[] @relation("UserRequests")
+  membershipInvitesSent GymMembershipRequest[] @relation("InvitedBy")
+  membershipDecisions   GymMembershipRequest[] @relation("DecidedBy")
 }
 
 model OAuthAccount {
@@ -154,8 +179,9 @@ model Gym {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  members  UserGym[]
-  programs GymProgram[]
+  members            UserGym[]
+  programs           GymProgram[]
+  membershipRequests GymMembershipRequest[]
 }
 
 model UserGym {
@@ -209,53 +235,98 @@ model UserProgram {
   @@id([userId, programId])
 }
 
-model NamedWorkout {
-  id                String          @id @default(cuid())
-  name              String          @unique
-  category          WorkoutCategory
-  aliases           String[]
-  isActive          Boolean         @default(true)
-  createdAt         DateTime        @default(now())
-  updatedAt         DateTime        @updatedAt
+model EmergencyContact {
+  id           String   @id @default(cuid())
+  userId       String
+  name         String
+  relationship String?
+  phone        String
+  email        String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
-  templateWorkoutId String?         @unique
-  templateWorkout   Workout?        @relation("NamedWorkoutTemplate", fields: [templateWorkoutId], references: [id])
-  workouts          Workout[]       @relation("NamedWorkoutInstances")
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+}
+
+// Pending request to join a gym — works in both directions:
+//  - STAFF_INVITED: staff invited an email to the gym; userId may be null
+//    until the invitee signs up or the email matches an existing User.
+//  - USER_REQUESTED: a user asked to join; userId is required, email is null.
+// On APPROVED, a UserGym row is created with role=roleToGrant.
+model GymMembershipRequest {
+  id          String                     @id @default(cuid())
+  gymId       String
+  direction   MembershipRequestDirection
+  status      MembershipRequestStatus    @default(PENDING)
+  email       String?
+  userId      String?
+  roleToGrant Role                       @default(MEMBER)
+  invitedById String?
+  decidedById String?
+  decidedAt   DateTime?
+  expiresAt   DateTime?
+  createdAt   DateTime                   @default(now())
+  updatedAt   DateTime                   @updatedAt
+
+  gym       Gym   @relation(fields: [gymId], references: [id], onDelete: Cascade)
+  user      User? @relation("UserRequests", fields: [userId], references: [id], onDelete: SetNull)
+  invitedBy User? @relation("InvitedBy", fields: [invitedById], references: [id], onDelete: SetNull)
+  decidedBy User? @relation("DecidedBy", fields: [decidedById], references: [id], onDelete: SetNull)
+
+  @@index([gymId, status])
+  @@index([userId, status])
+  @@index([email, status])
+}
+
+model NamedWorkout {
+  id        String          @id @default(cuid())
+  name      String          @unique
+  category  WorkoutCategory
+  aliases   String[]
+  isActive  Boolean         @default(true)
+  createdAt DateTime        @default(now())
+  updatedAt DateTime        @updatedAt
+
+  templateWorkoutId String?   @unique
+  templateWorkout   Workout?  @relation("NamedWorkoutTemplate", fields: [templateWorkoutId], references: [id])
+  workouts          Workout[] @relation("NamedWorkoutInstances")
 }
 
 model Workout {
-  id          String        @id @default(cuid())
-  programId   String?
-  title       String
-  description String
-  type        WorkoutType
-  status      WorkoutStatus @default(DRAFT)
-  scheduledAt DateTime
-  dayOrder    Int           @default(0)
-  namedWorkoutId String?
+  id               String        @id @default(cuid())
+  programId        String?
+  title            String
+  description      String
+  type             WorkoutType
+  status           WorkoutStatus @default(DRAFT)
+  scheduledAt      DateTime
+  dayOrder         Int           @default(0)
+  namedWorkoutId   String?
   // Stable identifier from an external source (e.g. "crossfit-mainsite:w20260425")
   // used for idempotent upserts by background ingest jobs. Null for user-authored workouts.
-  externalSourceId String?  @unique
-  createdAt   DateTime      @default(now())
-  updatedAt   DateTime      @updatedAt
+  externalSourceId String?       @unique
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @updatedAt
 
   // nullable: members can log personal workouts outside any program
-  program          Program?      @relation(fields: [programId], references: [id], onDelete: SetNull)
+  program          Program?          @relation(fields: [programId], references: [id], onDelete: SetNull)
   results          Result[]
-  namedWorkout     NamedWorkout? @relation("NamedWorkoutInstances", fields: [namedWorkoutId], references: [id])
-  templateFor      NamedWorkout? @relation("NamedWorkoutTemplate")  // required by Prisma parser — not used in queries
+  namedWorkout     NamedWorkout?     @relation("NamedWorkoutInstances", fields: [namedWorkoutId], references: [id])
+  templateFor      NamedWorkout?     @relation("NamedWorkoutTemplate") // required by Prisma parser — not used in queries
   workoutMovements WorkoutMovement[]
 }
 
 model Result {
-  id        String       @id @default(cuid())
-  userId    String
-  workoutId String
+  id            String        @id @default(cuid())
+  userId        String
+  workoutId     String
   level         WorkoutLevel
   workoutGender WorkoutGender
   value         Json
-  notes     String?
-  createdAt DateTime     @default(now())
+  notes         String?
+  createdAt     DateTime      @default(now())
 
   user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
   workout Workout @relation(fields: [workoutId], references: [id], onDelete: Cascade)
@@ -264,15 +335,15 @@ model Result {
 }
 
 model Movement {
-  id         String         @id @default(cuid())
-  name       String         @unique
-  status     MovementStatus @default(ACTIVE)
+  id         String            @id @default(cuid())
+  name       String            @unique
+  status     MovementStatus    @default(ACTIVE)
   parentId   String?
-  parent     Movement?      @relation("MovementVariations", fields: [parentId], references: [id])
-  variations Movement[]     @relation("MovementVariations")
+  parent     Movement?         @relation("MovementVariations", fields: [parentId], references: [id])
+  variations Movement[]        @relation("MovementVariations")
   workouts   WorkoutMovement[]
-  createdAt  DateTime       @default(now())
-  updatedAt  DateTime       @updatedAt
+  createdAt  DateTime          @default(now())
+  updatedAt  DateTime          @updatedAt
 
   @@index([parentId])
 }


### PR DESCRIPTION
Closes #121 · Part of #120

Schema-only migration ahead of the onboarding + two-sided gym membership feature work. Splits into its own PR per CLAUDE.md's migration-isolation policy so the feature branches (B / D1 / D2) can land in parallel without colliding on migration timestamps.

## Schema changes

### `User` — additive nullable fields
- `firstName`, `lastName` — first-class fields. Existing `name` preserved as a fallback so all current consumers stay green; B will start writing first/last and falling back to `name` for display.
- `birthday` (`@db.Date`), `avatarUrl`, `onboardedAt` — populated by Slice B (avatar wiring deferred to Slice C, but the column exists now).

### New: `EmergencyContact`
1:N from `User`. Phone required, email + relationship optional. `@@index([userId])`.

### New: `GymMembershipRequest`
Unified two-direction model (per the scoping discussion in #120):
- `direction`: `STAFF_INVITED` (gym staff invites a user by email) or `USER_REQUESTED` (user requests to join a gym).
- `status`: `PENDING` | `APPROVED` | `DECLINED` | `REVOKED` | `EXPIRED`.
- Optional `userId` (required for `USER_REQUESTED`; populated on `STAFF_INVITED` accept when email matches a user).
- Optional `email` (required for `STAFF_INVITED`).
- `roleToGrant`, `invitedById`, `decidedById`, `decidedAt`, `expiresAt`.
- Indexed for the three lookup paths: gym-inbox (`gymId, status`), user-inbox (`userId, status`), email-lookup-on-signup (`email, status`).

### Backfill
Migration ends with an idempotent `UPDATE` that splits existing `User.name` into `firstName`/`lastName` on first whitespace. Single-token names land entirely in `firstName`. Multi-token names put the first token in `firstName` and the remainder (preserving middle names like "Mary Anne Smith" → "Anne Smith") in `lastName`. Null/empty names leave both columns null. Guarded by `WHERE firstName IS NULL AND lastName IS NULL` so re-running is safe.

Verified against the dev DB:

| name | firstName | lastName |
|---|---|---|
| Test User | Test | User |
| Coach Jane | Coach | Jane |
| Test | Test | _(null)_ |
| Sub Tester | Sub | Tester |
| _(null)_ | _(null)_ | _(null)_ |
| NW Programmer | NW | Programmer |

## Tests

This is a schema-only change. No new test files in this PR — the new fields/models are unused by any code path. Behavior changes (and tests for them) land in B / D1 / D2 / C:

- **Slice B** (#122) will add API integration tests for the profile + emergency-contact endpoints, plus unit + Playwright coverage of the `/onboarding` flow.
- **Slice D1** (#123) and **D2** (#124) will add API integration tests for the `GymMembershipRequest` lifecycle in both directions.
- **Slice C** (#125) will cover avatar upload.

What was verified for this PR:
- `npm run db:migrate` applies cleanly against the dev DB.
- Backfill produces the expected output (table above).
- `npx tsc --noEmit` clean in both `apps/api` and `packages/db`.
- `npx turbo lint` (web) clean.

**Not automated / manual verification needed:**
- [ ] Apply migration against staging/prod-like data once available, confirming the backfill behaves correctly on real names. (Local fixtures are synthetic.)

## Out of scope (intentional)

- Any API endpoint or UI consuming the new fields/models — those land in B/D1/D2/C.
- Partial unique indexes for dedupe (e.g. one PENDING invite per `(gymId, email)`); enforced at the API layer in D1/D2 and added later if needed.
- `Gym.isPublic` — discoverability is unrestricted in this scope per #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)