### PR TITLE
feat(gym-logo): allow setting logo by URL (hosted or data:)

### DIFF
--- a/apps/api/src/routes/gymLogo.ts
+++ b/apps/api/src/routes/gymLogo.ts
@@ -45,6 +45,14 @@ router.post(
   uploadGymLogo,
   imageUploadErrorHandler,
 )
+router.put(
+  '/gyms/:gymId/logo',
+  requireAuth,
+  validateGymExists,
+  requireGymWriteAccess,
+  requireOwnerOrProgrammer,
+  setGymLogoUrl,
+)
 router.delete(
   '/gyms/:gymId/logo',
   requireAuth,
@@ -55,6 +63,24 @@ router.delete(
 )
 
 export default router
+
+// Cap on what we'll persist into Gym.logoUrl. Hosted URLs are tiny (<1KB);
+// data: URLs balloon — this keeps a single PNG under ~750KB raw and protects
+// the column from runaway pastes. Server allowlist is http(s) and image
+// data: URLs only.
+const MAX_LOGO_URL_LENGTH = 1_000_000
+function isAllowedLogoUrl(value: unknown): value is string {
+  if (typeof value !== 'string') return false
+  const trimmed = value.trim()
+  if (trimmed.length === 0 || trimmed.length > MAX_LOGO_URL_LENGTH) return false
+  if (/^data:image\/(png|jpeg|jpg|webp|gif|svg\+xml);/i.test(trimmed)) return true
+  try {
+    const u = new URL(trimmed)
+    return u.protocol === 'http:' || u.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
 
 async function uploadGymLogo(req: Request, res: Response) {
   const file = req.file
@@ -75,6 +101,29 @@ async function uploadGymLogo(req: Request, res: Response) {
 
   await prisma.gym.update({ where: { id: gymId }, data: { logoUrl: url } })
   res.json({ logoUrl: url })
+}
+
+async function setGymLogoUrl(req: Request, res: Response) {
+  const gymId = req.params.gymId as string
+  const { logoUrl } = (req.body ?? {}) as { logoUrl?: unknown }
+  if (!isAllowedLogoUrl(logoUrl)) {
+    res.status(400).json({
+      error: 'Invalid logoUrl. Use an http(s) URL or an image data: URL up to 1MB.',
+    })
+    return
+  }
+  const trimmed = logoUrl.trim()
+
+  // If the gym was previously using one of our own S3 objects, free it now —
+  // the Gym row will no longer reference it after the update below.
+  const existing = await prisma.gym.findUnique({ where: { id: gymId }, select: { logoUrl: true } })
+  if (existing?.logoUrl) {
+    const key = deriveKeyFromUrl(existing.logoUrl, 'gyms')
+    if (key) await getImageStorage().delete(key).catch(() => {})
+  }
+
+  await prisma.gym.update({ where: { id: gymId }, data: { logoUrl: trimmed } })
+  res.json({ logoUrl: trimmed })
 }
 
 async function deleteGymLogo(req: Request, res: Response) {

--- a/apps/api/tests/gymLogo.ts
+++ b/apps/api/tests/gymLogo.ts
@@ -45,6 +45,20 @@ async function postLogo(gymId: string, token: string, body: Buffer | string, con
   return api('POST', `/gyms/${gymId}/logo`, token, form)
 }
 
+async function putLogoUrl(gymId: string, token: string, logoUrl: unknown) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  const res = await fetch(`${BASE}/gyms/${gymId}/logo`, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify({ logoUrl }),
+  })
+  const text = await res.text()
+  let json: unknown
+  try { json = JSON.parse(text) } catch { json = text }
+  return { status: res.status, body: json as Record<string, unknown> }
+}
+
 async function makeJpegBuffer(width = 200, height = 200): Promise<Buffer> {
   return sharp({
     create: { width, height, channels: 3, background: { r: 200, g: 100, b: 50 } },
@@ -175,6 +189,52 @@ async function testValidation() {
   check('corrupt image bytes → 400', 400, garbage.status)
 }
 
+async function testSetUrl() {
+  console.log('\n=== Set logoUrl by link (PUT) ===')
+
+  // Auth + role
+  check('PUT without token → 401',
+    401, (await putLogoUrl(gymId, '', 'https://example.com/logo.png')).status)
+  check('PUT as MEMBER → 403',
+    403, (await putLogoUrl(gymId, memberToken, 'https://example.com/logo.png')).status)
+  check('PUT as COACH → 403 (branding is owner-level)',
+    403, (await putLogoUrl(gymId, coachToken, 'https://example.com/logo.png')).status)
+
+  // Validation
+  check('empty string → 400',
+    400, (await putLogoUrl(gymId, ownerToken, '')).status)
+  check('non-string → 400',
+    400, (await putLogoUrl(gymId, ownerToken, 42)).status)
+  check('javascript: URL → 400',
+    400, (await putLogoUrl(gymId, ownerToken, 'javascript:alert(1)')).status)
+  check('non-image data: URL → 400',
+    400, (await putLogoUrl(gymId, ownerToken, 'data:text/html,<script>')).status)
+
+  // First, seed an S3-style upload so we can verify the PUT cleans it up.
+  const seeded = await postLogo(gymId, ownerToken, await makeJpegBuffer())
+  check('precondition: seeded an uploaded logo', 200, seeded.status)
+
+  // OWNER sets a hosted URL
+  const hosted = 'https://cdn.example.com/some-logo.png'
+  const r = await putLogoUrl(gymId, ownerToken, hosted)
+  check('OWNER PUT hosted URL → 200', 200, r.status)
+  check('response echoes the URL', hosted, r.body.logoUrl)
+  const after1 = await prisma.gym.findUnique({ where: { id: gymId }, select: { logoUrl: true } })
+  check('Gym.logoUrl persisted as hosted URL', hosted, after1?.logoUrl)
+
+  // PROGRAMMER replaces with a small image data: URL
+  const tinyPng = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+  const r2 = await putLogoUrl(gymId, programmerToken, tinyPng)
+  check('PROGRAMMER PUT data: URL → 200', 200, r2.status)
+  const after2 = await prisma.gym.findUnique({ where: { id: gymId }, select: { logoUrl: true } })
+  check('Gym.logoUrl persisted as data: URL', tinyPng, after2?.logoUrl)
+
+  // Trims surrounding whitespace
+  const padded = `   ${hosted}   `
+  const r3 = await putLogoUrl(gymId, ownerToken, padded)
+  check('whitespace trimmed before persist', hosted, r3.body.logoUrl)
+}
+
 async function testDelete() {
   console.log('\n=== Delete ===')
   const before = await prisma.gym.findUnique({ where: { id: gymId }, select: { logoUrl: true } })
@@ -217,6 +277,7 @@ async function main() {
     await testAuthGuards()
     await testHappyPath()
     await testValidation()
+    await testSetUrl()
     await testDelete()
     await testScoping()
   } catch (err) {

--- a/apps/web/src/components/GymLogoUploader.test.tsx
+++ b/apps/web/src/components/GymLogoUploader.test.tsx
@@ -21,6 +21,7 @@ vi.mock('../lib/api', () => ({
     gyms: {
       logo: {
         upload: vi.fn(),
+        setUrl: vi.fn(),
         remove: vi.fn(),
       },
     },
@@ -67,6 +68,27 @@ describe('GymLogoUploader', () => {
     await user.upload(input, big)
     expect(await screen.findByText(/too large/i)).toBeInTheDocument()
     expect(api.gyms.logo.upload).not.toHaveBeenCalled()
+  })
+
+  it('"Use link" submits the pasted URL, fires onChange, refreshes, and clears the field', async () => {
+    vi.mocked(api.gyms.logo.setUrl).mockResolvedValue({ logoUrl: 'https://cdn.example.com/x.png' })
+    const onChange = vi.fn()
+    render(<GymLogoUploader gymId="g1" logoUrl={null} name="CrossFit Foo" onChange={onChange} />)
+    const user = userEvent.setup()
+    const input = screen.getByLabelText(/paste a link/i) as HTMLInputElement
+    await user.type(input, 'https://cdn.example.com/x.png')
+    await user.click(screen.getByRole('button', { name: /Use link/ }))
+    await waitFor(() =>
+      expect(api.gyms.logo.setUrl).toHaveBeenCalledWith('g1', 'https://cdn.example.com/x.png'),
+    )
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith('https://cdn.example.com/x.png'))
+    await waitFor(() => expect(refreshGyms).toHaveBeenCalled())
+    expect(input.value).toBe('')
+  })
+
+  it('"Use link" is disabled while the input is empty', () => {
+    render(<GymLogoUploader gymId="g1" logoUrl={null} name="CrossFit Foo" />)
+    expect(screen.getByRole('button', { name: /Use link/ })).toBeDisabled()
   })
 
   it('Remove button calls the delete endpoint, fires onChange(null), and refreshes', async () => {

--- a/apps/web/src/components/GymLogoUploader.tsx
+++ b/apps/web/src/components/GymLogoUploader.tsx
@@ -21,7 +21,8 @@ interface GymLogoUploaderProps {
 // GymContext so the TopBar picker thumbnails update without a manual reload.
 export default function GymLogoUploader({ gymId, logoUrl, name, onChange }: GymLogoUploaderProps) {
   const { refreshGyms } = useGym()
-  const [busy, setBusy] = useState<'upload' | 'remove' | null>(null)
+  const [busy, setBusy] = useState<'upload' | 'remove' | 'link' | null>(null)
+  const [linkUrl, setLinkUrl] = useState('')
 
   const { inputProps, open, error, setError } = useImageUpload({
     ariaLabel: 'Choose a gym logo',
@@ -48,6 +49,24 @@ export default function GymLogoUploader({ gymId, logoUrl, name, onChange }: GymL
       await refreshGyms()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to remove logo')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function handleUseLink(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const trimmed = linkUrl.trim()
+    if (!trimmed) return
+    setBusy('link')
+    setError(null)
+    try {
+      const { logoUrl: nextUrl } = await api.gyms.logo.setUrl(gymId, trimmed)
+      onChange?.(nextUrl)
+      setLinkUrl('')
+      await refreshGyms()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not use that link')
     } finally {
       setBusy(null)
     }
@@ -80,6 +99,28 @@ export default function GymLogoUploader({ gymId, logoUrl, name, onChange }: GymL
             </Button>
           )}
         </div>
+        <form onSubmit={handleUseLink} className="flex flex-wrap items-center gap-2 pt-1">
+          <label htmlFor={`gym-logo-url-${gymId}`} className="text-xs text-gray-400">
+            Or paste a link:
+          </label>
+          <input
+            id={`gym-logo-url-${gymId}`}
+            type="url"
+            inputMode="url"
+            placeholder="https://…"
+            value={linkUrl}
+            onChange={(e) => setLinkUrl(e.target.value)}
+            disabled={busy !== null}
+            className="flex-1 min-w-[12rem] rounded border border-gray-700 bg-gray-800 px-2 py-1 text-sm text-white placeholder-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
+          />
+          <Button
+            type="submit"
+            variant="secondary"
+            disabled={busy !== null || linkUrl.trim().length === 0}
+          >
+            {busy === 'link' ? 'Saving…' : 'Use link'}
+          </Button>
+        </form>
         {error && <p className="text-sm text-rose-400">{error}</p>}
       </div>
     </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -485,6 +485,12 @@ export const api = {
         form.append('file', file)
         return req<{ logoUrl: string }>(`/api/gyms/${gymId}/logo`, { method: 'POST', body: form })
       },
+      setUrl: (gymId: string, logoUrl: string) =>
+        req<{ logoUrl: string }>(`/api/gyms/${gymId}/logo`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ logoUrl }),
+        }),
       remove: (gymId: string) =>
         req<void>(`/api/gyms/${gymId}/logo`, { method: 'DELETE' }),
     },


### PR DESCRIPTION
## Summary

Quick expansion of the gym logo feature (#145, merged in #149): an OWNER or PROGRAMMER can now point `Gym.logoUrl` at an already-hosted image (their existing Squarespace / Instagram CDN URL, etc.) instead of re-uploading to our S3 bucket. Useful when a gym already has a polished logo hosted elsewhere and doesn't want to duplicate it into ours.

- New endpoint: `PUT /api/gyms/:gymId/logo` taking `{ logoUrl }`
- Accepts `http(s)://…` URLs and `data:image/…` URLs (jpeg / png / webp / gif / svg). Rejects `javascript:` and non-image `data:` URLs.
- Caps the value at 1MB so a runaway `data:` URL can't bloat the column.
- Frees the prior S3 object when switching away from a previously-uploaded logo (mirror of the DELETE handler's cleanup behavior).
- Web: `api.gyms.logo.setUrl(gymId, url)` and a small "Or paste a link" input beneath the existing upload row in `GymLogoUploader`.

Part of #145.

## Tests

**Unit** (`apps/web/src/components/GymLogoUploader.test.tsx`):
- `"Use link" submits the pasted URL, fires onChange, refreshes, and clears the field` — covers the happy path including form reset on success
- `"Use link" is disabled while the input is empty` — covers the no-empty-submits guard
- (Existing 5 tests for upload / size guard / Remove still pass against the refactored component)

**API integration** (`apps/api/tests/gymLogo.ts` — `=== Set logoUrl by link (PUT) ===` section):
- `PUT without token → 401`
- `PUT as MEMBER → 403`
- `PUT as COACH → 403 (branding is owner-level)`
- `empty string → 400`
- `non-string → 400`
- `javascript: URL → 400`
- `non-image data: URL → 400`
- `OWNER PUT hosted URL → 200` + persistence + response echo
- `PROGRAMMER PUT data: URL → 200` + persistence
- `whitespace trimmed before persist`
- (S3 cleanup behavior covered implicitly: PUT runs after a fresh POST so the prior key is freed; full delete flow still in `=== Delete ===`)

Run from worktree: API on port 3050, then `API_URL=http://localhost:3050/api npx tsx apps/api/tests/gymLogo.ts` → **39 / 39 pass**. Full web vitest suite **123 / 123 pass**.

**Not automated / manual verification:**
- [ ] Visual check that a hosted URL (e.g. an Instagram CDN URL) renders correctly via `<img src>` in the picker thumbnails and gym header — same code path as the S3 case, but worth eyeballing once.
- [ ] If a gym pastes a URL with an expiring signature (Instagram / S3 presigned), the logo will eventually break. We don't refresh or proxy — that's by design for this slice. Worth noting in any user-facing copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)