### PR TITLE
feat(jobs): drive job selection via JOB_NAME env var

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -65,22 +65,25 @@ The global error-handling middleware in `src/index.ts` automatically logs and re
 
 ## Background jobs
 
-One-shot scripts triggered on a schedule live under `src/jobs/`. The dispatcher at `src/jobs/index.ts` is the CLI entrypoint — it takes the job name as `argv[2]`, looks it up in the `JOBS` map, runs the matching handler, disconnects Prisma, and exits (`0` on success, `1` on handler error, `2` on unknown / missing job name).
+One-shot scripts triggered on a schedule live under `src/jobs/`. The dispatcher at `src/jobs/index.ts` is the CLI entrypoint — it reads the job name from `argv[2]` (or `process.env.JOB_NAME` as fallback), looks it up in the `JOBS` map, runs the matching handler, disconnects Prisma, and exits (`0` on success, `1` on handler error, `2` on unknown / missing job name).
 
-Each job is its own Railway service: same image (`Dockerfile.jobs`), different `startCommand` (the job name), different `cronSchedule`. The image's `ENTRYPOINT` runs the dispatcher, so Railway only needs to override the argument.
+Each job is its own Railway service, all sharing the `Dockerfile.jobs` image. The Dockerfile's CMD is `sh -c "exec node apps/api/dist/jobs/index.js \"${JOB_NAME:-noop}\""`, so the only per-service difference is the `JOB_NAME` service variable (set in the Railway dashboard). Cron cadence is also configured per-service in the dashboard. Do **not** use Railway's `startCommand` to pick the job — that path was unreliable on QA (the cron container produced no logs at all).
 
 **Adding a new job:**
 1. Create `src/jobs/<name>.ts` exporting an async handler.
 2. Register it in the dispatcher's `JOBS` map in `src/jobs/index.ts`.
-3. Add a `railway.<name>.toml` (or update `railway.jobs.toml`) with the desired `startCommand` and `cronSchedule`.
+3. In Railway: create a new cron service from this repo, point its build at `apps/api/railway.jobs.toml`, set `JOB_NAME=<name>` and the desired cron schedule.
 
 **Local invocation:**
 ```bash
-# from repo root
+# from repo root — argv path
 npm run dev:jobs -- <name>
 
-# or, for a built run that mirrors prod
-npm run build --workspace=@wodalytics/api && npm run job --workspace=@wodalytics/api -- <name>
+# or, mirroring prod via the env var
+JOB_NAME=<name> npm run job --workspace=@wodalytics/api
+
+# or, full Docker-image repro of the Railway service
+docker compose --profile jobs run --rm -e JOB_NAME=<name> jobs
 ```
 
 The Express API service does **not** import job code at runtime — the two services share modules under `src/lib/` and `src/db/`, but have separate entrypoints and separate Railway deployments. A job failure cannot affect the user-facing API.

--- a/apps/api/Dockerfile.jobs
+++ b/apps/api/Dockerfile.jobs
@@ -33,7 +33,13 @@ COPY --from=builder /app/apps/api/dist ./apps/api/dist
 
 # This is a one-shot job runner, not a server — no EXPOSE.
 # Migrations are owned by the API service; jobs assume the schema is already migrated.
-# ENTRYPOINT runs the dispatcher; CMD provides the default job name and is
-# overridden per-service in railway.jobs.toml via startCommand.
-ENTRYPOINT ["node", "apps/api/dist/jobs/index.js"]
-CMD ["crossfit-wod"]
+#
+# One image, many jobs: each Railway service sets `JOB_NAME` to the registry
+# key it wants to run (see `src/jobs/index.ts`). The `sh -c` form expands the
+# env var into argv before exec'ing node. Driving the dispatcher via Railway
+# `startCommand` proved unreliable on QA — the cron container produced no
+# logs at all — so we read the name from the environment instead.
+#
+# Defaults to `noop` if `JOB_NAME` is unset so a misconfigured service runs
+# the smoke-test handler rather than silently doing nothing.
+CMD ["sh", "-c", "exec node apps/api/dist/jobs/index.js \"${JOB_NAME:-noop}\""]

--- a/apps/api/railway.jobs.toml
+++ b/apps/api/railway.jobs.toml
@@ -1,16 +1,14 @@
-# Railway service config for the CrossFit Mainsite WOD ingest cron.
+# Railway service config for jobs that share the Dockerfile.jobs image.
 #
-# One image (Dockerfile.jobs) backs many Railway services — each service
-# overrides startCommand with a different job name. Add a new service per job;
-# all of them share the same image and dispatcher.
+# One image, many services: every cron service points at this Dockerfile and
+# selects which job to run by setting the `JOB_NAME` service variable in the
+# Railway dashboard (e.g. JOB_NAME=crossfit-wod). The Dockerfile's CMD reads
+# that env var and dispatches the matching handler in `src/jobs/index.ts`.
 #
-# Prerequisite: a Program named "CrossFit Mainsite WOD" must exist in the DB
-# before this service does anything useful. Until then the job logs a warning
-# and exits 0 each tick.
+# We do **not** set `startCommand` here — using it to pass the job name was
+# the source of the silent-failure deploys on QA. Cron schedule is also set
+# per-service in the Railway UI so the same TOML can be reused for every job.
 
 [build]
 dockerfilePath = "apps/api/Dockerfile.jobs"
 buildCommand = ""
-
-[deploy]
-startCommand = ""

--- a/apps/api/src/jobs/index.ts
+++ b/apps/api/src/jobs/index.ts
@@ -17,34 +17,9 @@ const JOBS: Record<string, JobHandler> = {
   'crossfit-wod': () => runCrossfitWodJob(),
 }
 
-// Env vars the API codebase reads. Logged (presence only, never values) at
-// dispatch start so a Railway run with missing wiring reveals it in the first
-// few lines rather than as a silent downstream failure.
-const TRACKED_ENV_VARS = [
-  'DATABASE_URL',
-  'NODE_ENV',
-  'TZ',
-  'PORT',
-  'API_PORT',
-  'ALLOWED_ORIGINS',
-  'FRONTEND_URL',
-  'GOOGLE_CLIENT_ID',
-  'GOOGLE_CLIENT_SECRET',
-  'GOOGLE_REDIRECT_URI',
-  'JWT_ACCESS_SECRET',
-  'JWT_REFRESH_SECRET',
-  'WODALYTICS_ADMIN_EMAILS',
-  'AWS_S3_BUCKET',
-  'AWS_REGION',
-  'AWS_ACCESS_KEY_ID',
-  'AWS_SECRET_ACCESS_KEY',
-  'AWS_S3_PUBLIC_URL_BASE',
-  'LOCAL_UPLOADS_ROOT',
-] as const
-
-// Returns the host (and optionally db name) from a postgres URL without
-// exposing credentials. Useful for confirming the cron is pointed at the
-// expected Railway DB without leaking the password into logs.
+// Returns the host (and db name) from a postgres URL without exposing
+// credentials. Useful for confirming a cron run is pointed at the expected
+// Railway DB without leaking the password into logs.
 function summarizeDatabaseUrl(url: string | undefined): string {
   if (!url) return '(unset)'
   try {
@@ -58,26 +33,19 @@ function summarizeDatabaseUrl(url: string | undefined): string {
 
 function logStartupDiagnostics(jobName: string): void {
   log.info(`dispatcher boot — job=${jobName} pid=${process.pid}`)
-  log.info(`runtime — node=${process.version} platform=${process.platform} arch=${process.arch} cwd=${process.cwd()}`)
+  log.info(`runtime — node=${process.version} platform=${process.platform} arch=${process.arch}`)
   log.info(`database — ${summarizeDatabaseUrl(process.env.DATABASE_URL)}`)
-  const envSummary = TRACKED_ENV_VARS.map((k) => `${k}=${process.env[k] ? 'set' : 'missing'}`).join(' ')
-  log.info(`env — ${envSummary}`)
-  // ICU/tz sanity — todayInPacific() depends on Intl.DateTimeFormat being able
-  // to resolve America/Los_Angeles. Alpine images historically ship with
-  // small-icu, which can cause silent fallback to UTC.
-  try {
-    const sample = new Intl.DateTimeFormat('en-US', { timeZone: 'America/Los_Angeles' }).format(new Date())
-    log.info(`intl — America/Los_Angeles resolved to "${sample}"`)
-  } catch (err) {
-    log.error(`intl — America/Los_Angeles lookup failed: ${err instanceof Error ? err.message : err}`)
-  }
 }
 
 async function main(): Promise<number> {
-  const jobName = process.argv[2]
+  // The container Dockerfile expands $JOB_NAME into argv before exec'ing
+  // node, so argv[2] is the canonical path in prod. Falling back to the
+  // env var directly keeps the dispatcher convenient to invoke ad-hoc
+  // (`JOB_NAME=foo node dist/jobs/index.js`) without changing the wrapper.
+  const jobName = process.argv[2] ?? process.env.JOB_NAME
 
   if (!jobName) {
-    log.error('no job name provided. usage: node dist/jobs/index.js <jobName>')
+    log.error('no job name provided. set JOB_NAME or pass as argv[2]')
     return 2
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,16 +56,14 @@ services:
       - postgres
       - api
 
-  # One-shot cron-job runner — mirrors the Railway service that runs the
-  # `crossfit-wod` job on a 15-min cadence. Behind the `jobs` profile so it
-  # does not auto-start with `docker compose up`. Env vars intentionally
-  # mirror what's set on Railway QA (only DATABASE_URL + NODE_ENV) so this
-  # is a faithful local repro for "no deploy logs" debugging.
+  # One-shot cron-job runner — mirrors a Railway cron service. Job is selected
+  # by `JOB_NAME`, the same env var the Railway services use. Behind the `jobs`
+  # profile so it does not auto-start with `docker compose up`.
   #
-  # Run a single tick:
+  # Run the default crossfit-wod tick:
   #   docker compose --profile jobs run --rm jobs
-  # Run a different job (override the default crossfit-wod):
-  #   docker compose --profile jobs run --rm jobs noop
+  # Run a different job:
+  #   docker compose --profile jobs run --rm -e JOB_NAME=noop jobs
   # Force a rebuild of the jobs image first:
   #   docker compose --profile jobs build jobs
   jobs:
@@ -77,7 +75,7 @@ services:
     environment:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/wodalytics
       NODE_ENV: production
-    command: ["crossfit-wod"]
+      JOB_NAME: crossfit-wod
     depends_on:
       - postgres
     restart: "no"


### PR DESCRIPTION
## Summary

Railway's `startCommand` proved unreliable for selecting which job a cron service runs — QA cron containers produced zero log output and never ran the dispatcher. Replaces it with an env-var-driven `CMD` so the job name is just another Railway service variable, which is the part of the platform we know works reliably.

Also trims the env-var audit + ICU probe added in #155 — that diagnostic was a one-shot debugging tool, not a permanent fixture. Kept the load-bearing logging (boot banner, masked DB summary, full error stack, run duration, stdout flush before exit).

## Changes

- **`apps/api/Dockerfile.jobs`** — `CMD` is now `sh -c "exec node apps/api/dist/jobs/index.js \"${JOB_NAME:-noop}\""`. `ENTRYPOINT` removed. Defaults to `noop` so a misconfigured service runs the smoke-test handler rather than silently doing nothing.
- **`apps/api/src/jobs/index.ts`** — dispatcher accepts `process.env.JOB_NAME` as a fallback to `argv[2]` so ad-hoc invocation (`JOB_NAME=foo node dist/jobs/index.js`) works without a wrapper. Removes the long `TRACKED_ENV_VARS` audit and the ICU probe. Keeps the boot banner, masked DB URL summary, error stack on failure, run-duration timing, and stdout flush before exit.
- **`apps/api/railway.jobs.toml`** — stops setting `startCommand`. Cron schedule and `JOB_NAME` both now live in the Railway dashboard per service. One TOML, many cron services.
- **`docker-compose.yml`** — jobs profile uses a `JOB_NAME` env var instead of a `command:` override, mirroring Railway exactly.
- **`apps/api/CLAUDE.md`** — Background jobs section updated to describe the new pattern.

## Required follow-up on Railway

For each existing cron service that uses `Dockerfile.jobs`:
1. Add a service variable `JOB_NAME=<job>` (e.g. `crossfit-wod`).
2. Clear any stale `Start Command` set in the service settings — it's no longer used.
3. Confirm cron schedule is still set in the dashboard.

The build for the new image will pick up the change without manual rebuild on the next deploy.

## Tests

**Local smoke tests** (no automated coverage exists for the dispatcher entrypoint — the existing API integration tests don't cover it):

- Built `wodalytics-jobs:local` via `docker compose --profile jobs build jobs` — clean build.
- Ran the dispatcher directly to confirm both invocation paths work:
  ```
  $ JOB_NAME=noop node apps/api/dist/jobs/index.js
  INFO [jobs] dispatcher boot — job=noop pid=…
  INFO [jobs] runtime — node=v25.7.0 platform=darwin arch=arm64
  INFO [jobs] database — postgresql://localhost:5432/wodalytics
  INFO [jobs] starting noop
  INFO [jobs] noop job ran
  INFO [jobs] finished noop in 0ms

  $ node apps/api/dist/jobs/index.js noop
  # same output (argv[2] path)
  ```
- `npx tsc --noEmit` clean across the API workspace.

**Not automated / manual verification needed:**
- [ ] After merging, set `JOB_NAME=crossfit-wod` on the QA cron service, redeploy, and confirm the dispatcher boot banner appears in the deploy logs at the next 15-min tick.
- [ ] Run `docker compose --profile jobs run --rm -e JOB_NAME=noop jobs` against a non-busy local stack to validate the full Docker invocation path end-to-end (couldn't run during PR build because the main repo's compose stack was holding the `wodalytics-db` container name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)