### PR TITLE
fix(web): pin rollup linux-x64-musl optional dep for QA Docker build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,5 +45,8 @@
     "typescript": "^5.7.3",
     "vite": "^6.2.0",
     "vitest": "^4.1.5"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-x64-musl": "4.60.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,6 +111,9 @@
         "typescript": "^5.7.3",
         "vite": "^6.2.0",
         "vitest": "^4.1.5"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-musl": "4.60.2"
       }
     },
     "apps/web/node_modules/@testing-library/react": {
@@ -4370,6 +4373,19 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ]
     },
     "node_modules/@sinclair/typebox": {


### PR DESCRIPTION
## Summary

The QA web build was failing with:

```
Error: Cannot find module @rollup/rollup-linux-x64-musl. npm has a bug related to
optional dependencies (https://github.com/npm/cli/issues/4828).
```

The `apps/web/Dockerfile` builds on `node:22-alpine` (musl libc). The lockfile already lists `@rollup/rollup-linux-x64-musl@4.60.2` as a transitive optional dep of `rollup`, but `npm ci` is hitting the long-standing npm bug where platform-specific optional deps aren't installed when the lockfile was generated on a different platform (macOS arm64 here).

The standard fix: declare the linux-x64-musl rollup binary as an explicit `optionalDependencies` of `@wodalytics/web`. The lockfile now records it at the root of `node_modules` with `cpu: ["x64"]` / `os: ["linux"]` filters, so:
- On macOS dev (arm64): npm skips it — no impact on local installs.
- In the alpine builder (linux-x64-musl): npm installs it deterministically — Vite/Rollup boots.

## Tests

**Local build smoke**:
- `npx turbo build --filter=@wodalytics/web` → passed (Vite 6.4.2, 384 modules transformed, dist emitted).

**Not automated / manual verification needed:**
- [ ] Re-run the Railway QA Docker build and confirm `@wodalytics/web:build` now succeeds.

Closes the QA build failure reported in this conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)