### PR TITLE
fix(web): split tsconfig so prod build skips test files

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "tsc --noEmit",
+    "lint": "tsc -b tsconfig.app.json tsconfig.node.json tsconfig.test.json --noEmit",
     "preview": "vite preview",
     "test": "vitest run && npx dotenv-cli -e ../../.env -- npx playwright test",
     "test:unit": "vitest run",

--- a/apps/web/src/pages/Feed.test.tsx
+++ b/apps/web/src/pages/Feed.test.tsx
@@ -47,6 +47,7 @@ function makeGymProgram(id: string, name: string, coverColor: string | null = nu
   return {
     gymId: 'gym-1',
     programId: id,
+    isDefault: false,
     createdAt: '2026-03-01T00:00:00.000Z',
     program: {
       id,

--- a/apps/web/src/pages/ProgramsIndex.test.tsx
+++ b/apps/web/src/pages/ProgramsIndex.test.tsx
@@ -25,6 +25,7 @@ function makeGymProgram(overrides: Partial<{ id: string; name: string; memberCou
   return {
     gymId: 'gym-1',
     programId: id,
+    isDefault: false,
     createdAt: '2026-03-01T00:00:00.000Z',
     program: {
       id,

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -12,7 +12,8 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": []
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test"]
 }

--- a/apps/web/tsconfig.test.json
+++ b/apps/web/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client"]
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

The Docker web build (`apps/web/Dockerfile`) was failing on `npm ci` + `tsc -b` because `tsc` type-checked `src/**/*.test.tsx` during the production build, forcing `@testing-library/dom`'s peer-dep types to resolve in the alpine builder image. On alpine + npm 10 that resolution surfaced as TS2305 errors (`screen` / `waitFor` / `fireEvent` "no exported member"). A second class of failures was test fixtures missing `isDefault` after `f4debcf` added the field to `GymProgram`.

Splits the web tsconfigs so the production build no longer touches test code or test-only deps. Runtime image (nginx + `dist/`) was already clean — this just removes the build-time leak.

## Changes

- `apps/web/tsconfig.app.json` — excludes `src/**/*.test.{ts,tsx}` and `src/test`; clears `types` (production code doesn't need vitest globals or jest-dom matchers).
- `apps/web/tsconfig.test.json` (new) — extends app, includes only test files, carries `vitest/globals` + `@testing-library/jest-dom` + `vite/client` types.
- `apps/web/src/pages/Feed.test.tsx` and `ProgramsIndex.test.tsx` — add `isDefault: false` to `makeGymProgram` fixtures.
- `apps/web/package.json` — `lint` script switched from `tsc --noEmit` (which was a silent no-op against `tsconfig.json`'s empty `files`) to `tsc -b tsconfig.app.json tsconfig.node.json tsconfig.test.json --noEmit` so all three projects actually get type-checked.

## Tests

**Build verification (clean install, mimics Docker):**
- Wiped `node_modules`, ran `npm ci`, then `npx turbo build --filter=@wodalytics/web` — green.
- Confirmed `dist/` does not contain any testing-library code (was already true; the leak was build-time only).

**Lint verification:**
- New lint command runs `tsc -b` over app + node + test configs; passes clean.
- Injected a deliberate type error (`isDefault: 'not-a-bool'`) into a fixture and confirmed lint surfaces TS2322. Reverted before commit.

**Unit tests:**
- `npm run test:unit --workspace=@wodalytics/web` — 89/89 pass across 15 files.

**Not automated / manual verification needed:**
- [ ] Re-run the QA Docker build (the original failure point) to confirm the alpine builder now succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)