### PR TITLE
chore(db): add ProgramVisibility enum + Program.visibility column (slice 4 prep)

### DIFF
--- a/packages/db/prisma/migrations/20260427144931_add_program_visibility/migration.sql
+++ b/packages/db/prisma/migrations/20260427144931_add_program_visibility/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "ProgramVisibility" AS ENUM ('PUBLIC', 'PRIVATE');
+
+-- AlterTable
+ALTER TABLE "Program" ADD COLUMN     "visibility" "ProgramVisibility" NOT NULL DEFAULT 'PRIVATE';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -97,6 +97,15 @@ enum ProgramRole {
   PROGRAMMER
 }
 
+// Discoverability of a Program. PUBLIC programs surface in the gym's Browse
+// page and any gym member can self-subscribe. PRIVATE programs require staff
+// invite (slice 3 endpoints). Default PRIVATE so existing programs don't
+// accidentally become discoverable on migration.
+enum ProgramVisibility {
+  PUBLIC
+  PRIVATE
+}
+
 enum WorkoutCategory {
   GIRL_WOD    // e.g. Fran, Cindy, Grace
   HERO_WOD    // e.g. Murph, Badger, DT
@@ -171,14 +180,15 @@ model UserGym {
 }
 
 model Program {
-  id          String    @id @default(cuid())
+  id          String            @id @default(cuid())
   name        String
   description String?
   startDate   DateTime
   endDate     DateTime?
   coverColor  String?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  visibility  ProgramVisibility @default(PRIVATE)
+  createdAt   DateTime          @default(now())
+  updatedAt   DateTime          @updatedAt
 
   gyms     GymProgram[]
   members  UserProgram[]


### PR DESCRIPTION
**Prep for slice 4 of #82 (#87)**

## Summary

Additive schema change ahead of the slice 4 feature work. Adds:
- `ProgramVisibility` enum (`PUBLIC` | `PRIVATE`)
- `Program.visibility` column with `@default(PRIVATE)`

Per the CLAUDE.md "Isolate migration PRs" guidance, this ships standalone so the slice 4 PR (API + UI for visibility, browse page, self-subscribe) can be reviewed without the schema change blocking it.

## Migration

```sql
-- CreateEnum
CREATE TYPE "ProgramVisibility" AS ENUM ('PUBLIC', 'PRIVATE');

-- AlterTable
ALTER TABLE "Program" ADD COLUMN     "visibility" "ProgramVisibility" NOT NULL DEFAULT 'PRIVATE';
```

## Why `PRIVATE` default

Existing programs predate any notion of visibility and were never advertised on a "Browse" surface. Defaulting them to `PRIVATE` is the safe choice — they keep behaving exactly as they do today, and staff can flip individual programs to `PUBLIC` once slice 4 lands. Defaulting to `PUBLIC` would retroactively expose every existing program to a discovery flow they were never designed for.

## Verification

- Schema applied locally; `\d "Program"` shows the column with default; `\dT "ProgramVisibility"` shows the enum.
- Migration file committed alongside (per CLAUDE.md "Schema migrations — required pre-merge checklist item").
- No code references `visibility` yet — the slice 4 PR adds those readers/writers.

## What's next

After this lands, the slice 4 PR will:
- Accept `visibility` on `PATCH /api/programs/:id`
- Include it in list/detail responses
- Add `GET /api/gyms/:gymId/programs/browse` (public-only, not-yet-joined)
- Repurpose `POST /api/programs/:id/subscribe` as self-subscribe (rejects PRIVATE with 403)
- Tighten `/workouts?programIds=…` so PRIVATE programs require staff role or a UserProgram row
- New "Browse Programs" page + sidebar entry; visibility badges on cards/detail; visibility radio in the edit drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)