### PR TITLE
fix(web): pin remaining linux-x64-musl native deps for QA Docker build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,6 +47,8 @@
     "vitest": "^4.1.5"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-musl": "4.60.2"
+    "@rollup/rollup-linux-x64-musl": "4.60.2",
+    "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+    "lightningcss-linux-x64-musl": "1.32.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,9 @@
         "vitest": "^4.1.5"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-musl": "4.60.2"
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "lightningcss-linux-x64-musl": "1.32.0"
       }
     },
     "apps/web/node_modules/@testing-library/react": {
@@ -5176,6 +5178,22 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 20"
@@ -10751,6 +10769,26 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 12.0.0"


### PR DESCRIPTION
## Summary

Follow-up to #153. Same npm optional-deps bug, two more native binaries that Tailwind v4 pulls in:

- `@tailwindcss/oxide-linux-x64-musl@4.2.4` — Tailwind's Rust core
- `lightningcss-linux-x64-musl@1.32.0` — Tailwind's CSS minifier

Latest QA build failed on `lightningcss` after the rollup fix landed; `@tailwindcss/oxide` would almost certainly have been next. Fixing both in one shot to avoid another round-trip.

Both new entries are gated on `cpu: x64` / `os: linux` in the lockfile, so macOS dev installs are unaffected.

## Tests

**Local build smoke**:
- `npx turbo build --filter=@wodalytics/web` → passed (Vite 6.4.2, 384 modules, 886ms).

**Not automated / manual verification needed:**
- [ ] Re-run the Railway QA Docker build and confirm `@wodalytics/web:build` succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)