### PR TITLE
chore(db): add WorkoutImport migration ahead of slice 6 bulk upload

### DIFF
--- a/packages/db/prisma/migrations/20260428155925_add_workout_import/migration.sql
+++ b/packages/db/prisma/migrations/20260428155925_add_workout_import/migration.sql
@@ -1,0 +1,38 @@
+-- CreateEnum
+CREATE TYPE "WorkoutImportStatus" AS ENUM ('PENDING', 'DRAFT', 'PUBLISHED', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "Workout" ADD COLUMN     "importId" TEXT;
+
+-- CreateTable
+CREATE TABLE "WorkoutImport" (
+    "id" TEXT NOT NULL,
+    "programId" TEXT NOT NULL,
+    "uploadedBy" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "rowCount" INTEGER NOT NULL,
+    "createdCount" INTEGER NOT NULL DEFAULT 0,
+    "skippedCount" INTEGER NOT NULL DEFAULT 0,
+    "status" "WorkoutImportStatus" NOT NULL DEFAULT 'PENDING',
+    "parsedJson" JSONB,
+    "errorJson" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WorkoutImport_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WorkoutImport_programId_idx" ON "WorkoutImport"("programId");
+
+-- CreateIndex
+CREATE INDEX "Workout_importId_idx" ON "Workout"("importId");
+
+-- AddForeignKey
+ALTER TABLE "Workout" ADD CONSTRAINT "Workout_importId_fkey" FOREIGN KEY ("importId") REFERENCES "WorkoutImport"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkoutImport" ADD CONSTRAINT "WorkoutImport_programId_fkey" FOREIGN KEY ("programId") REFERENCES "Program"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkoutImport" ADD CONSTRAINT "WorkoutImport_uploadedBy_fkey" FOREIGN KEY ("uploadedBy") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -130,6 +130,23 @@ enum WorkoutCategory {
   BENCHMARK // other common benchmarks (Fight Gone Bad, etc.)
 }
 
+// Lifecycle of a bulk-upload `WorkoutImport` row (slice 6 / #89):
+//   PENDING   → file uploaded + parsed, awaiting user confirmation in the modal.
+//               No Workout rows exist yet.
+//   DRAFT     → user confirmed the preview; Workout rows created with
+//               status=DRAFT and importId set. Visible on the calendar for
+//               review using the existing draft tooling.
+//   PUBLISHED → bulk-publish action ran; every DRAFT workout from this import
+//               is now PUBLISHED.
+//   FAILED    → unrecoverable parse error or user cancellation on the preview.
+//               No Workout rows are written; row stays in history for audit.
+enum WorkoutImportStatus {
+  PENDING
+  DRAFT
+  PUBLISHED
+  FAILED
+}
+
 // ─── Models ───────────────────────────────────────────────────────────────────
 
 model User {
@@ -156,6 +173,7 @@ model User {
   membershipRequests    GymMembershipRequest[] @relation("UserRequests")
   membershipInvitesSent GymMembershipRequest[] @relation("InvitedBy")
   membershipDecisions   GymMembershipRequest[] @relation("DecidedBy")
+  workoutImports        WorkoutImport[]
 }
 
 model OAuthAccount {
@@ -219,6 +237,7 @@ model Program {
   gyms     GymProgram[]
   members  UserProgram[]
   workouts Workout[]
+  imports  WorkoutImport[]
 }
 
 // Join table: a Program can belong to many Gyms and vice versa
@@ -321,6 +340,9 @@ model Workout {
   // Stable identifier from an external source (e.g. "crossfit-mainsite:w20260425")
   // used for idempotent upserts by background ingest jobs. Null for user-authored workouts.
   externalSourceId String?       @unique
+  // Set when this workout was created from a bulk CSV/XLSX upload (slice 6 / #89).
+  // Lets the bulk-publish action scope precisely to drafts from a specific import.
+  importId         String?
   createdAt        DateTime      @default(now())
   updatedAt        DateTime      @updatedAt
 
@@ -330,6 +352,35 @@ model Workout {
   namedWorkout     NamedWorkout?     @relation("NamedWorkoutInstances", fields: [namedWorkoutId], references: [id])
   templateFor      NamedWorkout?     @relation("NamedWorkoutTemplate") // required by Prisma parser — not used in queries
   workoutMovements WorkoutMovement[]
+  import           WorkoutImport?    @relation(fields: [importId], references: [id], onDelete: SetNull)
+
+  @@index([importId])
+}
+
+// Bulk-upload preview record (slice 6 / #89). One row per file uploaded by
+// staff. The parsed rows live in `parsedJson` between PENDING and DRAFT so
+// the modal can resume after a page reload. Errors and warnings (per-row,
+// per-cell) are keyed in `errorJson`. See WorkoutImportStatus for the
+// state machine.
+model WorkoutImport {
+  id           String              @id @default(cuid())
+  programId    String
+  uploadedBy   String
+  filename     String
+  rowCount     Int
+  createdCount Int                 @default(0)
+  skippedCount Int                 @default(0)
+  status       WorkoutImportStatus @default(PENDING)
+  parsedJson   Json?
+  errorJson    Json?
+  createdAt    DateTime            @default(now())
+  updatedAt    DateTime            @updatedAt
+
+  program  Program   @relation(fields: [programId], references: [id], onDelete: Cascade)
+  user     User      @relation(fields: [uploadedBy], references: [id])
+  workouts Workout[]
+
+  @@index([programId])
 }
 
 model Result {


### PR DESCRIPTION
## Summary

Additive Prisma migration laying the groundwork for slice 6 (#89 — bulk CSV/XLSX workout upload). Splits cleanly from the feature PR per the "isolate migration PRs" guidance in CLAUDE.md so the schema can deploy ahead of the application code that reads/writes it.

- New enum `WorkoutImportStatus` — `PENDING` / `DRAFT` / `PUBLISHED` / `FAILED`. Mirrors the workouts' aggregate state through the import lifecycle (see #89 for the full state machine + UX).
- New model `WorkoutImport` — preview payload, errors/warnings, counts per upload
- New nullable column `Workout.importId` + FK back to `WorkoutImport`. Lets the bulk-publish step scope precisely to drafts from a specific import (vs date-range guesswork)
- Back-relations on `User` and `Program`
- Indexes on `WorkoutImport.programId` and `Workout.importId`

No application code references the new fields in this PR. The slice 6 feature PR (#89) will land on top.

Part of #89.

## Tests

The schema is unreferenced by any code in this PR, so existing tests cover the only invariants here:

- `turbo lint` — confirms the schema parses + Prisma client regenerates cleanly
- `npm run test --workspace=@wodalytics/api` — existing API integration tests still green against the new schema (no regressions)

**Not automated / manual verification needed:**
- [ ] None — pure schema migration with no code surface

## Schema migration

Migration file committed: `packages/db/prisma/migrations/20260428155925_add_workout_import/migration.sql`.

Per CLAUDE.md: applied via `prisma migrate dev` and committed as part of this PR.
