### PR TITLE
feat(leaderboard): user avatars + read-only result detail view

### DIFF
--- a/apps/api/src/db/resultDbManager.ts
+++ b/apps/api/src/db/resultDbManager.ts
@@ -31,7 +31,7 @@ async function fetchLeaderboardRows(workoutId: string, filters: LeaderboardFilte
       ...(filters.workoutGender ? { workoutGender: filters.workoutGender } : {}),
     },
     include: {
-      user: { select: { id: true, name: true } },
+      user: { select: { id: true, name: true, firstName: true, lastName: true, email: true, avatarUrl: true } },
       workout: { select: { type: true } },
     },
   })

--- a/apps/api/tests/results.ts
+++ b/apps/api/tests/results.ts
@@ -61,7 +61,14 @@ async function setup() {
   console.log('\n=== Setup ===')
 
   const [userA, userB] = await Promise.all([
-    prisma.user.create({ data: { email: `at-result-a-${TS}@test.com` } }),
+    prisma.user.create({
+      data: {
+        email: `at-result-a-${TS}@test.com`,
+        firstName: 'Anna',
+        lastName: 'Avatar',
+        avatarUrl: `https://example.test/avatars/${TS}-a.png`,
+      },
+    }),
     prisma.user.create({ data: { email: `at-result-b-${TS}@test.com` } }),
   ])
   userAId = userA.id
@@ -172,6 +179,16 @@ async function runTests() {
     // FOR_TIME sorted ascending by seconds — userB (240s) beats userA (300s)
     const first = (entries[0] as Record<string, unknown>).user as Record<string, unknown>
     check('FOR_TIME leaderboard → fastest first (userB)', userBId, first.id)
+
+    // Avatar fields are required so the web Avatar primitive can render.
+    const userAEntry = entries.find(
+      (e) => ((e as Record<string, unknown>).user as Record<string, unknown>).id === userAId,
+    ) as Record<string, unknown>
+    const userAUser = userAEntry.user as Record<string, unknown>
+    check('leaderboard user → exposes avatarUrl', `https://example.test/avatars/${TS}-a.png`, userAUser.avatarUrl)
+    check('leaderboard user → exposes firstName', 'Anna', userAUser.firstName)
+    check('leaderboard user → exposes lastName', 'Avatar', userAUser.lastName)
+    check('leaderboard user → exposes email', `at-result-a-${TS}@test.com`, userAUser.email)
   }
 
   {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -25,6 +25,7 @@ import GymCreate from './pages/GymCreate.tsx'
 import GymSettings from './pages/GymSettings.tsx'
 import Feed from './pages/Feed.tsx'
 import WodDetail from './pages/WodDetail.tsx'
+import WodResultDetail from './pages/WodResultDetail.tsx'
 import History from './pages/History.tsx'
 
 export function PageErrorFallback({ error, resetErrorBoundary }: { error: unknown; resetErrorBoundary: () => void }) {
@@ -67,6 +68,7 @@ function AppLayout() {
               <Route path="/" element={<Navigate to="/feed" replace />} />
               <Route path="/feed" element={<Feed />} />
               <Route path="/workouts/:id" element={<WodDetail />} />
+              <Route path="/workouts/:id/results/:resultId" element={<WodResultDetail />} />
               <Route path="/history" element={<History />} />
               <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/calendar" element={<Calendar />} />

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -156,7 +156,14 @@ export interface WorkoutResult {
   value: Record<string, unknown>
   notes: string | null
   createdAt: string
-  user: { id: string; name: string | null }
+  user: {
+    id: string
+    name: string | null
+    firstName: string | null
+    lastName: string | null
+    email: string
+    avatarUrl: string | null
+  }
   workout: { type: WorkoutType }
 }
 

--- a/apps/web/src/pages/WodDetail.test.tsx
+++ b/apps/web/src/pages/WodDetail.test.tsx
@@ -1,8 +1,14 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import WodDetail from './WodDetail'
+
+// Renders the current pathname so navigation assertions can read it.
+function RouteSpy() {
+  const loc = useLocation()
+  return <div data-testid="current-route">{loc.pathname}</div>
+}
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -45,8 +51,10 @@ function makeWorkout(overrides = {}) {
 function renderPage(workoutId = 'workout-1') {
   return render(
     <MemoryRouter initialEntries={[`/workouts/${workoutId}`]}>
+      <RouteSpy />
       <Routes>
         <Route path="/workouts/:id" element={<WodDetail />} />
+        <Route path="/workouts/:id/results/:resultId" element={<div>result detail stub</div>} />
       </Routes>
     </MemoryRouter>,
   )
@@ -119,11 +127,19 @@ describe('WodDetail', () => {
 
 // ─── Level filter (segmented control + Show all) ─────────────────────────────
 
-function makeResult(overrides: { id: string; userId: string; name: string; level: 'RX_PLUS' | 'RX' | 'SCALED' | 'MODIFIED'; seconds: number }) {
+function makeResult(overrides: { id: string; userId: string; name: string; level: 'RX_PLUS' | 'RX' | 'SCALED' | 'MODIFIED'; seconds: number; avatarUrl?: string | null }) {
+  const [first, ...rest] = overrides.name.split(' ')
   return {
     id: overrides.id,
     userId: overrides.userId,
-    user: { id: overrides.userId, name: overrides.name },
+    user: {
+      id: overrides.userId,
+      name: overrides.name,
+      firstName: first ?? null,
+      lastName: rest.join(' ') || null,
+      email: `${overrides.userId}@test.com`,
+      avatarUrl: overrides.avatarUrl ?? null,
+    },
     level: overrides.level,
     workoutGender: 'OPEN' as const,
     value: { seconds: overrides.seconds, cappedOut: false },
@@ -145,7 +161,13 @@ const MIXED_LEADERBOARD = [
 function visibleAthleteOrder(): string[] {
   const cells = Array.from(document.querySelectorAll('tbody tr td:nth-child(2)'))
   return cells
-    .map((td) => td.textContent ?? '')
+    .map((td) => {
+      // Strip the avatar fallback (an aria-hidden initials div) so its
+      // text doesn't pollute the cell's textContent.
+      const clone = td.cloneNode(true) as HTMLElement
+      clone.querySelectorAll('[aria-hidden="true"]').forEach((el) => el.remove())
+      return clone.textContent ?? ''
+    })
     // Strip the "(you)" suffix added next to the viewer's row.
     .map((s) => s.replace(/\s*\(you\)\s*$/, '').trim())
     .filter((s) => s.length > 0)
@@ -201,6 +223,25 @@ describe('WodDetail level filter — graded inclusion + ordering', () => {
     for (const label of ['RX+', 'RX', 'Scaled', 'Modified']) {
       expect(screen.getByRole('radio', { name: label })).toBeDisabled()
     }
+  })
+
+  it('renders an avatar next to each athlete and navigates to the result detail when a row is clicked', async () => {
+    const userEv = userEvent.setup()
+    renderPage()
+    await screen.findByText('Rx User')
+
+    // Each visible row exposes a "View …'s result" button label, so the avatar
+    // + name area is reachable by keyboard and the row is clickable.
+    const buttons = screen.getAllByRole('button', { name: /View .+ result/i })
+    expect(buttons.length).toBeGreaterThan(0)
+
+    // Avatar fallback for "Rx User" → initials "RU" rendered in the cell.
+    expect(screen.getByText('RU')).toBeInTheDocument()
+
+    await userEv.click(screen.getByRole('button', { name: /View Rx User's result/i }))
+    expect(await screen.findByTestId('current-route')).toHaveTextContent(
+      '/workouts/workout-1/results/r-2',
+    )
   })
 
   it("auto-selects the viewer's own logged level when the leaderboard contains it", async () => {

--- a/apps/web/src/pages/WodDetail.tsx
+++ b/apps/web/src/pages/WodDetail.tsx
@@ -5,6 +5,7 @@ import { api, type Workout, type WorkoutCategory, type WorkoutResult, type Worko
 import { WORKOUT_TYPE_STYLES } from '../lib/workoutTypeStyles.ts'
 import LogResultDrawer from '../components/LogResultDrawer.tsx'
 import MarkdownDescription from '../components/MarkdownDescription.tsx'
+import Avatar from '../components/Avatar.tsx'
 import Button from '../components/ui/Button.tsx'
 import SegmentedControl from '../components/ui/SegmentedControl.tsx'
 
@@ -279,18 +280,40 @@ export default function WodDetail() {
               <tbody>
                 {filteredResults.map((result, index) => {
                   const isMe = result.userId === user?.id
+                  const displayName = result.user.name ?? 'Unknown'
+                  const goToDetail = () => navigate(`/workouts/${workout.id}/results/${result.id}`)
                   return (
                     <Fragment key={result.id}>
                       <tr
+                        role="button"
+                        tabIndex={0}
+                        aria-label={`View ${isMe ? 'your' : `${displayName}'s`} result`}
+                        onClick={goToDetail}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault()
+                            goToDetail()
+                          }
+                        }}
                         className={[
                           result.notes ? '' : 'border-b border-gray-900',
                           isMe ? 'text-indigo-300' : 'text-gray-300',
+                          'cursor-pointer hover:bg-gray-900/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950',
                         ].join(' ')}
                       >
                         <td className="py-2.5 pr-4 text-gray-500">{index + 1}</td>
                         <td className="py-2.5 pr-4 font-medium">
-                          {result.user.name ?? 'Unknown'}
-                          {isMe && <span className="ml-1.5 text-xs text-indigo-400">(you)</span>}
+                          <span className="flex items-center gap-2">
+                            <Avatar
+                              avatarUrl={result.user.avatarUrl}
+                              firstName={result.user.firstName}
+                              lastName={result.user.lastName}
+                              email={result.user.email}
+                              size="sm"
+                            />
+                            <span>{displayName}</span>
+                            {isMe && <span className="text-xs text-indigo-400">(you)</span>}
+                          </span>
                         </td>
                         <td className="py-2.5 pr-4 text-gray-400">{LEVEL_LABELS[result.level]}</td>
                         <td className="py-2.5 font-mono">{formatResultValue(result)}</td>

--- a/apps/web/src/pages/WodResultDetail.test.tsx
+++ b/apps/web/src/pages/WodResultDetail.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import WodResultDetail from './WodResultDetail'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../lib/api', () => ({
+  api: {
+    workouts: { get: vi.fn() },
+    results: { leaderboard: vi.fn() },
+  },
+}))
+
+const mockUseAuth = vi.fn()
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+import { api } from '../lib/api'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeWorkout(overrides = {}) {
+  return {
+    id: 'workout-1',
+    title: 'Fran',
+    description: '21-15-9 Thrusters and Pull-ups',
+    type: 'FOR_TIME' as const,
+    status: 'PUBLISHED' as const,
+    scheduledAt: '2026-07-15T12:00:00.000Z',
+    dayOrder: 0,
+    workoutMovements: [],
+    programId: null,
+    program: null,
+    namedWorkoutId: null,
+    namedWorkout: null,
+    _count: { results: 0 },
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeResult(overrides: {
+  id: string
+  userId: string
+  name: string
+  notes?: string | null
+  avatarUrl?: string | null
+}) {
+  const [first, ...rest] = overrides.name.split(' ')
+  return {
+    id: overrides.id,
+    userId: overrides.userId,
+    workoutId: 'workout-1',
+    user: {
+      id: overrides.userId,
+      name: overrides.name,
+      firstName: first ?? null,
+      lastName: rest.join(' ') || null,
+      email: `${overrides.userId}@test.com`,
+      avatarUrl: overrides.avatarUrl ?? null,
+    },
+    level: 'RX' as const,
+    workoutGender: 'OPEN' as const,
+    value: { seconds: 305, cappedOut: false },
+    notes: overrides.notes ?? null,
+    createdAt: '2026-04-01T00:00:00.000Z',
+    workout: { type: 'FOR_TIME' as const },
+  }
+}
+
+function renderPage(workoutId = 'workout-1', resultId = 'r-1') {
+  return render(
+    <MemoryRouter initialEntries={[`/workouts/${workoutId}/results/${resultId}`]}>
+      <Routes>
+        <Route path="/workouts/:id/results/:resultId" element={<WodResultDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('WodResultDetail', () => {
+  beforeEach(() => {
+    vi.mocked(api.workouts.get).mockReset()
+    vi.mocked(api.results.leaderboard).mockReset()
+    mockUseAuth.mockReturnValue({ user: { id: 'viewer-1' } })
+  })
+
+  it("shows 'Your Result' when the result belongs to the current user", async () => {
+    vi.mocked(api.workouts.get).mockResolvedValue(makeWorkout())
+    vi.mocked(api.results.leaderboard).mockResolvedValue([
+      makeResult({ id: 'r-mine', userId: 'viewer-1', name: 'Test User' }),
+    ] as never)
+
+    renderPage('workout-1', 'r-mine')
+    expect(await screen.findByRole('heading', { name: 'Your Result' })).toBeInTheDocument()
+  })
+
+  it("shows '<name>'s Result' when viewing another athlete", async () => {
+    vi.mocked(api.workouts.get).mockResolvedValue(makeWorkout())
+    vi.mocked(api.results.leaderboard).mockResolvedValue([
+      makeResult({ id: 'r-other', userId: 'somebody-else', name: 'Jane Doe' }),
+    ] as never)
+
+    renderPage('workout-1', 'r-other')
+    expect(await screen.findByRole('heading', { name: "Jane Doe's Result" })).toBeInTheDocument()
+  })
+
+  it('renders the workout description, formatted result, level, and notes', async () => {
+    vi.mocked(api.workouts.get).mockResolvedValue(makeWorkout())
+    vi.mocked(api.results.leaderboard).mockResolvedValue([
+      makeResult({
+        id: 'r-1',
+        userId: 'somebody-else',
+        name: 'Jane Doe',
+        notes: 'Felt strong on thrusters; chipped through pull-ups.',
+      }),
+    ] as never)
+
+    renderPage('workout-1', 'r-1')
+    // Workout context is rendered for read-only review
+    expect(await screen.findByRole('heading', { name: 'Fran' })).toBeInTheDocument()
+    expect(screen.getByText(/21-15-9/)).toBeInTheDocument()
+    // Formatted FOR_TIME result
+    expect(screen.getByText('5:05')).toBeInTheDocument()
+    // Level + notes
+    expect(screen.getByText('RX')).toBeInTheDocument()
+    expect(screen.getByText(/Felt strong on thrusters/)).toBeInTheDocument()
+  })
+
+  it('falls back to a friendly empty notes message when the result has no notes', async () => {
+    vi.mocked(api.workouts.get).mockResolvedValue(makeWorkout())
+    vi.mocked(api.results.leaderboard).mockResolvedValue([
+      makeResult({ id: 'r-1', userId: 'somebody-else', name: 'Jane Doe' }),
+    ] as never)
+
+    renderPage('workout-1', 'r-1')
+    expect(await screen.findByText('No notes for this result.')).toBeInTheDocument()
+  })
+
+  it('shows an error when the result cannot be located on the leaderboard', async () => {
+    vi.mocked(api.workouts.get).mockResolvedValue(makeWorkout())
+    vi.mocked(api.results.leaderboard).mockResolvedValue([] as never)
+
+    renderPage('workout-1', 'missing-result-id')
+    expect(await screen.findByText(/Result not found/i)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/pages/WodResultDetail.tsx
+++ b/apps/web/src/pages/WodResultDetail.tsx
@@ -1,0 +1,187 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext.tsx'
+import { api, type Workout, type WorkoutCategory, type WorkoutResult, type WorkoutLevel } from '../lib/api.ts'
+import { WORKOUT_TYPE_STYLES } from '../lib/workoutTypeStyles.ts'
+import MarkdownDescription from '../components/MarkdownDescription.tsx'
+import Avatar from '../components/Avatar.tsx'
+
+const CATEGORY_LABELS: Record<WorkoutCategory, string> = {
+  GIRL_WOD: 'Girl WOD',
+  HERO_WOD: 'Hero WOD',
+  OPEN_WOD: 'Open WOD',
+  GAMES_WOD: 'Games WOD',
+  BENCHMARK: 'Benchmark',
+}
+
+const LEVEL_LABELS: Record<WorkoutLevel, string> = {
+  RX_PLUS: 'RX+',
+  RX: 'RX',
+  SCALED: 'Scaled',
+  MODIFIED: 'Modified',
+}
+
+const WORKOUT_GENDER_LABELS: Record<'MALE' | 'FEMALE' | 'OPEN', string> = {
+  MALE: 'Male',
+  FEMALE: 'Female',
+  OPEN: 'Open',
+}
+
+function formatSeconds(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+function formatResultValue(result: WorkoutResult): string {
+  const v = result.value
+  const type = result.workout.type
+
+  if (type === 'AMRAP') {
+    const rounds = v.rounds as number
+    const reps = v.reps as number
+    return `${rounds} rounds + ${reps} reps`
+  }
+
+  if (type === 'FOR_TIME') {
+    if (v.cappedOut) return 'CAPPED'
+    return formatSeconds(v.seconds as number)
+  }
+
+  return '—'
+}
+
+export default function WodResultDetail() {
+  const { id, resultId } = useParams<{ id: string; resultId: string }>()
+  const navigate = useNavigate()
+  const { user } = useAuth()
+
+  const [workout, setWorkout] = useState<Workout | null>(null)
+  const [result, setResult] = useState<WorkoutResult | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id || !resultId) return
+    setLoading(true)
+    setError(null)
+    Promise.all([api.workouts.get(id), api.results.leaderboard(id)])
+      .then(([w, r]) => {
+        setWorkout(w)
+        const found = r.find((x) => x.id === resultId)
+        setResult(found ?? null)
+        if (!found) setError('Result not found.')
+      })
+      .catch((e) => setError((e as Error).message))
+      .finally(() => setLoading(false))
+  }, [id, resultId])
+
+  if (loading) {
+    return (
+      <div className="max-w-2xl mx-auto">
+        <p className="text-gray-400">Loading...</p>
+      </div>
+    )
+  }
+
+  if (error || !workout || !result) {
+    return (
+      <div className="max-w-2xl mx-auto">
+        <p className="text-red-400">{error ?? 'Result not found.'}</p>
+        <button
+          onClick={() => navigate(id ? `/workouts/${id}` : '/feed')}
+          className="mt-4 text-sm text-gray-400 hover:text-white transition-colors"
+        >
+          ← Back to WOD
+        </button>
+      </div>
+    )
+  }
+
+  const isMe = result.userId === user?.id
+  const ownerName = result.user.name ?? 'Unknown athlete'
+  const titleText = isMe ? 'Your Result' : `${ownerName}'s Result`
+
+  const scheduledDate = new Date(workout.scheduledAt).toLocaleDateString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <button
+        onClick={() => navigate(`/workouts/${workout.id}`)}
+        className="text-sm text-gray-400 hover:text-white transition-colors"
+      >
+        ← Back to WOD
+      </button>
+
+      {/* Title — avatar + whose result */}
+      <div className="flex items-center gap-3">
+        <Avatar
+          avatarUrl={result.user.avatarUrl}
+          firstName={result.user.firstName}
+          lastName={result.user.lastName}
+          email={result.user.email}
+          size="md"
+        />
+        <h1 className="text-2xl font-bold">{titleText}</h1>
+      </div>
+
+      {/* Workout context */}
+      <div>
+        <div className="flex items-center gap-3 mb-1">
+          <span className={`w-8 h-8 flex items-center justify-center rounded text-sm font-bold ${WORKOUT_TYPE_STYLES[workout.type].bg} ${WORKOUT_TYPE_STYLES[workout.type].tint}`}>
+            {WORKOUT_TYPE_STYLES[workout.type].abbr}
+          </span>
+          <h2 className="text-xl font-semibold">{workout.title}</h2>
+          {workout.namedWorkout && (
+            <span className="flex items-center gap-1.5 ml-1">
+              <span className="text-sm text-indigo-400">● {workout.namedWorkout.name}</span>
+              <span className="text-xs px-2 py-0.5 rounded-full bg-indigo-900/50 text-indigo-300 border border-indigo-700/40">
+                {CATEGORY_LABELS[workout.namedWorkout.category]}
+              </span>
+            </span>
+          )}
+        </div>
+        <p className="text-sm text-gray-500 ml-11">{scheduledDate}</p>
+      </div>
+
+      {workout.description && (
+        <div className="bg-gray-900 rounded-lg px-4 py-3">
+          <MarkdownDescription source={workout.description} />
+        </div>
+      )}
+
+      {(workout.workoutMovements?.length ?? 0) > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {workout.workoutMovements?.map((wm) => (
+            <span key={wm.movement.id} className="text-xs px-2.5 py-1 rounded-full bg-gray-800 text-gray-300 border border-gray-700">
+              {wm.movement.name}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Result block */}
+      <div className="px-4 py-3 rounded-lg bg-gray-900 border border-gray-700 space-y-2">
+        <div className="flex items-center gap-3 flex-wrap">
+          <span className="text-xs font-semibold text-gray-400 uppercase tracking-wide">Result</span>
+          <span className="text-base font-medium text-white font-mono">{formatResultValue(result)}</span>
+          <span className="text-xs text-gray-400">{LEVEL_LABELS[result.level]}</span>
+          <span className="text-xs text-gray-500">{WORKOUT_GENDER_LABELS[result.workoutGender]}</span>
+        </div>
+        {result.notes ? (
+          <div>
+            <p className="text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-1">Notes</p>
+            <p className="text-sm text-gray-300 whitespace-pre-wrap">{result.notes}</p>
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500 italic">No notes for this result.</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/test/a11y.test.tsx
+++ b/apps/web/src/test/a11y.test.tsx
@@ -93,7 +93,7 @@ function makeResult(overrides: Record<string, unknown> = {}) {
   return {
     id: 'r-1',
     userId: 'u-1',
-    user: { id: 'u-1', name: 'Athlete A' },
+    user: { id: 'u-1', name: 'Athlete A', firstName: 'Athlete', lastName: 'A', email: 'athlete-a@test.com', avatarUrl: null },
     level: 'RX' as const,
     workoutGender: 'OPEN' as const,
     value: { seconds: 300, cappedOut: false },

--- a/apps/web/tests/member-log-result.spec.ts
+++ b/apps/web/tests/member-log-result.spec.ts
@@ -116,6 +116,30 @@ test.describe('Member result-logging E2E', () => {
     await expect(page.getByRole('cell', { name: /4:30/ })).toBeVisible()
   })
 
+  test('Leaderboard: row click opens read-only result detail with the owner\'s name in the title', async ({ page }) => {
+    // Seed a result so the leaderboard has an entry to click.
+    await prisma.result.create({
+      data: {
+        workoutId: f.amrapWorkoutId, userId: f.memberUserId, level: 'RX',
+        workoutGender: 'OPEN',
+        value: { type: 'AMRAP', rounds: 5, reps: 10 },
+        notes: 'Felt fast on round 4.',
+      },
+    })
+    await loginMember(page, f)
+    await page.goto(`/workouts/${f.amrapWorkoutId}`)
+    await page.waitForSelector('h1')
+
+    // Click the row whose athlete cell contains "(you)" — the seeded result is the
+    // current user's, so the title becomes "Your Result" rather than the name.
+    await page.getByRole('button', { name: /View your result/i }).click()
+    await page.waitForURL(`**/workouts/${f.amrapWorkoutId}/results/**`)
+
+    await expect(page.getByRole('heading', { name: 'Your Result' })).toBeVisible()
+    await expect(page.getByText('Felt fast on round 4.')).toBeVisible()
+    await expect(page.getByText(/5 rounds \+ 10 reps/)).toBeVisible()
+  })
+
   test('History: a logged result appears on /history and links back to the WOD', async ({ page }) => {
     // Seed a result directly so this test isn't dependent on the AMRAP drawer flow.
     await prisma.result.create({


### PR DESCRIPTION
## Summary

- Adds the user's avatar inline to the left of their name on every WodDetail leaderboard row (uses the existing `Avatar` primitive — image when set, initials-on-gradient fallback otherwise).
- Makes each leaderboard row clickable and opens a new read-only **`WodResultDetail`** page at `/workouts/:id/results/:resultId` showing the workout context plus the result + notes. Title is `<Avatar/> Your Result` for the current user and `<Avatar/> {name}'s Result` for anyone else.
- Widens the leaderboard endpoint's user select to include `avatarUrl`, `firstName`, `lastName`, `email` so the avatar can render initials when no URL is set. No new API surface — the new page reuses `GET /api/workouts/:workoutId/results` and finds the row by id client-side.

No schema migration in this PR (the `User.avatarUrl` column already exists).

## Tests

**Unit** (`apps/web/src/pages/WodDetail.test.tsx`, `apps/web/src/pages/WodResultDetail.test.tsx`):
- *WodDetail* — added `renders an avatar next to each athlete and navigates to the result detail when a row is clicked`: asserts each row exposes a `View …'s result` button label, the initials placeholder renders for a leaderboard user without an avatar URL, and clicking the row updates the routed pathname to `/workouts/:id/results/:resultId`.
- *WodDetail* — existing graded-level / show-all / auto-detect tests updated for the new user shape (`firstName`, `lastName`, `email`, `avatarUrl`) and helper now strips the avatar's `aria-hidden` text from `td.textContent` so the sort-order assertions still work.
- *WodResultDetail* (new file, 5 tests):
  - `shows 'Your Result' when the result belongs to the current user`
  - `shows '<name>'s Result' when viewing another athlete`
  - `renders the workout description, formatted result, level, and notes`
  - `falls back to a friendly empty notes message when the result has no notes`
  - `shows an error when the result cannot be located on the leaderboard`
- *a11y* — `src/test/a11y.test.tsx` fixture updated to provide the new user fields so axe still runs cleanly against `WodDetail`.

**API integration** (`apps/api/tests/results.ts`):
- Existing leaderboard checks (FOR_TIME ordering, AMRAP ordering, `?level=`/`?gender=` filters, 401 unauth) all still pass.
- New assertions on the leaderboard response: each user row now exposes `avatarUrl`, `firstName`, `lastName`, and `email`. Setup seeds userA with a non-null `avatarUrl` and `firstName`/`lastName` so the assertions verify real values, not just key presence.

**Playwright E2E** (`apps/web/tests/member-log-result.spec.ts`):
- T1 (existing): `AMRAP: log result via drawer → leaderboard + "Your Result" updated` — still passes.
- T2 (existing): `FOR_TIME: leaderboard shows the formatted time after submit` — still passes.
- T3 (new): `Leaderboard: row click opens read-only result detail with the owner's name in the title` — seeds an AMRAP result, clicks the leaderboard row labelled `View your result`, lands on `/workouts/:id/results/:resultId`, and asserts the heading is `Your Result`, the notes are visible, and the formatted value (`5 rounds + 10 reps`) renders.
- T4 (existing): `History: a logged result appears on /history and links back to the WOD` — still passes.

**How this was verified locally**

Per repo `CLAUDE.md`, ran the full worktree-aware stack (`npm run dev:worktree`) and:

- `npx vitest run` (apps/web) — **22 files / 129 tests passed**.
- `npm run test:worktree -- api` — **all 7 API integration files passed (137 + 47 + 36 + 34 + 27 + 15 + ... = green)**, including the new leaderboard-avatar assertions.
- `npm run test:worktree -- e2e tests/member-log-result.spec.ts` — **4/4 passed**.
- `npm run test:worktree -- e2e` (full suite) — **33/34 passed**. The single failure (`programs.spec.ts:277 — MEMBER joins a PUBLIC program from Browse`) reproduces on the merge base with this PR's changes stashed; it is the pre-existing shared-DB fixture-leakage issue and is not caused by this PR.

**Not automated / manual verification needed:**
- [x] Visual polish of the avatar size relative to the leaderboard row's vertical rhythm in production CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)