### PR TITLE
chore(db): add Gym.logoUrl column

### DIFF
--- a/packages/db/prisma/migrations/20260429004608_add_gym_logo_url/migration.sql
+++ b/packages/db/prisma/migrations/20260429004608_add_gym_logo_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Gym" ADD COLUMN     "logoUrl" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -203,6 +203,7 @@ model Gym {
   name      String
   slug      String   @unique
   timezone  String   @default("UTC")
+  logoUrl   String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 


### PR DESCRIPTION
Part of #120 · Prerequisite for #145

Tiny additive migration ahead of the gym-logo upload feature work, following CLAUDE.md's migration-isolation policy.

## Schema change

\`\`\`prisma
model Gym {
  // …existing fields…
  logoUrl String?
}
\`\`\`

Single nullable column. No backfill — existing gyms keep \`logoUrl: null\` until staff upload one. Backwards-compatible (old code reading the model just ignores the new field).

## Verified

- \`npm run db:migrate\` applies cleanly against the dev DB.
- \`Gym\` table has the new column (\`\\d "Gym"\` confirms).
- \`turbo lint\` clean across api workspace.

## What's next

#145 (the feature PR) consumes this column via:
- \`POST /api/gyms/:gymId/logo\` (multipart upload, OWNER/PROGRAMMER only)
- \`DELETE /api/gyms/:gymId/logo\`
- Web \`GymLogoUploader\` on \`/gym-settings\` Details tab
- Logo rendered in the TopBar gym picker, \`/gym-settings\` header, \`/gyms/browse\` cards

The feature PR builds on slice C's \`ImageStorage\` abstraction (#125 / PR #144) — most of the upload pipeline is already there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)