### PR TITLE
chore(db): add GymProgram.isDefault + partial unique index (slice 5 prep)

### DIFF
--- a/packages/db/prisma/migrations/20260427191018_add_gym_program_is_default/migration.sql
+++ b/packages/db/prisma/migrations/20260427191018_add_gym_program_is_default/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "GymProgram" ADD COLUMN     "isDefault" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+-- Enforce at most one default program per gym. Partial index so non-default
+-- rows aren't constrained against each other.
+CREATE UNIQUE INDEX "GymProgram_gym_default_key"
+  ON "GymProgram"("gymId") WHERE "isDefault" = true;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -225,6 +225,10 @@ model Program {
 model GymProgram {
   gymId     String
   programId String
+  // At most one default per gym — enforced via a partial unique index in the
+  // migration: `CREATE UNIQUE INDEX … WHERE "isDefault" = true`. New gym
+  // members are auto-subscribed to the default program (slice 5 / #88).
+  isDefault Boolean  @default(false)
   createdAt DateTime @default(now())
 
   gym     Gym     @relation(fields: [gymId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
**Prep for slice 5 of #82 (#88)**

## Summary

Additive schema change ahead of the slice 5 feature work. Adds:
- `GymProgram.isDefault` Boolean column with `@default(false)`
- Partial unique index enforcing at most one default per gym

```sql
ALTER TABLE "GymProgram" ADD COLUMN "isDefault" BOOLEAN NOT NULL DEFAULT false;

CREATE UNIQUE INDEX "GymProgram_gym_default_key"
  ON "GymProgram"("gymId") WHERE "isDefault" = true;
```

Per the CLAUDE.md "Isolate migration PRs" guidance, this ships standalone so the slice 5 PR (PATCH default endpoint, auto-subscribe on gym join, UI toggle + ⭐ badge) can be reviewed without the schema change blocking it.

## Why a partial unique index

A vanilla `UNIQUE` on `(gymId)` would only allow one row per gym total — wrong, we want many programs per gym, just one of them default. The partial form (`WHERE "isDefault" = true`) constrains only the default rows, leaving non-default rows free to coexist. This catches the "two defaults via concurrent writes" race at the DB layer; the slice-5 endpoint will also clear-and-set transactionally so the typical OWNER flow never trips it.

## Verification

- Schema applied locally; `\d "GymProgram"` shows the column with `false` default and the partial index:
  ```
  "GymProgram_gym_default_key" UNIQUE, btree ("gymId") WHERE "isDefault" = true
  ```
- No code references `isDefault` yet — the slice 5 PR adds the readers/writers.

## What's next

After this lands, the slice 5 PR will:
- `PATCH /api/gyms/:gymId/programs/:programId/default` (OWNER only) — clears existing default and sets new in one transaction; rejects PRIVATE programs with 400
- `GET /api/gyms/:gymId/programs` includes `isDefault`
- Auto-subscribe hook on gym join — new members are subscribed to the gym default if one exists; fail-soft so a subscribe error never blocks the join itself
- Web: ⭐ Default badge on the program detail header, index card, and Browse page; "Set as gym default" toggle in the Overview tab (OWNER, disabled when PRIVATE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)