### PR TITLE
fix(web): drop invalid htmlFor from <span> label text

### DIFF
--- a/apps/web/src/components/GymInvitationsPanel.tsx
+++ b/apps/web/src/components/GymInvitationsPanel.tsx
@@ -105,7 +105,7 @@ export default function GymInvitationsPanel() {
               />
             </label>
             <label className="block">
-              <span className="text-xs text-gray-400 mb-1 block" htmlFor="invite-role">Role</span>
+              <span className="text-xs text-gray-400 mb-1 block">Role</span>
               <select
                 id="invite-role"
                 value={roleToGrant}

--- a/apps/web/src/pages/GymCreate.tsx
+++ b/apps/web/src/pages/GymCreate.tsx
@@ -66,7 +66,7 @@ export default function GymCreate() {
         </label>
 
         <label className="block">
-          <span className="text-xs text-gray-400 mb-1 block" htmlFor="gym-create-timezone">Timezone</span>
+          <span className="text-xs text-gray-400 mb-1 block">Timezone</span>
           <select
             id="gym-create-timezone"
             value={timezone}


### PR DESCRIPTION
## Summary

Two `<span>` elements had an `htmlFor` attribute, which is only valid on `<label>`. This produced TS2322 errors under `tsc --noEmit` and was masked by editor tooling on `main`.

The wrapping `<label className=\"block\">` in both spots already provides the form-control association implicitly via nesting, so the `htmlFor` was both invalid and redundant. The fix is a one-attribute removal in each file.

- `apps/web/src/components/GymInvitationsPanel.tsx:108` — Role select label
- `apps/web/src/pages/GymCreate.tsx:69` — Timezone select label

Surfaced while typechecking the avatar-upload merge into another worktree.

## Tests

**Existing coverage** (no new tests needed — visual labels were already correct, only the invalid attribute was removed):
- `apps/web/src/test/a11y.test.tsx` — page-level axe scan still passes (form labels are associated via the wrapping label nesting; axe accepts both wrapping and explicit \`for\`).
- `npm run lint --workspace=@wodalytics/web` — now exits clean; previously failed with two TS2322 errors.

**Not automated:**
- [ ] Manual visual check: invite member dropdown + create-gym timezone dropdown still focus their input on click. (No DOM change beyond removing an invalid attribute.)