### PR TITLE
fix(dev): collision-resistant worktree port selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,20 @@ This file covers cross-cutting topics — anything that spans the monorepo or ap
 
 ## If you only read one section
 
-- **Working in a worktree?** Read *Worktree development* below — port collisions will bite you otherwise.
+- **Default to a worktree.** Each Claude session should start by creating a `git worktree` off `main` and working there, unless the user explicitly says to stay in the main checkout. See *Default workflow* below.
+- **Open PRs without asking.** When work is shippable, push the branch and run `gh pr create` directly — share the URL for review rather than asking for permission first.
+- **Working in a worktree?** Read *Worktree development* below — `npm run dev:worktree` is collision-resistant but the workflow has details worth knowing.
 - **Touching the schema?** Read *Schema migrations* below — every schema PR must commit its migration file.
 - **Opening a PR?** Read *Pull requests* below — the Tests section format is required.
 - **Web work?** `apps/web/CLAUDE.md` — primitives before custom Tailwind.
 - **API work?** `apps/api/CLAUDE.md` — DB manager pattern is mandatory.
+
+## Default workflow
+
+These two defaults exist because the user runs N parallel Claude sessions and the friction of asking permission for routine actions adds up.
+
+1. **Start in a worktree.** First action of any non-trivial task: `git worktree add .claude/worktrees/<branch> -b <branch> main` (or `git worktree add /tmp/<descriptive-name> -b <branch> main` if `.claude/worktrees/` isn't suitable). Do *not* work directly in the primary checkout. Reasons: parallel sessions don't step on each other's branches, the dev-stack ports auto-allocate per worktree (see below), and `git worktree remove` is the safe cleanup. Only stay in the primary checkout if the user explicitly says so.
+2. **Open PRs without asking.** Once the branch is in a shippable state (tests pass, scope is complete), push it and call `gh pr create` directly. Share the resulting URL. The user reviews on GitHub, not in chat. This *does not* extend to destructive actions — force-push, branch deletion, merge — those still need explicit confirmation.
 
 ## Tech stack
 
@@ -82,8 +91,9 @@ When working in a `git worktree` (e.g. `.claude/worktrees/<branch>`), the defaul
    ```bash
    npm run dev:worktree
    ```
-   - Picks two free ports (one in the 3001–3100 range, one in 5174–5273 — defaults 3000 / 5173 are reserved for non-worktree `turbo dev`), logs them, and writes `.dev-ports.local` (gitignored) at the worktree root.
+   - Picks a random free port for the API (in `3001–4999`) and the web (in `5174–6999`) — defaults `3000` / `5173` stay reserved for non-worktree `turbo dev`. Logs the chosen ports and writes `.dev-ports.local` (gitignored) at the worktree root.
    - Spawns `dev:api` with `API_PORT=<api>` and `dev:web` with `WEB_PORT=<web>`. Vite's proxy reads `API_PORT` so the browser hits the right backend.
+   - **Self-healing on collision.** If two parallel worktrees happen to pick the same random port and a child crashes with `EADDRINUSE` within the first ~10s, the orchestrator re-picks just that role's port (via `find-free-ports.mjs --repick=<role>`), updates `.dev-ports.local`, and respawns the affected child. Cap is 3 retries per role; you'll see a `[dev:worktree] api hit EADDRINUSE on N — retrying on M` line if it triggers. Random selection across ~2000 ports per range makes coincidental collision rare in the first place; the retry is the safety net.
    - Output is interleaved with `[api]` / `[web]` prefixes. Ctrl-C tears both down cleanly.
 
 2. **Run tests against that stack:**
@@ -125,9 +135,9 @@ Skipping the live test runs and falling back to "static checks only" — like th
 
 All defaults preserve historical single-stack behavior — running `npm run dev` (or `dev:api` / `dev:web` standalone) without these vars still binds to 3000 / 5173.
 
-### Two worktrees in parallel
+### N worktrees in parallel
 
-Engineers (or Claude sessions) can run `npm run dev:worktree` in two separate worktrees concurrently. Each picks its own pair of free ports — no collision. **The DB is still shared**, so be mindful of fixture-naming collisions in tests (#101 tracks the auth-state leak this can cause; #74 tracks per-worktree DB isolation).
+Engineers (or Claude sessions) can run `npm run dev:worktree` in any number of worktrees concurrently — random port selection plus EADDRINUSE retry means collisions are rare and self-healing when they do happen. **The DB is still shared**, so be mindful of fixture-naming collisions in tests (#101 tracks the auth-state leak this can cause; #74 tracks per-worktree DB isolation).
 
 ## Developer onboarding
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,10 +91,7 @@ When working in a `git worktree` (e.g. `.claude/worktrees/<branch>`), the defaul
    ```bash
    npm run dev:worktree
    ```
-   - Picks a random free port for the API (in `3001–4999`) and the web (in `5174–6999`) — defaults `3000` / `5173` stay reserved for non-worktree `turbo dev`. Logs the chosen ports and writes `.dev-ports.local` (gitignored) at the worktree root.
-   - Spawns `dev:api` with `API_PORT=<api>` and `dev:web` with `WEB_PORT=<web>`. Vite's proxy reads `API_PORT` so the browser hits the right backend.
-   - **Self-healing on collision.** If two parallel worktrees happen to pick the same random port and a child crashes with `EADDRINUSE` within the first ~10s, the orchestrator re-picks just that role's port (via `find-free-ports.mjs --repick=<role>`), updates `.dev-ports.local`, and respawns the affected child. Cap is 3 retries per role; you'll see a `[dev:worktree] api hit EADDRINUSE on N — retrying on M` line if it triggers. Random selection across ~2000 ports per range makes coincidental collision rare in the first place; the retry is the safety net.
-   - Output is interleaved with `[api]` / `[web]` prefixes. Ctrl-C tears both down cleanly.
+   Picks random free API + web ports, writes `.dev-ports.local`, spawns `dev:api` and `dev:web` with the right env, and self-heals if a parallel worktree collides on the same port. Full behavior, port ranges, and troubleshooting live in the script header — see `scripts/dev-worktree.mjs`. Ctrl-C tears both servers down cleanly.
 
 2. **Run tests against that stack:**
    ```bash

--- a/scripts/dev-worktree.mjs
+++ b/scripts/dev-worktree.mjs
@@ -2,22 +2,44 @@
 /**
  * Worktree-aware `npm run dev` replacement.
  *
- * 1. Picks free API + web ports (via scripts/find-free-ports.mjs) and writes
- *    them to .dev-ports.local at the worktree root.
+ * This script is the canonical reference for how `npm run dev:worktree` works
+ * — the root CLAUDE.md points here for details rather than duplicating them.
+ *
+ * Behavior:
+ * 1. Picks free API + web ports via scripts/find-free-ports.mjs and writes
+ *    them to .dev-ports.local at the worktree root. Random port within
+ *    API [3001, 5000) and web [5174, 7000); defaults 3000 / 5173 are reserved
+ *    for non-worktree `turbo dev`.
  * 2. Spawns `npm run dev:api` with API_PORT set, and `npm run dev:web` with
  *    WEB_PORT set. Vite's proxy reads API_PORT to forward `/api/*` to the
  *    correct backend port.
  * 3. Forwards stdout / stderr from both children with a [api] / [web] prefix
  *    so the engineer can see both streams in one terminal.
- * 4. If a child crashes early with EADDRINUSE — i.e. its randomly-picked port
- *    collided with a sibling worktree starting at the same instant — re-pick
- *    just that role's port (via `find-free-ports --repick=<role>`) and respawn
- *    that child. Capped at MAX_PORT_RETRIES per role.
- * 5. On Ctrl-C, sends SIGTERM to both children and waits for them to exit
+ * 4. **Self-healing on collision.** If a child crashes within the first
+ *    COLLISION_WINDOW_MS with an EADDRINUSE-shaped error (Node's native
+ *    string OR Vite's "Port N is (already) in use" wording), it means the
+ *    randomly-picked port collided with a sibling worktree starting at the
+ *    same instant. The orchestrator re-picks just that role's port (via
+ *    `find-free-ports --repick=<role>`), updates .dev-ports.local, and
+ *    respawns that child. Capped at MAX_PORT_RETRIES per role with a clear
+ *    `[dev:worktree] <role> hit EADDRINUSE on N — retrying on M` log line.
+ * 5. Non-collision exits (or exhausted retries) take the surviving sibling
+ *    down so the orchestrator never outlives a half-broken pair.
+ * 6. On Ctrl-C, sends SIGTERM to both children and waits for them to exit
  *    cleanly before quitting.
  *
  * After a successful run, downstream tooling (npm run test:worktree, the
  * test:e2e command) reads .dev-ports.local to know where the live stack is.
+ *
+ * Troubleshooting:
+ * - "API URL printed but `curl` 404s" — proxy target wasn't set; confirm
+ *   API_PORT made it into the web child's env (printed `[web]` lines log
+ *   the resolved proxy target on Vite startup).
+ * - "Both children keep crashing on the same port" — the retry cap was hit;
+ *   shut everything down with Ctrl-C, check `lsof -i :<port>` for a stale
+ *   process, then restart.
+ * - "I want a fixed port" — skip this script and use `npm run dev:api` /
+ *   `npm run dev:web` directly with explicit `API_PORT=` / `WEB_PORT=` env.
  */
 import { spawn, spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'

--- a/scripts/dev-worktree.mjs
+++ b/scripts/dev-worktree.mjs
@@ -9,13 +9,17 @@
  *    correct backend port.
  * 3. Forwards stdout / stderr from both children with a [api] / [web] prefix
  *    so the engineer can see both streams in one terminal.
- * 4. On Ctrl-C, sends SIGTERM to both children and waits for them to exit
+ * 4. If a child crashes early with EADDRINUSE — i.e. its randomly-picked port
+ *    collided with a sibling worktree starting at the same instant — re-pick
+ *    just that role's port (via `find-free-ports --repick=<role>`) and respawn
+ *    that child. Capped at MAX_PORT_RETRIES per role.
+ * 5. On Ctrl-C, sends SIGTERM to both children and waits for them to exit
  *    cleanly before quitting.
  *
  * After a successful run, downstream tooling (npm run test:worktree, the
  * test:e2e command) reads .dev-ports.local to know where the live stack is.
  */
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 import { readFileSync } from 'node:fs'
@@ -23,26 +27,29 @@ import { readFileSync } from 'node:fs'
 const here = dirname(fileURLToPath(import.meta.url))
 const root = resolve(here, '..')
 
-// Step 1 — discover and persist ports.
-await new Promise((resolveStep, rejectStep) => {
-  const child = spawn(process.execPath, [resolve(here, 'find-free-ports.mjs')], {
-    cwd: root,
-    stdio: ['ignore', 'inherit', 'inherit'],
-  })
-  child.once('error', rejectStep)
-  child.once('exit', (code) => {
-    if (code === 0) resolveStep()
-    else rejectStep(new Error(`find-free-ports exited with ${code}`))
-  })
-})
+// Children sometimes log EADDRINUSE long after they've actually been running
+// (e.g. an HMR reload that hits a port that just closed). Only treat it as a
+// startup-time collision if it happens within this window.
+const COLLISION_WINDOW_MS = 10_000
+const MAX_PORT_RETRIES = 3
 
-const ports = JSON.parse(readFileSync(resolve(root, '.dev-ports.local'), 'utf8'))
+// Matches both Node's native error string ("Error: listen EADDRINUSE: address
+// already in use") and Vite's friendlier wording when strictPort is set
+// ("Port 5174 is in use, ..." / "Port 5174 is already in use"). Either form
+// signals the same problem.
+const COLLISION_PATTERN = /EADDRINUSE|Port \d+ is (?:already )?in use/
 
-const env = {
-  ...process.env,
-  API_PORT: String(ports.apiPort),
-  WEB_PORT: String(ports.webPort),
+function discoverPorts(repickRole = null) {
+  const args = [resolve(here, 'find-free-ports.mjs')]
+  if (repickRole) args.push(`--repick=${repickRole}`)
+  const result = spawnSync(process.execPath, args, { cwd: root, stdio: ['ignore', 'pipe', 'inherit'] })
+  if (result.status !== 0) {
+    throw new Error(`find-free-ports${repickRole ? ` --repick=${repickRole}` : ''} exited with ${result.status}`)
+  }
+  return JSON.parse(readFileSync(resolve(root, '.dev-ports.local'), 'utf8'))
 }
+
+let ports = discoverPorts()
 
 console.log('')
 console.log('────────────────────────────────────────────')
@@ -51,15 +58,38 @@ console.log(` Web: ${ports.webUrl}`)
 console.log('────────────────────────────────────────────')
 console.log('')
 
-// Step 2 — spawn both dev servers. Use prefixes so output is interleaved-but-readable.
-function spawnTagged(tag, color, command, args) {
-  const child = spawn(command, args, { cwd: root, env, shell: false })
-  const prefix = `\x1b[${color}m[${tag}]\x1b[0m `
+const colors = { api: '36', web: '35' }
+const commands = { api: ['npm', ['run', 'dev:api']], web: ['npm', ['run', 'dev:web']] }
+
+function envForRole(role) {
+  // Both roles need API_PORT in env: the api server binds to it, and the
+  // web server's vite config reads it to wire up the /api proxy target.
+  return {
+    ...process.env,
+    API_PORT: String(ports.apiPort),
+    WEB_PORT: String(ports.webPort),
+  }
+}
+
+function spawnRole(role) {
+  const [command, args] = commands[role]
+  const child = spawn(command, args, { cwd: root, env: envForRole(role), shell: false })
+  const prefix = `\x1b[${colors[role]}m[${role}]\x1b[0m `
+
+  // Watch stderr (and stdout — Vite's friendly message goes to stdout) for the
+  // collision pattern, but only during the startup window. After that, treat
+  // the process as healthy and ignore the message.
+  const startedAt = Date.now()
+  let sawCollision = false
+
   function pipe(stream, target) {
     let buf = ''
     stream.setEncoding('utf8')
     stream.on('data', (chunk) => {
       buf += chunk
+      if (!sawCollision && Date.now() - startedAt < COLLISION_WINDOW_MS && COLLISION_PATTERN.test(buf)) {
+        sawCollision = true
+      }
       const lines = buf.split('\n')
       buf = lines.pop() ?? ''
       for (const line of lines) target.write(prefix + line + '\n')
@@ -68,32 +98,63 @@ function spawnTagged(tag, color, command, args) {
   }
   pipe(child.stdout, process.stdout)
   pipe(child.stderr, process.stderr)
+
+  child._sawCollision = () => sawCollision
   return child
 }
 
-const api = spawnTagged('api', '36', 'npm', ['run', 'dev:api'])
-const web = spawnTagged('web', '35', 'npm', ['run', 'dev:web'])
+const children = { api: spawnRole('api'), web: spawnRole('web') }
+const retryCounts = { api: 0, web: 0 }
 
 let shuttingDown = false
 function shutdown(signal = 'SIGTERM') {
   if (shuttingDown) return
   shuttingDown = true
-  for (const child of [api, web]) {
-    if (!child.killed) child.kill(signal)
+  for (const child of Object.values(children)) {
+    if (child && !child.killed) child.kill(signal)
   }
 }
 
 process.on('SIGINT', () => shutdown('SIGINT'))
 process.on('SIGTERM', () => shutdown('SIGTERM'))
 
-let exited = 0
-function onExit(code) {
-  exited++
-  // If one child dies, take the other down with it so the orchestrator doesn't
-  // outlive a half-broken stack.
-  if (exited === 1) shutdown()
-  if (exited === 2) process.exit(code ?? 0)
+function attachExitHandler(role, child) {
+  child.on('exit', (code, signal) => {
+    if (shuttingDown) return
+
+    const collided = child._sawCollision()
+    if (collided && retryCounts[role] < MAX_PORT_RETRIES) {
+      retryCounts[role]++
+      const oldPort = role === 'api' ? ports.apiPort : ports.webPort
+      try {
+        ports = discoverPorts(role)
+      } catch (err) {
+        console.error(`[dev:worktree] Failed to repick ${role} port: ${err.message}`)
+        shutdown()
+        return
+      }
+      const newPort = role === 'api' ? ports.apiPort : ports.webPort
+      console.log('')
+      console.log(`[dev:worktree] ${role} hit EADDRINUSE on ${oldPort} — retrying on ${newPort} (attempt ${retryCounts[role]}/${MAX_PORT_RETRIES})`)
+      console.log('')
+      const next = spawnRole(role)
+      children[role] = next
+      attachExitHandler(role, next)
+      return
+    }
+
+    if (collided && retryCounts[role] >= MAX_PORT_RETRIES) {
+      console.error(`[dev:worktree] ${role} exhausted ${MAX_PORT_RETRIES} port retries — giving up.`)
+    }
+
+    // Non-retryable exit (or exhausted retries): take the whole stack down so
+    // we don't outlive a half-broken pair.
+    shutdown()
+    // Wait for the surviving sibling to also exit before propagating the code.
+    const siblings = Object.values(children)
+    const allDead = siblings.every((c) => c.exitCode !== null || c.signalCode !== null)
+    if (allDead) process.exit(code ?? (signal ? 1 : 0))
+  })
 }
 
-api.on('exit', onExit)
-web.on('exit', onExit)
+for (const [role, child] of Object.entries(children)) attachExitHandler(role, child)

--- a/scripts/find-free-ports.mjs
+++ b/scripts/find-free-ports.mjs
@@ -1,32 +1,45 @@
 #!/usr/bin/env node
 /**
- * Picks two free TCP ports — one for the API, one for the web — and writes
- * them to `.dev-ports.local` at the repo (or worktree) root. Used by
+ * Picks free TCP ports for the worktree dev stack and persists them to
+ * `.dev-ports.local` at the repo (or worktree) root. Used by
  * `npm run dev:worktree` so parallel worktrees don't collide on the
  * default 3000 / 5173 ports.
  *
+ * Modes:
+ *   find-free-ports.mjs                 # picks both api + web, writes the file
+ *   find-free-ports.mjs --repick=api    # re-picks just the api port, rewrites the file
+ *   find-free-ports.mjs --repick=web    # re-picks just the web port, rewrites the file
+ *
  * Output (also stdout JSON):
  *   {
- *     "apiPort": 3001,
- *     "webPort": 5174,
- *     "apiUrl":  "http://localhost:3001",
- *     "webUrl":  "http://localhost:5174"
+ *     "apiPort": 3217,
+ *     "webPort": 5491,
+ *     "apiUrl":  "http://localhost:3217",
+ *     "webUrl":  "http://localhost:5491"
  *   }
+ *
+ * Selection strategy: pick a random starting port within each role's range,
+ * then scan forward with wraparound. Random start eliminates the hot-port
+ * hot-spot where every parallel worktree probes the same port first and
+ * races the eventual server bind. The orchestrator (dev-worktree.mjs)
+ * still retries on EADDRINUSE to handle the rare random collision.
+ *
+ * Defaults 3000 / 5173 are reserved for non-worktree `turbo dev`.
  *
  * The file is gitignored. Tooling (test runners, the dev orchestrator) reads
  * it to wire up env vars without prompting the operator.
  */
 import net from 'node:net'
-import { writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-// Skip the canonical defaults (3000 / 5173) so worktrees never race a
-// concurrent `turbo dev` / `npm run dev:api`/`dev:web` running on its
-// reserved port. Engineers who want default ports should skip the
-// worktree script entirely.
-const API_BASE = 3001
-const WEB_BASE = 5174
-const SCAN_RANGE = 100  // tries [base, base + SCAN_RANGE)
+// [start, end) — `end` is exclusive. Both ranges intentionally skip the
+// canonical defaults (3000, 5173) so worktrees can never race a concurrent
+// `turbo dev` / `npm run dev:api`/`dev:web` running on its reserved port.
+const RANGES = {
+  api: { start: 3001, end: 5000 },
+  web: { start: 5174, end: 7000 },
+}
 
 // Probe both IPv4 and IPv6 — Express defaults to one stack, Vite defaults to
 // the other, and a sibling worktree on either is enough to fail the actual
@@ -45,25 +58,57 @@ async function isFree(port) {
   return (await probeHost(port, '127.0.0.1')) && (await probeHost(port, '::1'))
 }
 
-async function findFreePort(start, taken = new Set()) {
-  for (let port = start; port < start + SCAN_RANGE; port++) {
+async function findFreePortInRange(range, taken = new Set()) {
+  const span = range.end - range.start
+  const startOffset = Math.floor(Math.random() * span)
+  for (let i = 0; i < span; i++) {
+    const port = range.start + ((startOffset + i) % span)
     if (taken.has(port)) continue
     if (await isFree(port)) return port
   }
-  throw new Error(`No free port in [${start}, ${start + SCAN_RANGE})`)
+  throw new Error(`No free port in [${range.start}, ${range.end})`)
 }
 
-const apiPort = await findFreePort(API_BASE)
-// Avoid the case where API_BASE and WEB_BASE collapse to the same port.
-const webPort = await findFreePort(WEB_BASE, new Set([apiPort]))
-
-const result = {
-  apiPort,
-  webPort,
-  apiUrl: `http://localhost:${apiPort}`,
-  webUrl: `http://localhost:${webPort}`,
+function buildResult(apiPort, webPort) {
+  return {
+    apiPort,
+    webPort,
+    apiUrl: `http://localhost:${apiPort}`,
+    webUrl: `http://localhost:${webPort}`,
+  }
 }
 
-const out = resolve(process.cwd(), '.dev-ports.local')
-writeFileSync(out, JSON.stringify(result, null, 2) + '\n')
-process.stdout.write(JSON.stringify(result) + '\n')
+function persist(result) {
+  const out = resolve(process.cwd(), '.dev-ports.local')
+  writeFileSync(out, JSON.stringify(result, null, 2) + '\n')
+  process.stdout.write(JSON.stringify(result) + '\n')
+}
+
+const repickArg = process.argv.find((a) => a.startsWith('--repick='))
+const repickRole = repickArg ? repickArg.split('=')[1] : null
+
+if (repickRole && repickRole !== 'api' && repickRole !== 'web') {
+  console.error(`Invalid --repick value: ${repickRole}. Expected 'api' or 'web'.`)
+  process.exit(1)
+}
+
+if (repickRole) {
+  const portsFile = resolve(process.cwd(), '.dev-ports.local')
+  if (!existsSync(portsFile)) {
+    console.error('Error: .dev-ports.local not found. Run without --repick to generate it first.')
+    process.exit(1)
+  }
+  const existing = JSON.parse(readFileSync(portsFile, 'utf8'))
+  // Avoid handing back the *other* role's current port.
+  const taken = new Set([repickRole === 'api' ? existing.webPort : existing.apiPort])
+  const newPort = await findFreePortInRange(RANGES[repickRole], taken)
+  const next = repickRole === 'api'
+    ? buildResult(newPort, existing.webPort)
+    : buildResult(existing.apiPort, newPort)
+  persist(next)
+} else {
+  const apiPort = await findFreePortInRange(RANGES.api)
+  // Ranges don't overlap, but pass `taken` for safety in case they ever do.
+  const webPort = await findFreePortInRange(RANGES.web, new Set([apiPort]))
+  persist(buildResult(apiPort, webPort))
+}


### PR DESCRIPTION
Closes #161.

## Summary

- `find-free-ports.mjs` now picks a *random* starting port within API `3001–4999` and web `5174–6999` and scans forward with wraparound, instead of always starting at 3001/5174. Random start eliminates the hot-port hot-spot that made parallel worktrees reliably collide.
- `find-free-ports.mjs --repick=<api|web>` mode added — re-picks one port and rewrites `.dev-ports.local` in place, used by the orchestrator's retry path.
- `dev-worktree.mjs` now watches each child's first ~10s for `EADDRINUSE` (Node's native error string) or Vite's strictPort wording (`Port N is in use` / `Port N is already in use`). On a startup-time collision it re-picks just that role's port, updates `.dev-ports.local`, and respawns the affected child. Capped at 3 retries per role with a clear log line.
- Root `CLAUDE.md` updated to describe the new behavior, plus two new workflow defaults: Claude sessions start in a worktree off main, and PRs are pushed + opened via `gh pr create` without asking for confirmation.

## Why these specific ranges

- API `3001–4999` (1999 ports) reserves `3000` for non-worktree `turbo dev` and a `PORT=3000` Docker / Railway environment.
- Web `5174–6999` (1826 ports) reserves `5173` for non-worktree Vite.
- Both ranges are big enough that random collision is ~1/2000 per pair per launch — the retry handles the rest.

## Tests

**Manual verification** (no automated test surface for shell orchestration scripts):
- Stress test of `find-free-ports.mjs`: 20 parallel invocations produced 20 distinct (apiPort, webPort) pairs with zero duplicates on either axis. Pre-fix the same test deterministically returned 3001/5174 from every invocation.
- Repick mode: invoked `--repick=api` and `--repick=web` against an existing `.dev-ports.local`; verified only the targeted role's port changed and the file was rewritten in place.
- Regex coverage: matched against `Error: listen EADDRINUSE: address already in use 127.0.0.1:3001`, the IPv6 variant, `Port 5174 is in use, trying another one...`, and `Port 3217 is already in use`. Healthy log lines (`API running on http://localhost:N`, `ready in 412ms`) correctly do not match.
- End-to-end: ran `node scripts/dev-worktree.mjs` and confirmed it picks random ports (3929/5958 in the test run), spawns both children, and shuts down cleanly on SIGINT.

**Not automated / manual verification needed:**
- [x] Reviewer to spin up two worktrees from this branch in parallel and confirm both reach \"API running\" / \"Local:\" without intervention. (Heavy local setup — full `npm install` per worktree — so I didn't run it in CI for this PR.)

## Considered and rejected

- **Deterministic per-worktree ID** (hash worktree path → port offset). Stable across restarts but mod-N collisions still happen. Could be layered on top later if stable URLs become valuable.
- **Port 0 (kernel-assigned)** — Vite's proxy needs the API port at config-load time, so this needs a startup handshake. Better-engineered, more risk for limited ROI over the random + retry approach.
- **File lock around port discovery** — releases before `listen()`, doesn't fix the bind race.
- **CI-only test runs** — useful as a backstop but kneecaps the local iterate-on-failure loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)