### PR TITLE
fix(programs): subscribers can see + filter by unaffiliated programs

### DIFF
--- a/apps/api/src/db/programDbManager.ts
+++ b/apps/api/src/db/programDbManager.ts
@@ -92,12 +92,14 @@ export type ProgramGymAccessResult = 'ok' | 'not-found' | 'forbidden'
  * Visibility-aware access check for the workouts list endpoint
  * (`GET /workouts?programIds=…`).
  *
- *   - Program must be linked to the gym (program-vs-gym vetting).
- *   - PUBLIC programs are visible to every gym member.
- *   - PRIVATE programs require either staff role in any linked gym
- *     (OWNER / PROGRAMMER / COACH) or an existing `UserProgram` row for
- *     the caller. Members who haven't been invited get a 403 even though
- *     they're in the gym.
+ *   - Gym-affiliated programs:
+ *       - Program must be linked to the gym (program-vs-gym vetting).
+ *       - PUBLIC: visible to every gym member.
+ *       - PRIVATE: staff in any linked gym OR a UserProgram subscriber.
+ *   - Unaffiliated programs (no `GymProgram` rows — e.g. CrossFit Mainsite):
+ *       - Caller must have a `UserProgram` subscription. Visibility is
+ *         irrelevant here because there's no gym whose membership we could
+ *         lean on; the subscription is the only access signal.
  *
  * Caller-vs-gym is checked by the route guard before this is called.
  */
@@ -111,11 +113,24 @@ export async function findProgramGymAccessForUser(
     where: { id: programId },
     select: {
       visibility: true,
-      gyms: { where: { gymId }, select: { gymId: true } },
+      gyms: { select: { gymId: true } },
     },
   })
   if (!program) return 'not-found'
-  if (program.gyms.length === 0) return 'forbidden'
+
+  const linkedGymIds = program.gyms.map((g) => g.gymId)
+
+  if (linkedGymIds.length === 0) {
+    // Unaffiliated — only UserProgram subscribers can see the workouts.
+    const sub = await prisma.userProgram.findUnique({
+      where: { userId_programId: { userId, programId } },
+      select: { userId: true },
+    })
+    return sub ? 'ok' : 'forbidden'
+  }
+
+  if (!linkedGymIds.includes(gymId)) return 'forbidden'
+
   if (program.visibility === 'PUBLIC') return 'ok'
 
   // PRIVATE: staff bypass + UserProgram subscribers

--- a/apps/api/src/db/userProgramDbManager.ts
+++ b/apps/api/src/db/userProgramDbManager.ts
@@ -63,9 +63,13 @@ export async function findProgramMembersWithUserInfo(programId: string) {
 }
 
 /**
- * Returns the GymProgram rows for programs the caller can see in this gym.
+ * Returns the GymProgram rows for programs the caller can see in this gym,
+ * plus any unaffiliated programs the caller subscribes to (e.g. CrossFit
+ * Mainsite WOD). Unaffiliated programs are returned in the same shape with
+ * `gymId = ''` and `isDefault = false` so the picker can render them with
+ * no shape changes on the client.
  *
- * Two roles, two answers:
+ * Two roles, two answers (gym-scoped portion):
  *   - Staff (OWNER / PROGRAMMER / COACH) → all programs linked to the gym
  *     so they can pick any program in their picker
  *   - MEMBER → programs they have a UserProgram row for, **plus** the gym's
@@ -74,35 +78,59 @@ export async function findProgramMembersWithUserInfo(programId: string) {
  *     write-side hook (slice 5 / #88).
  *
  * Caller-vs-gym is checked by the route guard before this is called.
- * Default program is sorted first so the picker pins it visually.
+ * Default program is sorted first so the picker pins it visually; the
+ * unaffiliated subscriptions follow the gym list, sorted by joinedAt asc.
  */
 export async function findProgramsAvailableToUserInGym(
   userId: string,
   gymId: string,
   isStaff: boolean,
 ) {
-  if (isStaff) {
-    return prisma.gymProgram.findMany({
-      where: { gymId },
-      orderBy: [{ isDefault: 'desc' }, { createdAt: 'desc' }],
-      include: {
-        program: { include: { _count: { select: { members: true, workouts: true } } } },
-      },
-    })
-  }
-  return prisma.gymProgram.findMany({
+  const gymProgramInclude = {
+    program: { include: { _count: { select: { members: true, workouts: true } } } },
+  } as const
+
+  const gymPrograms = isStaff
+    ? await prisma.gymProgram.findMany({
+        where: { gymId },
+        orderBy: [{ isDefault: 'desc' }, { createdAt: 'desc' }],
+        include: gymProgramInclude,
+      })
+    : await prisma.gymProgram.findMany({
+        where: {
+          gymId,
+          OR: [
+            // Programs the member has a real UserProgram subscription for…
+            { program: { members: { some: { userId } } } },
+            // …plus whichever program is marked default for this gym.
+            { isDefault: true },
+          ],
+        },
+        orderBy: [{ isDefault: 'desc' }, { createdAt: 'desc' }],
+        include: gymProgramInclude,
+      })
+
+  // Unaffiliated programs (no GymProgram rows) the caller subscribes to.
+  // They aren't tied to any gym, so they show up regardless of which gym
+  // is selected in the picker.
+  const unaffiliatedSubs = await prisma.userProgram.findMany({
     where: {
-      gymId,
-      OR: [
-        // Programs the member has a real UserProgram subscription for…
-        { program: { members: { some: { userId } } } },
-        // …plus whichever program is marked default for this gym.
-        { isDefault: true },
-      ],
+      userId,
+      program: { gyms: { none: {} } },
     },
-    orderBy: [{ isDefault: 'desc' }, { createdAt: 'desc' }],
+    orderBy: { joinedAt: 'asc' },
     include: {
       program: { include: { _count: { select: { members: true, workouts: true } } } },
     },
   })
+
+  const unaffiliatedAsGymProgram = unaffiliatedSubs.map((sub) => ({
+    gymId: '',
+    programId: sub.programId,
+    isDefault: false,
+    createdAt: sub.joinedAt,
+    program: sub.program,
+  }))
+
+  return [...gymPrograms, ...unaffiliatedAsGymProgram]
 }

--- a/apps/api/src/db/workoutDbManager.ts
+++ b/apps/api/src/db/workoutDbManager.ts
@@ -72,10 +72,19 @@ export async function findWorkoutsByGymAndDateRange(
   to: Date,
   filters: WorkoutDateRangeFilters = {},
 ) {
+  // When the caller pins specific programIds the route layer has already
+  // run visibility-aware access checks per id (including allowing unaffiliated
+  // programs the caller subscribes to). Drop the gym-scoping constraint in
+  // that case so workouts under unaffiliated programs come back instead of
+  // silently filtering to the empty set.
+  const gymScope = filters.programIds?.length
+    ? {}
+    : { program: { gyms: { some: { gymId } } } }
+
   const workouts = await prisma.workout.findMany({
     where: {
       scheduledAt: { gte: from, lte: to },
-      program: { gyms: { some: { gymId } } },
+      ...gymScope,
       ...(filters.publishedOnly ? { status: WorkoutStatus.PUBLISHED } : {}),
       ...(filters.movementIds?.length
         ? { workoutMovements: { some: { movementId: { in: filters.movementIds } } } }

--- a/apps/api/tests/programs.ts
+++ b/apps/api/tests/programs.ts
@@ -880,6 +880,60 @@ async function runTests() {
     const r = await api('POST', `/programs/${catalogPrivate.id}/subscribe`, memberToken)
     check('POST subscribe (unaffiliated PRIVATE) → 403', 403, r.status)
   }
+
+  // ── Subscriber visibility into unaffiliated programs (#143 follow-up) ───────
+  console.log('\n=== Unaffiliated subscribers see their programs ===')
+
+  // Seed a workout under the unaffiliated PUBLIC program so the filter has
+  // something to return. outsider just joined catalogPublic above.
+  const catalogWorkout = await prisma.workout.create({
+    data: {
+      programId: catalogPublic.id,
+      title: 'Unaffiliated WOD',
+      description: 'mainsite-style workout',
+      type: 'AMRAP',
+      scheduledAt: new Date('2026-06-15T12:00:00Z'),
+      status: 'PUBLISHED',
+    },
+  })
+
+  {
+    // /me/programs surfaces the outsider's unaffiliated subscription even
+    // though it has no GymProgram row tying it to otherGymId.
+    const r = await api('GET', `/me/programs?gymId=${otherGymId}`, outsiderToken)
+    check('GET me/programs as outsider → 200', 200, r.status)
+    const rows = r.body as unknown as { programId: string; gymId: string }[]
+    const ids = rows.map((row) => row.programId)
+    check('me/programs includes unaffiliated subscription', true, ids.includes(catalogPublic.id))
+    const unaffRow = rows.find((row) => row.programId === catalogPublic.id)
+    check('me/programs unaffiliated row has empty gymId', '', unaffRow?.gymId)
+  }
+
+  {
+    // Filtering /workouts by an unaffiliated program the caller subscribes to
+    // returns those workouts (was a 403 / empty before this fix).
+    const r = await api(
+      'GET',
+      `/gyms/${otherGymId}/workouts?from=2026-06-01&to=2026-06-30T23:59:59Z&programIds=${catalogPublic.id}`,
+      outsiderToken,
+    )
+    check('GET workouts ?programIds=<unaffiliated> as subscriber → 200', 200, r.status)
+    const rows = r.body as unknown as { id: string }[]
+    check('workouts filter returns the unaffiliated workout', true, rows.some((w) => w.id === catalogWorkout.id))
+  }
+
+  {
+    // Non-subscribers still 403 on the same filter — visibility hasn't
+    // collapsed to "any authenticated user".
+    const r = await api(
+      'GET',
+      `/gyms/${gymId}/workouts?from=2026-06-01&to=2026-06-30T23:59:59Z&programIds=${catalogPublic.id}`,
+      memberToken,
+    )
+    check('GET workouts ?programIds=<unaffiliated> as non-subscriber → 403', 403, r.status)
+  }
+
+  await prisma.workout.delete({ where: { id: catalogWorkout.id } })
 }
 
 // ─── Teardown ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to #143. After joining the **CrossFit Mainsite WOD** program from the new public catalog, the program disappeared from the program picker and filtering by it on `/workouts` returned **403**. Three read-side layers needed updating to teach the API about gym-less programs.

- `findProgramGymAccessForUser` — when the program has **zero linked gyms**, allow access if the caller has a `UserProgram` subscription, regardless of visibility. Previously every gym-less program 403'd unconditionally.
- `findWorkoutsByGymAndDateRange` — when the caller pins specific `programIds`, drop the `program.gyms.some({ gymId })` constraint. Per-id access is already vetted at the route layer, so the gym scope was redundant — and it was silently filtering unaffiliated workouts to the empty set.
- `findProgramsAvailableToUserInGym` — append the caller's unaffiliated `UserProgram` subscriptions as synthetic `GymProgram`-shaped rows (`gymId = ''`, `isDefault = false`) so the picker renders them with **no client change** required.

## Tests

**API integration** (`apps/api/tests/programs.ts` — new `Unaffiliated subscribers see their programs` block):
- `GET /me/programs` as the unaffiliated subscriber → 200, list includes the joined program with `gymId === ''`
- `GET /gyms/:gymId/workouts?programIds=<unaffiliated>` as subscriber → 200 and the returned rows include the workout under that program
- Same call as a non-subscriber → 403 (visibility hasn't collapsed to "any authenticated user")

Existing `Slice 4` and `Slice 5` assertions remain green — the gym-affiliated paths are unchanged.

**Verification:** ran `npm run test:worktree -- api` against the worktree dev stack — 326 assertions across 7 suites, 0 failures, including the 6 new ones.

## Manual verification needed
- [x] As a member, open the picker → confirm the CrossFit Mainsite WOD entry appears after joining from `/browse-programs`.
- [x] Tick the entry → confirm the Feed/Calendar populates with Mainsite workouts (no 403 in the network tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)