### PR TITLE
feat(programs): Slice 4 — visibility (PUBLIC/PRIVATE) + Browse + self-subscribe

### DIFF
--- a/apps/api/src/db/gymProgramDbManager.ts
+++ b/apps/api/src/db/gymProgramDbManager.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@wodalytics/db'
+import { prisma, type ProgramVisibility } from '@wodalytics/db'
 
 interface CreateProgramData {
   name: string
@@ -6,6 +6,7 @@ interface CreateProgramData {
   startDate: string | Date
   endDate?: string | Date
   coverColor?: string
+  visibility?: ProgramVisibility
 }
 
 const programCountSelect = {
@@ -39,9 +40,32 @@ export async function createProgramAndLinkToGym(gymId: string, data: CreateProgr
       startDate: new Date(data.startDate),
       endDate: data.endDate ? new Date(data.endDate) : undefined,
       coverColor: data.coverColor,
+      visibility: data.visibility,
       gyms: { create: { gymId } },
     },
     include: programCountSelect,
   })
   return { program }
+}
+
+/**
+ * Lists PUBLIC programs in the gym that the caller has NOT yet joined.
+ * Drives the Browse page (slice 4 / #87). Caller's gym membership is
+ * already vetted by the route guard.
+ */
+export async function findBrowseProgramsForGymAndUser(gymId: string, userId: string) {
+  return prisma.gymProgram.findMany({
+    where: {
+      gymId,
+      program: {
+        visibility: 'PUBLIC',
+        // Exclude programs the caller is already a member of.
+        members: { none: { userId } },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+    include: {
+      program: { include: programCountSelect },
+    },
+  })
 }

--- a/apps/api/src/db/programDbManager.ts
+++ b/apps/api/src/db/programDbManager.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@wodalytics/db'
+import { prisma, type ProgramVisibility } from '@wodalytics/db'
 
 interface UpdateProgramData {
   name?: string
@@ -6,6 +6,7 @@ interface UpdateProgramData {
   startDate?: Date
   endDate?: Date | null
   coverColor?: string | null
+  visibility?: ProgramVisibility
 }
 
 export async function findProgramWithGymIds(id: string) {
@@ -39,22 +40,41 @@ export async function createProgramByName(name: string, startDate: Date = new Da
 
 export type ProgramGymAccessResult = 'ok' | 'not-found' | 'forbidden'
 
-// Verify the program exists, is linked to the given gym, and the caller is a
-// member of that gym. Used by the workouts list endpoint when a `?programId`
-// query param is present (route-level `requireGymMembership` already vetted
-// caller-vs-gym; this helper just ties program-vs-gym into the picture).
-//
-// Slice 2 deliberately does not enforce visibility (PUBLIC vs PRIVATE) — that
-// arrives in slice 4 (#87) and tightens this same check.
+/**
+ * Visibility-aware access check for the workouts list endpoint
+ * (`GET /workouts?programIds=…`).
+ *
+ *   - Program must be linked to the gym (program-vs-gym vetting).
+ *   - PUBLIC programs are visible to every gym member.
+ *   - PRIVATE programs require either staff role in any linked gym
+ *     (OWNER / PROGRAMMER / COACH) or an existing `UserProgram` row for
+ *     the caller. Members who haven't been invited get a 403 even though
+ *     they're in the gym.
+ *
+ * Caller-vs-gym is checked by the route guard before this is called.
+ */
 export async function findProgramGymAccessForUser(
   programId: string,
   gymId: string,
+  userId: string,
+  callerGymRole: string,
 ): Promise<ProgramGymAccessResult> {
   const program = await prisma.program.findUnique({
     where: { id: programId },
-    select: { gyms: { where: { gymId }, select: { gymId: true } } },
+    select: {
+      visibility: true,
+      gyms: { where: { gymId }, select: { gymId: true } },
+    },
   })
   if (!program) return 'not-found'
   if (program.gyms.length === 0) return 'forbidden'
-  return 'ok'
+  if (program.visibility === 'PUBLIC') return 'ok'
+
+  // PRIVATE: staff bypass + UserProgram subscribers
+  if (callerGymRole === 'OWNER' || callerGymRole === 'PROGRAMMER' || callerGymRole === 'COACH') return 'ok'
+  const sub = await prisma.userProgram.findUnique({
+    where: { userId_programId: { userId, programId } },
+    select: { userId: true },
+  })
+  return sub ? 'ok' : 'forbidden'
 }

--- a/apps/api/src/routes/programs.ts
+++ b/apps/api/src/routes/programs.ts
@@ -22,6 +22,7 @@ import {
   findProgramsWithDetailsByGymId,
   findProgramWithDetailsByIdAndGymId,
   createProgramAndLinkToGym,
+  findBrowseProgramsForGymAndUser,
 } from '../db/gymProgramDbManager.js'
 import {
   findProgramWithGymIds,
@@ -34,7 +35,6 @@ import {
 } from '../db/userGymDbManager.js'
 import {
   findProgramById,
-  subscribeUserToProgram,
   unsubscribeUserFromProgram,
   createUserProgramSubscription,
   findProgramMembersWithUserInfo,
@@ -55,6 +55,9 @@ router.get('/me/programs', requireAuth, listMyProgramsInGym)
 
 // GET  /api/gyms/:gymId/programs
 router.get('/gyms/:gymId/programs', requireAuth, validateGymExists, requireGymMembership, listProgramsForGym)
+
+// GET  /api/gyms/:gymId/programs/browse  — PUBLIC programs the caller hasn't joined yet (slice 4)
+router.get('/gyms/:gymId/programs/browse', requireAuth, validateGymExists, requireGymMembership, listBrowseProgramsForGym)
 
 // POST /api/gyms/:gymId/programs
 router.post('/gyms/:gymId/programs', requireAuth, validateGymExists, requireGymWriteAccess, createProgramForGym)
@@ -77,12 +80,14 @@ router.post('/programs/:id/members', requireAuth, requireProgramGymManager, invi
 // DELETE /api/programs/:id/members/:userId  — remove a member's subscription (slice 3)
 router.delete('/programs/:id/members/:userId', requireAuth, requireProgramGymManager, removeProgramMember)
 
-// POST   /api/programs/:id/subscribe  — used by the gym-level Members page (per-member view).
-//        Predates slice 3's cleaner /members routes; left in place so the existing UI keeps working.
-router.post('/programs/:id/subscribe', subscribeToProgram)
+// POST /api/programs/:id/subscribe  — self-subscribe (slice 4). Caller must be
+//        a member of one of the program's linked gyms; program must be PUBLIC.
+//        Returns 403 on PRIVATE, 409 on duplicate.
+router.post('/programs/:id/subscribe', requireAuth, selfSubscribeToProgram)
 
-// DELETE /api/programs/:id/subscribe  — see note above
-router.delete('/programs/:id/subscribe', unsubscribeFromProgram)
+// DELETE /api/programs/:id/subscribe  — leave a program (slice 4). Mirrors the
+//        self-subscribe endpoint. Staff-managed removal lives at /members/:userId.
+router.delete('/programs/:id/subscribe', requireAuth, selfUnsubscribeFromProgram)
 
 export default router
 
@@ -138,15 +143,23 @@ async function patchProgram(req: Request, res: Response) {
     return res.status(400).json({ error: `${field}: ${message}` })
   }
 
-  const { name, description, startDate, endDate, coverColor } = parsed.data
+  const { name, description, startDate, endDate, coverColor, visibility } = parsed.data
   const program = await updateProgramById(req.params.id as string, {
     name,
     description,
     startDate: startDate ? new Date(startDate) : undefined,
     endDate: endDate === null ? null : endDate ? new Date(endDate) : undefined,
     coverColor,
+    visibility,
   })
   res.json(program)
+}
+
+async function listBrowseProgramsForGym(req: Request, res: Response) {
+  const gymId = req.params.gymId as string
+  const userId = req.user!.id
+  const rows = await findBrowseProgramsForGymAndUser(gymId, userId)
+  res.json(rows)
 }
 
 async function deleteProgram(req: Request, res: Response) {
@@ -230,19 +243,51 @@ async function removeProgramMember(req: Request, res: Response) {
   res.status(204).send()
 }
 
-async function subscribeToProgram(req: Request, res: Response) {
-  const { userId, role } = req.body as { userId: string; role?: 'MEMBER' | 'PROGRAMMER' }
-  const program = await findProgramById(req.params.id as string)
-  if (!program) return res.status(404).json({ error: 'Program not found' })
+async function selfSubscribeToProgram(req: Request, res: Response) {
+  const programId = req.params.id as string
+  const userId = req.user!.id
 
-  const programRole = role === 'PROGRAMMER' ? ProgramRole.PROGRAMMER : ProgramRole.MEMBER
-  const userProgram = await subscribeUserToProgram(userId, req.params.id as string, programRole)
-  res.status(201).json(userProgram)
+  const programWithGyms = await findProgramWithGymIds(programId)
+  if (!programWithGyms) return res.status(404).json({ error: 'Program not found' })
+
+  // Caller must belong to at least one gym linked to the program. Otherwise
+  // they can't even know the program exists, let alone subscribe.
+  const callerInLinkedGym = await isUserMemberOfAnyGym(userId, programWithGyms.gyms.map((g) => g.gymId))
+  if (!callerInLinkedGym) return res.status(403).json({ error: 'Forbidden' })
+
+  // Visibility check — PRIVATE programs only accept staff-managed invites.
+  const programMeta = await findProgramById(programId)
+  if (programMeta?.visibility === 'PRIVATE') {
+    return res.status(403).json({ error: 'This program is private. Ask a staff member for an invite.' })
+  }
+
+  try {
+    const created = await createUserProgramSubscription(userId, programId, ProgramRole.MEMBER)
+    res.status(201).json({
+      programId,
+      userId: created.userId,
+      role: created.role,
+      joinedAt: created.joinedAt,
+    })
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+      return res.status(409).json({ error: 'Already a member' })
+    }
+    throw err
+  }
 }
 
-async function unsubscribeFromProgram(req: Request, res: Response) {
-  const { userId } = req.body as { userId: string }
-  await unsubscribeUserFromProgram(userId, req.params.id as string)
+async function selfUnsubscribeFromProgram(req: Request, res: Response) {
+  const programId = req.params.id as string
+  const userId = req.user!.id
+  try {
+    await unsubscribeUserFromProgram(userId, programId)
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+      return res.status(404).json({ error: 'Not a member' })
+    }
+    throw err
+  }
   res.status(204).send()
 }
 

--- a/apps/api/src/routes/workouts.ts
+++ b/apps/api/src/routes/workouts.ts
@@ -90,10 +90,12 @@ async function getWorkoutsByGymAndDateRange(req: Request, res: Response) {
     ? rawProgramIds.split(',').map((s) => s.trim()).filter(Boolean)
     : []
   if (programIdList.length > 0) {
-    // Each id is independently access-checked. Return the first failure so
-    // a malformed url in the picker doesn't silently leak a partial result.
+    // Each id is independently access-checked. Visibility-aware (slice 4):
+    // PRIVATE programs require staff role in any linked gym OR a UserProgram
+    // row; PUBLIC programs are visible to every gym member.
+    const callerGymRole = membership?.role ?? 'MEMBER'
     for (const id of programIdList) {
-      const access = await findProgramGymAccessForUser(id, gymId)
+      const access = await findProgramGymAccessForUser(id, gymId, req.user!.id, callerGymRole)
       if (access === 'not-found') return res.status(404).json({ error: `Program not found: ${id}` })
       if (access === 'forbidden') return res.status(403).json({ error: 'Forbidden' })
     }

--- a/apps/api/tests/programs.ts
+++ b/apps/api/tests/programs.ts
@@ -255,10 +255,10 @@ async function runTests() {
   // Three fresh programs: A1 + A2 linked to `gymId` (caller's gym), B linked to
   // `otherGymId` only. One workout per program, all in the test date range.
   const programA1 = await prisma.program.create({
-    data: { name: `Filter A1 ${TS}`, startDate: new Date('2026-05-01'), gyms: { create: { gymId } } },
+    data: { name: `Filter A1 ${TS}`, startDate: new Date('2026-05-01'), visibility: 'PUBLIC', gyms: { create: { gymId } } },
   })
   const programA2 = await prisma.program.create({
-    data: { name: `Filter A2 ${TS}`, startDate: new Date('2026-05-01'), gyms: { create: { gymId } } },
+    data: { name: `Filter A2 ${TS}`, startDate: new Date('2026-05-01'), visibility: 'PUBLIC', gyms: { create: { gymId } } },
   })
   const programB = await prisma.program.create({
     data: { name: `Filter B ${TS}`, startDate: new Date('2026-05-01'), gyms: { create: { gymId: otherGymId } } },
@@ -507,6 +507,149 @@ async function runTests() {
     const r = await api('GET', `/me/programs?gymId=${gymId}`)
     check('me/programs without auth → 401', 401, r.status)
   }
+
+  // ── Slice 4 — visibility, browse, self-subscribe ───────────────────────────
+  console.log('\n=== Slice 4: visibility + browse + self-subscribe ===')
+
+  {
+    // Default visibility on a freshly created program is PRIVATE.
+    const r = await api('POST', `/gyms/${gymId}/programs`, programmerToken, {
+      name: `Visibility default ${TS}`,
+      startDate: '2026-06-01',
+    })
+    check('POST without visibility → 201', 201, r.status)
+    const created = r.body.program as { id: string; visibility: string } | undefined
+    check('POST default visibility = PRIVATE', 'PRIVATE', created?.visibility)
+    if (created?.id) createdProgramIds.push(created.id)
+  }
+
+  // Two slice-4 fixture programs: one PUBLIC, one PRIVATE, both linked to gymId.
+  const publicProgram = await prisma.program.create({
+    data: {
+      name: `Slice4 Public ${TS}`,
+      startDate: new Date('2026-06-01'),
+      visibility: 'PUBLIC',
+      gyms: { create: { gymId } },
+    },
+  })
+  const privateProgram = await prisma.program.create({
+    data: {
+      name: `Slice4 Private ${TS}`,
+      startDate: new Date('2026-06-01'),
+      visibility: 'PRIVATE',
+      gyms: { create: { gymId } },
+    },
+  })
+  createdProgramIds.push(publicProgram.id, privateProgram.id)
+
+  {
+    // PATCH visibility flip
+    const r = await api('PATCH', `/programs/${privateProgram.id}`, programmerToken, { visibility: 'PUBLIC' })
+    check('PATCH visibility=PUBLIC → 200', 200, r.status)
+    check('PATCH visibility persisted', 'PUBLIC', r.body.visibility)
+    // Flip back so subsequent assertions still see it as PRIVATE.
+    await api('PATCH', `/programs/${privateProgram.id}`, programmerToken, { visibility: 'PRIVATE' })
+  }
+
+  {
+    // PATCH visibility as MEMBER → 403
+    const r = await api('PATCH', `/programs/${publicProgram.id}`, memberToken, { visibility: 'PRIVATE' })
+    check('PATCH visibility as MEMBER → 403', 403, r.status)
+  }
+
+  {
+    // Browse: only PUBLIC programs the caller hasn't joined
+    const r = await api('GET', `/gyms/${gymId}/programs/browse`, memberToken)
+    check('GET browse as MEMBER → 200', 200, r.status)
+    const ids = (r.body as unknown as { programId: string }[]).map((g) => g.programId)
+    check('Browse includes PUBLIC program', true, ids.includes(publicProgram.id))
+    check('Browse excludes PRIVATE program', false, ids.includes(privateProgram.id))
+  }
+
+  {
+    // Self-subscribe to PUBLIC → 201, then duplicate → 409
+    const r = await api('POST', `/programs/${publicProgram.id}/subscribe`, memberToken)
+    check('POST subscribe (PUBLIC) → 201', 201, r.status)
+    check('POST subscribe → role=MEMBER', 'MEMBER', r.body.role)
+  }
+
+  {
+    const r = await api('POST', `/programs/${publicProgram.id}/subscribe`, memberToken)
+    check('POST subscribe duplicate → 409', 409, r.status)
+  }
+
+  {
+    // After joining, browse no longer surfaces the same program
+    const r = await api('GET', `/gyms/${gymId}/programs/browse`, memberToken)
+    const ids = (r.body as unknown as { programId: string }[]).map((g) => g.programId)
+    check('Browse drops just-joined program', false, ids.includes(publicProgram.id))
+  }
+
+  {
+    // Self-subscribe to PRIVATE → 403
+    const r = await api('POST', `/programs/${privateProgram.id}/subscribe`, memberToken)
+    check('POST subscribe (PRIVATE) → 403', 403, r.status)
+  }
+
+  {
+    // Outsider (in otherGymId only) → 403, not 404, so we don't leak existence
+    const r = await api('POST', `/programs/${publicProgram.id}/subscribe`, outsiderToken)
+    check('POST subscribe as non-gym user → 403', 403, r.status)
+  }
+
+  {
+    // Self-unsubscribe — leave the program
+    const r = await api('DELETE', `/programs/${publicProgram.id}/subscribe`, memberToken)
+    check('DELETE subscribe (own membership) → 204', 204, r.status)
+  }
+
+  {
+    // Already left → 404 from the same endpoint
+    const r = await api('DELETE', `/programs/${publicProgram.id}/subscribe`, memberToken)
+    check('DELETE subscribe (already left) → 404', 404, r.status)
+  }
+
+  // ── Visibility-aware /workouts?programIds=… (slice 4 tightening) ────────────
+
+  // Seed one PUBLISHED workout in the PRIVATE program.
+  const privateWorkout = await prisma.workout.create({
+    data: {
+      programId: privateProgram.id, title: 'Private workout', description: 'private', type: 'AMRAP',
+      scheduledAt: new Date('2026-06-10T12:00:00Z'), status: 'PUBLISHED',
+    },
+  })
+
+  const range4 = 'from=2026-06-01&to=2026-06-30T23:59:59Z'
+
+  {
+    // MEMBER (no UserProgram row) hitting /workouts?programIds=<private> → 403
+    const r = await api('GET', `/gyms/${gymId}/workouts?${range4}&programIds=${privateProgram.id}`, memberToken)
+    check('GET ?programIds=<private> as MEMBER → 403', 403, r.status)
+  }
+
+  {
+    // Coach (gym staff) gets through despite no UserProgram row
+    const r = await api('GET', `/gyms/${gymId}/workouts?${range4}&programIds=${privateProgram.id}`, coachToken)
+    check('GET ?programIds=<private> as COACH → 200', 200, r.status)
+  }
+
+  {
+    // OWNER bypasses too
+    const r = await api('GET', `/gyms/${gymId}/workouts?${range4}&programIds=${privateProgram.id}`, ownerToken)
+    check('GET ?programIds=<private> as OWNER → 200', 200, r.status)
+  }
+
+  {
+    // Subscribe member directly so they can see PRIVATE workouts they were invited to
+    await prisma.userProgram.create({ data: { userId: memberUserId, programId: privateProgram.id, role: 'MEMBER' } })
+    const r = await api('GET', `/gyms/${gymId}/workouts?${range4}&programIds=${privateProgram.id}`, memberToken)
+    check('GET ?programIds=<private> as subscribed MEMBER → 200', 200, r.status)
+    await prisma.userProgram.delete({
+      where: { userId_programId: { userId: memberUserId, programId: privateProgram.id } },
+    })
+  }
+
+  await prisma.workout.delete({ where: { id: privateWorkout.id } })
 }
 
 // ─── Teardown ─────────────────────────────────────────────────────────────────

--- a/apps/api/tests/workouts.ts
+++ b/apps/api/tests/workouts.ts
@@ -282,37 +282,10 @@ async function runTests() {
   if (dayOrderWorkout1Id) await prisma.workout.delete({ where: { id: dayOrderWorkout1Id } })
   if (dayOrderWorkout2Id) await prisma.workout.delete({ where: { id: dayOrderWorkout2Id } })
 
-  // ── Subscribe role ─────────────────────────────────────────────────────────
-  console.log('\n=== Subscribe role ===')
-
-  {
-    const u = await prisma.user.create({ data: { email: `at-sub-prog-${TS}@test.com` } })
-    const r = await api('POST', `/programs/${programId}/subscribe`, undefined, {
-      userId: u.id,
-      role: 'PROGRAMMER',
-    })
-    check('POST /programs/:id/subscribe role=PROGRAMMER → 201', 201, r.status)
-    check('POST /programs/:id/subscribe → role=PROGRAMMER', 'PROGRAMMER', r.body.role)
-    await prisma.user.delete({ where: { id: u.id } })
-  }
-
-  {
-    const u = await prisma.user.create({ data: { email: `at-sub-mem-${TS}@test.com` } })
-    const r = await api('POST', `/programs/${programId}/subscribe`, undefined, { userId: u.id })
-    check('POST /programs/:id/subscribe (no role) → 201', 201, r.status)
-    check('POST /programs/:id/subscribe → role=MEMBER', 'MEMBER', r.body.role)
-    await prisma.user.delete({ where: { id: u.id } })
-  }
-
-  {
-    // memberUser is already subscribed as MEMBER — re-subscribe promotes to PROGRAMMER
-    const r = await api('POST', `/programs/${programId}/subscribe`, undefined, {
-      userId: memberUserId,
-      role: 'PROGRAMMER',
-    })
-    check('Re-subscribe MEMBER as PROGRAMMER → 201', 201, r.status)
-    check('Re-subscribe → role promoted to PROGRAMMER', 'PROGRAMMER', r.body.role)
-  }
+  // (The legacy "Subscribe role" block lived here. Slice 4 (#87) repurposed
+  // POST /programs/:id/subscribe as auth'd self-subscribe; staff-managed
+  // membership now uses POST /programs/:id/members. Coverage moved to
+  // apps/api/tests/programs.ts under the slice-3 + slice-4 sections.)
 
   // ── Workout auth: gym-linked program (#118) ────────────────────────────────
   // Regression coverage for the bug where workout write access ran the caller's

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,6 +15,7 @@ import Calendar from './pages/Calendar.tsx'
 import Members from './pages/Members.tsx'
 import ProgramsIndex from './pages/ProgramsIndex.tsx'
 import ProgramDetail from './pages/ProgramDetail.tsx'
+import BrowsePrograms from './pages/BrowsePrograms.tsx'
 import Settings from './pages/Settings.tsx'
 import Feed from './pages/Feed.tsx'
 import WodDetail from './pages/WodDetail.tsx'
@@ -64,6 +65,7 @@ function AppLayout() {
               <Route path="/calendar" element={<Calendar />} />
               <Route path="/programs" element={<ProgramsIndex />} />
               <Route path="/programs/:id" element={<ProgramDetail />} />
+              <Route path="/browse-programs" element={<BrowsePrograms />} />
               <Route path="/members" element={<Members />} />
               <Route path="/settings" element={<Settings />} />
             </Routes>

--- a/apps/web/src/components/ProgramFormDrawer.tsx
+++ b/apps/web/src/components/ProgramFormDrawer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { api, type Program } from '../lib/api'
+import { api, type Program, type ProgramVisibility } from '../lib/api'
 import Button from './ui/Button'
 
 const COVER_COLORS = [
@@ -33,6 +33,7 @@ export default function ProgramFormDrawer({ gymId, program, open, onClose, onSav
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
   const [coverColor, setCoverColor] = useState<string | null>(null)
+  const [visibility, setVisibility] = useState<ProgramVisibility>('PRIVATE')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -43,6 +44,7 @@ export default function ProgramFormDrawer({ gymId, program, open, onClose, onSav
     setStartDate(toDateInputValue(program?.startDate))
     setEndDate(toDateInputValue(program?.endDate))
     setCoverColor(program?.coverColor ?? null)
+    setVisibility(program?.visibility ?? 'PRIVATE')
     setError(null)
   }, [open, program?.id])
 
@@ -68,6 +70,7 @@ export default function ProgramFormDrawer({ gymId, program, open, onClose, onSav
           startDate,
           endDate: endDate || null,
           coverColor: coverColor || null,
+          visibility,
         })
         onSaved(updated)
       } else {
@@ -77,6 +80,7 @@ export default function ProgramFormDrawer({ gymId, program, open, onClose, onSav
           startDate,
           endDate: endDate || undefined,
           coverColor: coverColor || undefined,
+          visibility,
         })
         onSaved(created)
       }
@@ -192,6 +196,40 @@ export default function ProgramFormDrawer({ gymId, program, open, onClose, onSav
                   ].join(' ')}
                 />
               ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs text-gray-400 mb-2">Visibility</label>
+            <div className="grid grid-cols-1 gap-2">
+              {([
+                { value: 'PRIVATE', label: '🔒 Private', body: 'Staff invite only — members must be added to see the program.' },
+                { value: 'PUBLIC',  label: '🌐 Public',  body: 'Any gym member can find and join from Browse Programs.' },
+              ] as const).map((opt) => {
+                const checked = visibility === opt.value
+                return (
+                  <label
+                    key={opt.value}
+                    className={[
+                      'flex items-start gap-3 px-3 py-2 rounded border cursor-pointer transition-colors',
+                      checked ? 'border-indigo-500 bg-indigo-500/10' : 'border-gray-700 hover:border-gray-600',
+                    ].join(' ')}
+                  >
+                    <input
+                      type="radio"
+                      name="visibility"
+                      value={opt.value}
+                      checked={checked}
+                      onChange={() => setVisibility(opt.value)}
+                      className="mt-1 h-4 w-4 border-gray-600 bg-gray-800 text-indigo-500 focus:ring-indigo-500"
+                    />
+                    <span className="min-w-0">
+                      <span className="block text-sm text-white">{opt.label}</span>
+                      <span className="block text-xs text-gray-400 mt-0.5">{opt.body}</span>
+                    </span>
+                  </label>
+                )
+              })}
             </div>
           </div>
         </div>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import ProgramFilterPicker from './ProgramFilterPicker.tsx'
 const memberLinks = [
   { to: '/feed',    label: 'Feed'    },
   { to: '/history', label: 'History' },
+  { to: '/browse-programs', label: 'Browse Programs' },
 ]
 
 const staffLinks = [

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -192,6 +192,8 @@ export interface Member {
   programs: { id: string; name: string }[]
 }
 
+export type ProgramVisibility = 'PUBLIC' | 'PRIVATE'
+
 export interface Program {
   id: string
   name: string
@@ -199,6 +201,7 @@ export interface Program {
   startDate: string
   endDate: string | null
   coverColor: string | null
+  visibility: ProgramVisibility
   createdAt: string
   updatedAt: string
   _count?: { members: number; workouts: number }
@@ -326,7 +329,7 @@ export const api = {
 
       create: (
         gymId: string,
-        data: { name: string; description?: string; startDate: string; endDate?: string; coverColor?: string },
+        data: { name: string; description?: string; startDate: string; endDate?: string; coverColor?: string; visibility?: ProgramVisibility },
         token?: string,
       ) =>
         req<{ program: Program }>(`/api/gyms/${gymId}/programs`, {
@@ -334,6 +337,9 @@ export const api = {
           body: JSON.stringify(data),
           token,
         }),
+
+      browse: (gymId: string, token?: string) =>
+        req<GymProgram[]>(`/api/gyms/${gymId}/programs/browse`, { token }),
     },
   },
 
@@ -479,6 +485,7 @@ export const api = {
         startDate?: string
         endDate?: string | null
         coverColor?: string | null
+        visibility?: ProgramVisibility
       },
       token?: string,
     ) =>
@@ -509,18 +516,19 @@ export const api = {
         req<void>(`/api/programs/${programId}/members/${userId}`, { method: 'DELETE', token }),
     },
 
-    subscribe: (id: string, userId: string, token?: string) =>
-      req<unknown>(`/api/programs/${id}/subscribe`, {
-        method: 'POST',
-        body: JSON.stringify({ userId }),
-        token,
-      }),
+    /**
+     * Self-subscribe to a PUBLIC program (slice 4). Server returns 403 on
+     * PRIVATE programs, 409 on duplicate. Drives the Browse page's Join
+     * button.
+     */
+    subscribe: (id: string, token?: string) =>
+      req<{ programId: string; userId: string; role: ProgramRole; joinedAt: string }>(
+        `/api/programs/${id}/subscribe`,
+        { method: 'POST', token },
+      ),
 
-    unsubscribe: (id: string, userId: string, token?: string) =>
-      req<void>(`/api/programs/${id}/subscribe`, {
-        method: 'DELETE',
-        body: JSON.stringify({ userId }),
-        token,
-      }),
+    /** Leave a program — caller's own membership only. */
+    unsubscribe: (id: string, token?: string) =>
+      req<void>(`/api/programs/${id}/subscribe`, { method: 'DELETE', token }),
   },
 }

--- a/apps/web/src/pages/BrowsePrograms.tsx
+++ b/apps/web/src/pages/BrowsePrograms.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api, type GymProgram } from '../lib/api'
+import { useGym } from '../context/GymContext.tsx'
+import { useProgramFilter } from '../context/ProgramFilterContext.tsx'
+import Button from '../components/ui/Button'
+import EmptyState from '../components/ui/EmptyState'
+import Skeleton from '../components/ui/Skeleton'
+
+/**
+ * Browse Programs (slice 4 / #87)
+ *
+ * Lists PUBLIC programs in the caller's gym they have NOT yet joined. Click
+ * Join → POST /programs/:id/subscribe → land on the Feed filtered to the
+ * newly-joined program.
+ */
+export default function BrowsePrograms() {
+  const { gymId } = useGym()
+  const navigate = useNavigate()
+  const { setSelected: setProgramFilter } = useProgramFilter()
+  const [programs, setPrograms] = useState<GymProgram[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [joiningId, setJoiningId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!gymId) return
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    api.gyms.programs.browse(gymId)
+      .then((list) => { if (!cancelled) setPrograms(list) })
+      .catch((e) => { if (!cancelled) setError((e as Error).message) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [gymId])
+
+  async function handleJoin(programId: string) {
+    setJoiningId(programId)
+    setError(null)
+    try {
+      await api.programs.subscribe(programId)
+      // Drop the joined program from the list immediately for snappier UX.
+      setPrograms((prev) => prev.filter((gp) => gp.programId !== programId))
+      // Drop the user on the filtered Feed for the new program — completes the
+      // "found something interesting → seeing today's workout" loop in one click.
+      setProgramFilter([programId])
+      navigate('/feed')
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setJoiningId(null)
+    }
+  }
+
+  if (!gymId) {
+    return (
+      <div>
+        <h1 className="text-2xl font-bold mb-2">Browse programs</h1>
+        <p className="text-gray-400">Set up your gym in Settings first.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-1">Browse programs</h1>
+      <p className="text-sm text-gray-400 mb-6">Public programs you can join in this gym.</p>
+
+      {error && <p className="text-red-400 mb-4">{error}</p>}
+
+      {loading && <Skeleton variant="feed-row" count={3} />}
+
+      {!loading && programs.length === 0 && !error && (
+        <EmptyState
+          title="Nothing to browse right now"
+          body="Public programs will show up here when staff create them. Check back later, or ask a staff member for an invite to a private program."
+        />
+      )}
+
+      {programs.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {programs.map(({ program }) => {
+            const stripe = program.coverColor ?? '#374151'
+            const memberCount = program._count?.members ?? 0
+            return (
+              <div
+                key={program.id}
+                className="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden flex flex-col"
+              >
+                <div style={{ backgroundColor: stripe }} className="h-1.5 w-full" />
+                <div className="p-4 flex-1 flex flex-col">
+                  <h3 className="font-semibold text-white truncate">{program.name}</h3>
+                  {program.description && (
+                    <p className="mt-1 text-xs text-gray-400 line-clamp-3">{program.description}</p>
+                  )}
+                  <p className="mt-3 text-xs text-gray-400">
+                    {memberCount} {memberCount === 1 ? 'member' : 'members'}
+                  </p>
+                  <div className="mt-4 flex">
+                    <Button
+                      variant="primary"
+                      onClick={() => handleJoin(program.id)}
+                      disabled={joiningId === program.id}
+                      className="flex-1"
+                    >
+                      {joiningId === program.id ? 'Joining…' : 'Join'}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/Feed.test.tsx
+++ b/apps/web/src/pages/Feed.test.tsx
@@ -55,6 +55,7 @@ function makeGymProgram(id: string, name: string, coverColor: string | null = nu
       startDate: '2026-03-01T00:00:00.000Z',
       endDate: null,
       coverColor,
+      visibility: 'PRIVATE',
       createdAt: '2026-03-01T00:00:00.000Z',
       updatedAt: '2026-03-01T00:00:00.000Z',
     },

--- a/apps/web/src/pages/Members.tsx
+++ b/apps/web/src/pages/Members.tsx
@@ -85,7 +85,7 @@ export default function Members() {
 
   async function handleSubscribe(userId: string, programId: string) {
     try {
-      await api.programs.subscribe(programId, userId)
+      await api.programs.members.invite(programId, { userId })
       await loadData()
     } catch (e) {
       setError((e as Error).message)
@@ -94,7 +94,7 @@ export default function Members() {
 
   async function handleUnsubscribe(userId: string, programId: string) {
     try {
-      await api.programs.unsubscribe(programId, userId)
+      await api.programs.members.remove(programId, userId)
       await loadData()
     } catch (e) {
       setError((e as Error).message)

--- a/apps/web/src/pages/ProgramDetail.test.tsx
+++ b/apps/web/src/pages/ProgramDetail.test.tsx
@@ -28,7 +28,9 @@ vi.mock('../context/GymContext.tsx', () => ({
 
 import { api } from '../lib/api'
 
-function makeGymProgram(overrides: Partial<{ name: string; description: string | null }> = {}) {
+function makeGymProgram(
+  overrides: Partial<{ name: string; description: string | null; visibility: 'PUBLIC' | 'PRIVATE' }> = {},
+) {
   return {
     gymId: 'gym-1',
     programId: 'program-1',
@@ -40,6 +42,7 @@ function makeGymProgram(overrides: Partial<{ name: string; description: string |
       startDate: '2026-03-01T00:00:00.000Z',
       endDate: '2026-03-31T00:00:00.000Z',
       coverColor: '#6366F1',
+      visibility: overrides.visibility ?? 'PRIVATE' as const,
       createdAt: '2026-03-01T00:00:00.000Z',
       updatedAt: '2026-03-01T00:00:00.000Z',
       _count: { members: 5, workouts: 31 },
@@ -172,5 +175,21 @@ describe('ProgramDetail', () => {
 
     // The Members tab fetch should have been triggered
     await waitFor(() => expect(api.programs.members.list).toHaveBeenCalledWith('program-1'))
+  })
+
+  // ─── Visibility badge (slice 4) ────────────────────────────────────────────
+
+  it('renders the 🔒 Private visibility badge by default', async () => {
+    vi.mocked(api.programs.get).mockResolvedValue(makeGymProgram())
+    renderPage()
+    expect(await screen.findByRole('heading', { name: 'Override — March 2026' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Private program')).toBeInTheDocument()
+  })
+
+  it('renders the 🌐 Public visibility badge for a PUBLIC program', async () => {
+    vi.mocked(api.programs.get).mockResolvedValue(makeGymProgram({ visibility: 'PUBLIC' }))
+    renderPage()
+    expect(await screen.findByRole('heading', { name: 'Override — March 2026' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Public program')).toBeInTheDocument()
   })
 })

--- a/apps/web/src/pages/ProgramDetail.tsx
+++ b/apps/web/src/pages/ProgramDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { api, type GymProgram, type Program } from '../lib/api'
+import { api, type GymProgram, type Program, type ProgramVisibility } from '../lib/api'
 import { useGym } from '../context/GymContext.tsx'
 import Button from '../components/ui/Button'
 import Skeleton from '../components/ui/Skeleton'
@@ -87,7 +87,10 @@ export default function ProgramDetail() {
       <div className="flex items-start gap-4 mb-6">
         <div style={{ backgroundColor: stripe }} className="w-1.5 h-12 rounded-full shrink-0" />
         <div className="flex-1 min-w-0">
-          <h1 className="text-2xl font-bold truncate">{program.name}</h1>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h1 className="text-2xl font-bold truncate">{program.name}</h1>
+            <VisibilityBadge visibility={program.visibility} />
+          </div>
           {program.description && (
             <p className="mt-1 text-sm text-gray-400">{program.description}</p>
           )}
@@ -237,5 +240,23 @@ function ComingSoon({ label }: { label: string }) {
       <p className="text-sm text-gray-400">{label}</p>
       <p className="mt-1 text-xs text-gray-400">Coming in a later slice of #82</p>
     </div>
+  )
+}
+
+export function VisibilityBadge({ visibility, className = '' }: { visibility: ProgramVisibility; className?: string }) {
+  const isPublic = visibility === 'PUBLIC'
+  return (
+    <span
+      aria-label={isPublic ? 'Public program' : 'Private program'}
+      className={[
+        'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium border',
+        isPublic
+          ? 'bg-emerald-500/15 text-emerald-300 border-emerald-400/30'
+          : 'bg-gray-800 text-gray-300 border-gray-700',
+        className,
+      ].filter(Boolean).join(' ')}
+    >
+      {isPublic ? '🌐 Public' : '🔒 Private'}
+    </span>
   )
 }

--- a/apps/web/src/pages/ProgramsIndex.test.tsx
+++ b/apps/web/src/pages/ProgramsIndex.test.tsx
@@ -33,6 +33,7 @@ function makeGymProgram(overrides: Partial<{ id: string; name: string; memberCou
       startDate: '2026-03-01T00:00:00.000Z',
       endDate: null,
       coverColor: overrides.coverColor ?? null,
+      visibility: 'PRIVATE' as const,
       createdAt: '2026-03-01T00:00:00.000Z',
       updatedAt: '2026-03-01T00:00:00.000Z',
       _count: {

--- a/apps/web/src/pages/ProgramsIndex.tsx
+++ b/apps/web/src/pages/ProgramsIndex.tsx
@@ -6,6 +6,7 @@ import Button from '../components/ui/Button'
 import EmptyState from '../components/ui/EmptyState'
 import Skeleton from '../components/ui/Skeleton'
 import ProgramFormDrawer from '../components/ProgramFormDrawer'
+import { VisibilityBadge } from './ProgramDetail'
 
 function formatDateRange(start: string, end: string | null): string {
   const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', year: 'numeric' }
@@ -113,9 +114,12 @@ function ProgramCard({ program }: { program: Program }) {
     >
       <div style={{ backgroundColor: stripe }} className="h-1.5 w-full" />
       <div className="p-4">
-        <h3 className="font-semibold text-white truncate group-hover:text-indigo-300 transition-colors">
-          {program.name}
-        </h3>
+        <div className="flex items-start gap-2">
+          <h3 className="font-semibold text-white truncate group-hover:text-indigo-300 transition-colors flex-1 min-w-0">
+            {program.name}
+          </h3>
+          <VisibilityBadge visibility={program.visibility} className="shrink-0" />
+        </div>
         {program.description && (
           <p className="mt-1 text-xs text-gray-400 line-clamp-2">{program.description}</p>
         )}

--- a/apps/web/tests/programs.spec.ts
+++ b/apps/web/tests/programs.spec.ts
@@ -115,7 +115,9 @@ test.describe('Programs CRUD E2E', () => {
     await loginAndSelectGym(page, f.member.id, 'MEMBER', f.gymId)
     await page.goto('/feed')
     await expect(page.locator('aside').first()).toBeVisible()
-    await expect(page.locator('aside').first().getByRole('link', { name: 'Programs' })).toHaveCount(0)
+    // exact: true — slice 4 added a "Browse Programs" link visible to all roles,
+    // so the substring-match would falsely succeed.
+    await expect(page.locator('aside').first().getByRole('link', { name: 'Programs', exact: true })).toHaveCount(0)
   })
 
   test('OWNER deletes a program', async ({ page }) => {
@@ -262,6 +264,63 @@ test.describe('Programs CRUD E2E', () => {
         where: { userId_gymId: { userId: coach.id, gymId: f.gymId } },
       }).catch(() => {})
       await prisma.user.delete({ where: { id: coach.id } }).catch(() => {})
+    }
+  })
+
+  // ── #87: visibility + Browse + self-subscribe ──────────────────────────────
+  // ────────────────────────────────────────────────────────────────────────────
+
+  test('MEMBER joins a PUBLIC program from Browse and lands on its filtered Feed', async ({ page }) => {
+    const name = `E2E Browse Public ${randomUUID().slice(0, 6)}`
+    const seeded = await prisma.program.create({
+      data: {
+        name,
+        startDate: new Date('2026-06-01'),
+        visibility: 'PUBLIC',
+        coverColor: '#10B981',
+        gyms: { create: { gymId: f.gymId } },
+      },
+    })
+
+    await loginAndSelectGym(page, f.member.id, 'MEMBER', f.gymId)
+    await page.goto('/browse-programs')
+    await expect(page.locator('h1', { hasText: 'Browse programs' })).toBeVisible()
+
+    // The seeded PUBLIC program is on the page; click Join
+    await expect(page.getByText(name)).toBeVisible({ timeout: 5000 })
+    await page.getByRole('button', { name: 'Join' }).click()
+
+    // Lands on /feed (program filter set to the joined program by the page)
+    await page.waitForURL('**/feed**')
+
+    // The UserProgram row should now exist
+    const sub = await prisma.userProgram.findUnique({
+      where: { userId_programId: { userId: f.member.id, programId: seeded.id } },
+    })
+    expect(sub).not.toBeNull()
+  })
+
+  test('Browse hides PRIVATE programs and programs the user already joined', async ({ page }) => {
+    const ts = randomUUID().slice(0, 6)
+    const publicProgram = await prisma.program.create({
+      data: { name: `E2E Public ${ts}`, startDate: new Date('2026-06-01'), visibility: 'PUBLIC', gyms: { create: { gymId: f.gymId } } },
+    })
+    const privateProgram = await prisma.program.create({
+      data: { name: `E2E Private ${ts}`, startDate: new Date('2026-06-01'), visibility: 'PRIVATE', gyms: { create: { gymId: f.gymId } } },
+    })
+    const alreadyJoined = await prisma.program.create({
+      data: { name: `E2E Already Joined ${ts}`, startDate: new Date('2026-06-01'), visibility: 'PUBLIC', gyms: { create: { gymId: f.gymId } } },
+    })
+    await prisma.userProgram.create({ data: { userId: f.member.id, programId: alreadyJoined.id, role: 'MEMBER' } })
+
+    try {
+      await loginAndSelectGym(page, f.member.id, 'MEMBER', f.gymId)
+      await page.goto('/browse-programs')
+      await expect(page.getByText(publicProgram.name)).toBeVisible({ timeout: 5000 })
+      await expect(page.getByText(privateProgram.name)).not.toBeVisible()
+      await expect(page.getByText(alreadyJoined.name)).not.toBeVisible()
+    } finally {
+      await prisma.userProgram.deleteMany({ where: { programId: { in: [publicProgram.id, privateProgram.id, alreadyJoined.id] } } }).catch(() => {})
     }
   })
 })

--- a/packages/db/prisma/migrations/20260427144931_add_program_visibility/migration.sql
+++ b/packages/db/prisma/migrations/20260427144931_add_program_visibility/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "ProgramVisibility" AS ENUM ('PUBLIC', 'PRIVATE');
+
+-- AlterTable
+ALTER TABLE "Program" ADD COLUMN     "visibility" "ProgramVisibility" NOT NULL DEFAULT 'PRIVATE';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -97,6 +97,15 @@ enum ProgramRole {
   PROGRAMMER
 }
 
+// Discoverability of a Program. PUBLIC programs surface in the gym's Browse
+// page and any gym member can self-subscribe. PRIVATE programs require staff
+// invite (slice 3 endpoints). Default PRIVATE so existing programs don't
+// accidentally become discoverable on migration.
+enum ProgramVisibility {
+  PUBLIC
+  PRIVATE
+}
+
 enum WorkoutCategory {
   GIRL_WOD    // e.g. Fran, Cindy, Grace
   HERO_WOD    // e.g. Murph, Badger, DT
@@ -171,14 +180,15 @@ model UserGym {
 }
 
 model Program {
-  id          String    @id @default(cuid())
+  id          String            @id @default(cuid())
   name        String
   description String?
   startDate   DateTime
   endDate     DateTime?
   coverColor  String?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  visibility  ProgramVisibility @default(PRIVATE)
+  createdAt   DateTime          @default(now())
+  updatedAt   DateTime          @updatedAt
 
   gyms     GymProgram[]
   members  UserProgram[]

--- a/packages/types/src/program.ts
+++ b/packages/types/src/program.ts
@@ -4,12 +4,15 @@ const hexColor = z
   .string()
   .regex(/^#[0-9a-fA-F]{6}$/, 'coverColor must be a 6-digit hex like #6366F1')
 
+export const ProgramVisibilitySchema = z.enum(['PUBLIC', 'PRIVATE'])
+
 export const CreateProgramSchema = z.object({
   name: z.string().min(1, 'Name is required').max(120),
   description: z.string().max(2000).optional(),
   startDate: z.string().datetime({ offset: true }).or(z.string().date()),
   endDate: z.string().datetime({ offset: true }).or(z.string().date()).optional(),
   coverColor: hexColor.optional(),
+  visibility: ProgramVisibilitySchema.optional(),
 })
 
 export const UpdateProgramSchema = z
@@ -19,6 +22,7 @@ export const UpdateProgramSchema = z
     startDate: z.string().datetime({ offset: true }).or(z.string().date()).optional(),
     endDate: z.string().datetime({ offset: true }).or(z.string().date()).nullable().optional(),
     coverColor: hexColor.nullable().optional(),
+    visibility: ProgramVisibilitySchema.optional(),
   })
   .refine((data) => Object.keys(data).length > 0, { message: 'At least one field is required' })
 
@@ -39,3 +43,4 @@ export const InviteProgramMemberSchema = z
 export type CreateProgramInput = z.infer<typeof CreateProgramSchema>
 export type UpdateProgramInput = z.infer<typeof UpdateProgramSchema>
 export type InviteProgramMemberInput = z.infer<typeof InviteProgramMemberSchema>
+export type ProgramVisibility = z.infer<typeof ProgramVisibilitySchema>


### PR DESCRIPTION
**Closes #87 · Part of #82 · Builds on #127** (the migration PR — must merge first)

## Summary

Fourth vertical slice of the Programs feature. Programs gain a **visibility** axis — `PUBLIC` programs are discoverable on a new Browse page and any gym member can self-subscribe; `PRIVATE` programs require staff invite (slice 3 endpoints). Default `PRIVATE` so existing programs don't accidentally become discoverable.

The schema migration ships separately in **#127** (per CLAUDE.md "Isolate migration PRs"). This PR is feature-only and depends on #127 landing first.

## What ships

**API**

| Method | Path | Slice 4 behaviour |
|---|---|---|
| `POST`   | `/api/gyms/:gymId/programs` | accepts `visibility` in body |
| `PATCH`  | `/api/programs/:id` | accepts `visibility` (write access) |
| `GET`    | `/api/gyms/:gymId/programs/browse` | **NEW** — PUBLIC programs in the gym the caller hasn't joined yet |
| `POST`   | `/api/programs/:id/subscribe` | **REPURPOSED** — auth'd self-subscribe (was unauth'd staff-managed). Caller must be in any linked gym; program must be PUBLIC. `201` / `403` on PRIVATE / non-gym / `409` on duplicate. |
| `DELETE` | `/api/programs/:id/subscribe` | leave a program (own membership only) |
| `GET`    | `/api/gyms/:gymId/workouts?programIds=…` | **TIGHTENED** — PRIVATE programs require staff role in any linked gym OR a UserProgram subscription |

The legacy unauth'd `/subscribe?body=userId` semantics is gone. The gym-level Members page was migrated to the slice-3 `/members` endpoints in this PR.

**Web**
- New `BrowsePrograms` page at `/browse-programs` — grid of joinable PUBLIC programs with a Join button. Joining auto-applies the program filter and drops the user on `/feed`. Empty state for first-run gyms.
- Sidebar gains "Browse Programs" in the member-link group (visible to all roles).
- `ProgramFormDrawer` gains a visibility radio with explanatory copy.
- New `VisibilityBadge` component — 🔒 / 🌐 — used on `ProgramCard` and on the program detail header.

**Schema** (in #127)
- `ProgramVisibility` enum (`PUBLIC` | `PRIVATE`)
- `Program.visibility` column with `@default(PRIVATE)`

## Tests

**Unit** (`apps/web/src/pages/ProgramDetail.test.tsx`):
- renders the 🔒 Private visibility badge by default
- renders the 🌐 Public visibility badge for a PUBLIC program

**API integration** (`apps/api/tests/programs.ts`) — +20 assertions, **70 → 90**:
- `POST /programs` without visibility → defaults to `PRIVATE`
- `PATCH /programs/:id` with visibility flip; MEMBER PATCH → 403
- Browse: includes PUBLIC, excludes PRIVATE, drops just-joined
- Self-subscribe: 201 happy / 409 duplicate / 403 PRIVATE / 403 non-gym
- Self-unsubscribe: 204 leaves / 404 already-left
- `/workouts?programIds=<private>`: 403 MEMBER (no sub) / 200 COACH / 200 OWNER / 200 subscribed-MEMBER

**Playwright E2E** (`apps/web/tests/programs.spec.ts`) — +2 cases:
- MEMBER joins a PUBLIC program from Browse and lands on its filtered Feed (verifies the `UserProgram` row is created)
- Browse hides PRIVATE programs and programs the user already joined

## Verification

Run from this worktree (`dev:worktree` on API:3060 / Web:5260):

| Check | Result |
|---|---|
| `npx turbo lint --filter=@wodalytics/web` | clean |
| `tsc --noEmit` in `apps/api` | clean |
| `npm run test:unit --workspace=@wodalytics/web` | **77 / 77 pass** |
| `npm run test:worktree -- api` | **275 / 275 pass** across 8 files (programs.ts: 90/90) |
| `npm run test:worktree -- e2e` (full suite) | **24 / 24 pass** |

## Notable design decisions

- **`/subscribe` repurpose**: the legacy unauth'd route accepted `body.userId` and was used by the gym-level Members page. Slice 3 added `/members/:userId` for the same staff-managed flow, so this PR migrates `Members.tsx` to that and frees `/subscribe` to mean self-subscribe. Cleaner than adding a third route.
- **`/workouts?programIds` tightening** lives next to the existing access check (`findProgramGymAccessForUser`) — it now takes `(programId, gymId, userId, callerGymRole)` and returns `'forbidden'` for PRIVATE programs the caller isn't staff in or subscribed to. PUBLIC programs are visible to every gym member.
- **Drive-by gitignored fixture update**: the existing slice-2 filter test created A1/A2 programs as default-PRIVATE which broke the MEMBER assertion under the new visibility rules. Updated those fixtures to `visibility: 'PUBLIC'` since the slice-2 intent was "MEMBER can see programs in their gym" — which now means PUBLIC.
- **Members.tsx migration**: replaced `api.programs.subscribe(programId, userId)` calls with `api.programs.members.invite(programId, { userId })` and the matching remove. The slice-3 endpoint already covers staff-managed bulk subscribe, so no new server work needed.

## Migration PR

🟢 **#127** — `chore(db): add ProgramVisibility enum + Program.visibility column` — must merge first. This branch is rebased on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)