### PR TITLE
feat(mobile): gender filter chips on WodDetail leaderboard (#130 Slice 4)

### DIFF
--- a/apps/mobile/__tests__/WodDetailScreen.test.tsx
+++ b/apps/mobile/__tests__/WodDetailScreen.test.tsx
@@ -101,7 +101,7 @@ describe('WodDetailScreen', () => {
     const scaledEntry = { ...makeEntry('e2', 'bob', 'Bob'), level: 'SCALED' as const }
     ;(api.workouts.results as jest.Mock).mockResolvedValue([rxEntry, scaledEntry])
 
-    const { findByText, findAllByText, queryByText } = render(
+    const { findByText, queryByText, getByTestId } = render(
       <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
     )
 
@@ -112,14 +112,92 @@ describe('WodDetailScreen', () => {
     await findByText('Alice')
     await findByText('Bob')
 
-    // First "Scaled" match is the chip; the second is Bob's row level badge.
-    const [scaledChip] = await findAllByText('Scaled')
-    fireEvent.press(scaledChip)
+    fireEvent.press(getByTestId('level-chip-Scaled'))
     await waitFor(() => expect(queryByText('Alice')).toBeNull())
     await findByText('Bob')
 
     // No second API call — same data, just a different visible slice.
     expect((api.workouts.results as jest.Mock).mock.calls).toHaveLength(1)
+  })
+
+  test('gender chip narrows the visible leaderboard client-side', async () => {
+    const womenEntry = {
+      ...makeEntry('e1', 'alice', 'Alice'),
+      workoutGender: 'FEMALE' as const,
+    }
+    const menEntry = {
+      ...makeEntry('e2', 'bob', 'Bob'),
+      workoutGender: 'MALE' as const,
+    }
+    ;(api.workouts.results as jest.Mock).mockResolvedValue([womenEntry, menEntry])
+
+    const { findByText, queryByText, getByTestId } = render(
+      <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
+    )
+
+    await findByText('Alice')
+    await findByText('Bob')
+
+    fireEvent.press(getByTestId('gender-chip-Women'))
+    await waitFor(() => expect(queryByText('Bob')).toBeNull())
+    await findByText('Alice')
+
+    // Same fetch, just narrowed client-side.
+    expect((api.workouts.results as jest.Mock).mock.calls).toHaveLength(1)
+  })
+
+  test('level + gender filters combine; empty-state copy reflects both', async () => {
+    const rxFemale = {
+      ...makeEntry('e1', 'alice', 'Alice'),
+      level: 'RX' as const,
+      workoutGender: 'FEMALE' as const,
+    }
+    const scaledMale = {
+      ...makeEntry('e2', 'bob', 'Bob'),
+      level: 'SCALED' as const,
+      workoutGender: 'MALE' as const,
+    }
+    ;(api.workouts.results as jest.Mock).mockResolvedValue([rxFemale, scaledMale])
+
+    const { findByText, queryByText, getByTestId } = render(
+      <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
+    )
+
+    await findByText('Alice')
+
+    // Filter to RX + Men → no entries match → empty-state copy lists both.
+    fireEvent.press(getByTestId('level-chip-RX'))
+    fireEvent.press(getByTestId('gender-chip-Men'))
+
+    await waitFor(() => expect(queryByText('Alice')).toBeNull())
+    await waitFor(() => expect(queryByText('Bob')).toBeNull())
+    await findByText('No RX / Men results yet.')
+  })
+
+  test('switching the active filter to one that excludes the user keeps the result badge', async () => {
+    // Logged at RX/Female; filter to RX+/Men → leaderboard list empty, but
+    // the "your result" badge still derives from the unfiltered fetch and
+    // stays visible (no spurious "Log Result" CTA, no 409 on retry).
+    const myEntry = {
+      ...makeEntry('e1', 'me', 'Me'),
+      level: 'RX' as const,
+      workoutGender: 'FEMALE' as const,
+    }
+    ;(api.workouts.results as jest.Mock).mockResolvedValue([myEntry])
+
+    const { findByText, findByTestId, queryByText, getByTestId } = render(
+      <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
+    )
+
+    await findByText('Fran')
+    await findByTestId('result-badge')
+
+    fireEvent.press(getByTestId('level-chip-RX+'))
+    fireEvent.press(getByTestId('gender-chip-Men'))
+
+    await findByText('No RX+ / Men results yet.')
+    await findByTestId('result-badge')
+    expect(queryByText('Log Result')).toBeNull()
   })
 
   test('user keeps their result badge under a filter that excludes their level', async () => {

--- a/apps/mobile/src/screens/WodDetailScreen.tsx
+++ b/apps/mobile/src/screens/WodDetailScreen.tsx
@@ -10,7 +10,7 @@ import {
 import { useFocusEffect } from '@react-navigation/native'
 import type { StackScreenProps } from '@react-navigation/stack'
 import type { RootStackParamList } from '../../App'
-import { api, type Workout, type LeaderboardEntry, type WorkoutLevel } from '../lib/api'
+import { api, type Workout, type LeaderboardEntry, type WorkoutLevel, type WorkoutGender } from '../lib/api'
 import { useAuth } from '../context/AuthContext'
 import { formatResultValue } from '../lib/format'
 
@@ -31,12 +31,26 @@ const LEVEL_LABELS: Record<WorkoutLevel, string> = {
   MODIFIED: 'Modified',
 }
 
+const GENDER_FILTERS: { label: string; value: WorkoutGender | null }[] = [
+  { label: 'All', value: null },
+  { label: 'Women', value: 'FEMALE' },
+  { label: 'Men', value: 'MALE' },
+  { label: 'Open', value: 'OPEN' },
+]
+
+const GENDER_LABELS: Record<WorkoutGender, string> = {
+  FEMALE: 'Women',
+  MALE: 'Men',
+  OPEN: 'Open',
+}
+
 export default function WodDetailScreen({ route, navigation }: Props) {
   const { workoutId } = route.params
   const { user } = useAuth()
   const [workout, setWorkout] = useState<Workout | null>(null)
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([])
   const [levelFilter, setLevelFilter] = useState<WorkoutLevel | null>(null)
+  const [genderFilter, setGenderFilter] = useState<WorkoutGender | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -69,9 +83,20 @@ export default function WodDetailScreen({ route, navigation }: Props) {
   const hasLogged = !!userResult
 
   const visibleLeaderboard = useMemo(
-    () => (levelFilter ? leaderboard.filter((e) => e.level === levelFilter) : leaderboard),
-    [leaderboard, levelFilter],
+    () =>
+      leaderboard
+        .filter((e) => !levelFilter || e.level === levelFilter)
+        .filter((e) => !genderFilter || e.workoutGender === genderFilter),
+    [leaderboard, levelFilter, genderFilter],
   )
+
+  const emptyLeaderboardCopy = useMemo(() => {
+    const parts: string[] = []
+    if (levelFilter) parts.push(LEVEL_LABELS[levelFilter])
+    if (genderFilter) parts.push(GENDER_LABELS[genderFilter])
+    if (parts.length === 0) return 'No results yet.'
+    return `No ${parts.join(' / ')} results yet.`
+  }, [levelFilter, genderFilter])
 
   if (loading) {
     return (
@@ -155,9 +180,10 @@ export default function WodDetailScreen({ route, navigation }: Props) {
         >
           {LEVEL_FILTERS.map((f) => (
             <TouchableOpacity
-              key={f.label}
+              key={`level-${f.label}`}
               style={[styles.chip, levelFilter === f.value && styles.chipActive]}
               onPress={() => setLevelFilter(f.value)}
+              testID={`level-chip-${f.label}`}
             >
               <Text style={[styles.chipText, levelFilter === f.value && styles.chipTextActive]}>
                 {f.label}
@@ -166,10 +192,29 @@ export default function WodDetailScreen({ route, navigation }: Props) {
           ))}
         </ScrollView>
 
+        {/* Gender filter chips */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.filterRow}
+          contentContainerStyle={styles.filterContent}
+        >
+          {GENDER_FILTERS.map((f) => (
+            <TouchableOpacity
+              key={`gender-${f.label}`}
+              style={[styles.chip, genderFilter === f.value && styles.chipActive]}
+              onPress={() => setGenderFilter(f.value)}
+              testID={`gender-chip-${f.label}`}
+            >
+              <Text style={[styles.chipText, genderFilter === f.value && styles.chipTextActive]}>
+                {f.label}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+
         {visibleLeaderboard.length === 0 ? (
-          <Text style={styles.emptyLeaderboard}>
-            {levelFilter ? `No ${LEVEL_LABELS[levelFilter]} results yet.` : 'No results yet.'}
-          </Text>
+          <Text style={styles.emptyLeaderboard}>{emptyLeaderboardCopy}</Text>
         ) : (
           visibleLeaderboard.map((entry, idx) => (
             <View


### PR DESCRIPTION
## Summary

Slice 4 of #130 — WodDetail leaderboard parity with the web. Adds the gender filter alongside the existing level filter, combines them client-side, and updates the empty-state copy to list whichever filters are active.

The slice 2 fix (badge derives from the unfiltered leaderboard, not the visible slice) carries over for free: filtering to a level + gender that excludes the user's own entry still keeps their "your result" badge rendered, and the "Log Result" CTA stays hidden.

Mirrors the web's WodDetail (`apps/web/src/pages/WodDetail.tsx`):
- Filter labels: `All / Women / Men / Open` ↔ `null / FEMALE / MALE / OPEN`
- Empty-state shape parity: `"No results yet."` / `"No RX results yet."` / `"No Women results yet."` / `"No RX / Men results yet."`

No new API calls — both chip rows narrow the same single fetch via `useMemo`.

**Out of scope (deferred):** age-division filter (#97 on web; not shipped there yet either).

## Tests

**Unit / RNTL** (`apps/mobile/__tests__/WodDetailScreen.test.tsx`, 8/8 in this file, 53/53 across the mobile suite):

- Existing cases (5) still pass — re-targeted via the new chip `testID`s (`level-chip-<Label>` / `gender-chip-<Label>`) so they don't collide with in-row level/gender badges that share the same text.
- `gender chip narrows the visible leaderboard client-side` — Female + Male entries returned; pressing "Women" hides Male, single API call total.
- `level + gender filters combine; empty-state copy reflects both` — RX/Female + Scaled/Male returned; selecting RX + Men → empty state reads `"No RX / Men results yet."`
- `switching to a filter that excludes the user keeps the result badge` — user logged at RX/Female; selecting RX+ + Men → leaderboard list shows the empty-state copy, badge still rendered, no spurious "Log Result" CTA.

**Builds**: types/api/web all typecheck and build clean.

**Not automated / manual verification needed:**

Run on Expo Go against `EXPO_PUBLIC_API_URL=https://qa.wodalytics.com`:

- [x] Open a workout with multiple results across genders → tap "Women" → only female entries remain → tap "All" → all return
- [x] Combine "RX" + "Men" → only RX/Male entries shown → empty state reads `"No RX / Men results yet."` if no entries match
- [x] Log a result yourself, then filter to a level/gender that excludes you → "your result" badge still visible, no "Log Result" CTA

Part of #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)