### PR TITLE
fix(web): result display shows NaN:NaN — read new value.score shape (regression from #157)

### DIFF
--- a/apps/web/src/lib/formatResult.test.ts
+++ b/apps/web/src/lib/formatResult.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest'
+import { formatResultValue } from './formatResult'
+
+describe('formatResultValue', () => {
+  test('TIME score → "M:SS"', () => {
+    expect(formatResultValue({ score: { kind: 'TIME', seconds: 305, cappedOut: false } })).toBe('5:05')
+    expect(formatResultValue({ score: { kind: 'TIME', seconds: 525, cappedOut: false } })).toBe('8:45')
+    expect(formatResultValue({ score: { kind: 'TIME', seconds: 60,  cappedOut: false } })).toBe('1:00')
+  })
+
+  test('TIME score with cappedOut → "CAPPED"', () => {
+    expect(formatResultValue({ score: { kind: 'TIME', seconds: 600, cappedOut: true } })).toBe('CAPPED')
+  })
+
+  test('ROUNDS_REPS with rounds → "X rounds + Y reps"', () => {
+    expect(formatResultValue({ score: { kind: 'ROUNDS_REPS', rounds: 6, reps: 12, cappedOut: false } })).toBe('6 rounds + 12 reps')
+  })
+
+  test('ROUNDS_REPS without rounds → "Y reps"', () => {
+    expect(formatResultValue({ score: { kind: 'ROUNDS_REPS', reps: 95, cappedOut: false } })).toBe('95 reps')
+  })
+
+  test('LOAD score → "value unit"', () => {
+    expect(formatResultValue({ score: { kind: 'LOAD', load: 225, unit: 'LB' } })).toBe('225 lb')
+    expect(formatResultValue({ score: { kind: 'LOAD', load: 100, unit: 'KG' } })).toBe('100 kg')
+  })
+
+  test('DISTANCE score → "value unit"', () => {
+    expect(formatResultValue({ score: { kind: 'DISTANCE', distance: 500, unit: 'M' } })).toBe('500 m')
+    expect(formatResultValue({ score: { kind: 'DISTANCE', distance: 5,   unit: 'KM' } })).toBe('5 km')
+  })
+
+  test('CALORIES score → "N cal"', () => {
+    expect(formatResultValue({ score: { kind: 'CALORIES', calories: 30 } })).toBe('30 cal')
+  })
+
+  test('movementResults only → "N sets logged"', () => {
+    expect(formatResultValue({ movementResults: [{ sets: [{}, {}, {}] }, { sets: [{}, {}] }] })).toBe('5 sets logged')
+    expect(formatResultValue({ movementResults: [{ sets: [{}] }] })).toBe('1 set logged')
+  })
+
+  test('null/undefined/empty → "—"', () => {
+    expect(formatResultValue(null)).toBe('—')
+    expect(formatResultValue(undefined)).toBe('—')
+    expect(formatResultValue({})).toBe('—')
+    expect(formatResultValue({ movementResults: [] })).toBe('—')
+  })
+})

--- a/apps/web/src/lib/formatResult.ts
+++ b/apps/web/src/lib/formatResult.ts
@@ -1,0 +1,50 @@
+// Single source of truth for rendering a `Result.value` to a human-friendly
+// string. Reads the new `{ score?, movementResults }` shape; for strength
+// results with no workout-level score, summarizes the per-movement set count.
+
+interface ResultValueShape {
+  score?: {
+    kind: 'ROUNDS_REPS' | 'TIME' | 'LOAD' | 'DISTANCE' | 'CALORIES' | 'REPS'
+    rounds?: number
+    reps?: number
+    seconds?: number
+    cappedOut?: boolean
+    load?: number
+    unit?: string
+    distance?: number
+    calories?: number
+  }
+  movementResults?: { sets?: unknown[] }[]
+}
+
+function formatSeconds(totalSec: number): string {
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+export function formatResultValue(value: Record<string, unknown> | undefined | null): string {
+  if (!value) return '—'
+  const v = value as unknown as ResultValueShape
+  const score = v.score
+  if (score) {
+    switch (score.kind) {
+      case 'ROUNDS_REPS': {
+        if (score.cappedOut && (score.reps ?? 0) === 0 && !score.rounds) return 'CAPPED'
+        return score.rounds !== undefined
+          ? `${score.rounds} rounds + ${score.reps ?? 0} reps`
+          : `${score.reps ?? 0} reps`
+      }
+      case 'TIME':     return score.cappedOut ? 'CAPPED' : formatSeconds(score.seconds ?? 0)
+      case 'LOAD':     return `${score.load} ${(score.unit ?? '').toLowerCase()}`.trim()
+      case 'DISTANCE': return `${score.distance} ${(score.unit ?? '').toLowerCase()}`.trim()
+      case 'CALORIES': return `${score.calories} cal`
+      case 'REPS':     return `${score.reps ?? 0} reps`
+    }
+  }
+  if (v.movementResults && v.movementResults.length > 0) {
+    const sets = v.movementResults.reduce((n, mr) => n + (mr.sets?.length ?? 0), 0)
+    return sets > 0 ? `${sets} set${sets === 1 ? '' : 's'} logged` : '—'
+  }
+  return '—'
+}

--- a/apps/web/src/pages/History.tsx
+++ b/apps/web/src/pages/History.tsx
@@ -6,6 +6,7 @@ import { useMovements } from '../context/MovementsContext.tsx'
 import MovementFilterInput from '../components/MovementFilterInput.tsx'
 import Button from '../components/ui/Button.tsx'
 import EmptyState from '../components/ui/EmptyState.tsx'
+import { formatResultValue as formatValue } from '../lib/formatResult.ts'
 
 const LEVEL_LABELS: Record<WorkoutLevel, string> = {
   RX_PLUS: 'RX+',
@@ -14,24 +15,8 @@ const LEVEL_LABELS: Record<WorkoutLevel, string> = {
   MODIFIED: 'Modified',
 }
 
-function formatSeconds(seconds: number): string {
-  const m = Math.floor(seconds / 60)
-  const s = seconds % 60
-  return `${m}:${String(s).padStart(2, '0')}`
-}
-
 function formatResultValue(result: HistoryResult): string {
-  const v = result.value
-  const type = result.workout.type as WorkoutType
-
-  if (type === 'AMRAP') {
-    return `${v.rounds as number} rounds + ${v.reps as number} reps`
-  }
-  if (type === 'FOR_TIME') {
-    if (v.cappedOut) return 'CAPPED'
-    return formatSeconds(v.seconds as number)
-  }
-  return '—'
+  return formatValue(result.value)
 }
 
 function monthKey(dateStr: string): string {

--- a/apps/web/src/pages/WodDetail.test.tsx
+++ b/apps/web/src/pages/WodDetail.test.tsx
@@ -142,7 +142,7 @@ function makeResult(overrides: { id: string; userId: string; name: string; level
     },
     level: overrides.level,
     workoutGender: 'OPEN' as const,
-    value: { seconds: overrides.seconds, cappedOut: false },
+    value: { score: { kind: 'TIME', seconds: overrides.seconds, cappedOut: false }, movementResults: [] },
     notes: null,
     createdAt: '2026-04-01T00:00:00.000Z',
     workout: { id: 'workout-1', type: 'FOR_TIME' as const, scheduledAt: '2026-07-15T12:00:00.000Z', title: 'Test Workout' },

--- a/apps/web/src/pages/WodDetail.tsx
+++ b/apps/web/src/pages/WodDetail.tsx
@@ -8,6 +8,7 @@ import MarkdownDescription from '../components/MarkdownDescription.tsx'
 import Avatar from '../components/Avatar.tsx'
 import Button from '../components/ui/Button.tsx'
 import SegmentedControl from '../components/ui/SegmentedControl.tsx'
+import { formatResultValue as formatValue } from '../lib/formatResult.ts'
 
 const CATEGORY_LABELS: Record<WorkoutCategory, string> = {
   GIRL_WOD: 'Girl WOD',
@@ -48,28 +49,8 @@ const GENDER_OPTIONS: { value: GenderFilter; label: string }[] = [
   { value: 'FEMALE', label: 'Female' },
 ]
 
-function formatSeconds(seconds: number): string {
-  const m = Math.floor(seconds / 60)
-  const s = seconds % 60
-  return `${m}:${String(s).padStart(2, '0')}`
-}
-
 function formatResultValue(result: WorkoutResult): string {
-  const v = result.value
-  const type = result.workout.type
-
-  if (type === 'AMRAP') {
-    const rounds = v.rounds as number
-    const reps = v.reps as number
-    return `${rounds} rounds + ${reps} reps`
-  }
-
-  if (type === 'FOR_TIME') {
-    if (v.cappedOut) return 'CAPPED'
-    return formatSeconds(v.seconds as number)
-  }
-
-  return '—'
+  return formatValue(result.value)
 }
 
 export default function WodDetail() {

--- a/apps/web/src/pages/WodResultDetail.test.tsx
+++ b/apps/web/src/pages/WodResultDetail.test.tsx
@@ -64,7 +64,7 @@ function makeResult(overrides: {
     },
     level: 'RX' as const,
     workoutGender: 'OPEN' as const,
-    value: { seconds: 305, cappedOut: false },
+    value: { score: { kind: 'TIME', seconds: 305, cappedOut: false }, movementResults: [] },
     notes: overrides.notes ?? null,
     createdAt: '2026-04-01T00:00:00.000Z',
     workout: { type: 'FOR_TIME' as const },

--- a/apps/web/src/pages/WodResultDetail.tsx
+++ b/apps/web/src/pages/WodResultDetail.tsx
@@ -5,6 +5,7 @@ import { api, type Workout, type WorkoutCategory, type WorkoutResult, type Worko
 import { WORKOUT_TYPE_STYLES } from '../lib/workoutTypeStyles.ts'
 import MarkdownDescription from '../components/MarkdownDescription.tsx'
 import Avatar from '../components/Avatar.tsx'
+import { formatResultValue as formatValue } from '../lib/formatResult.ts'
 
 const CATEGORY_LABELS: Record<WorkoutCategory, string> = {
   GIRL_WOD: 'Girl WOD',
@@ -27,28 +28,8 @@ const WORKOUT_GENDER_LABELS: Record<'MALE' | 'FEMALE' | 'OPEN', string> = {
   OPEN: 'Open',
 }
 
-function formatSeconds(seconds: number): string {
-  const m = Math.floor(seconds / 60)
-  const s = seconds % 60
-  return `${m}:${String(s).padStart(2, '0')}`
-}
-
 function formatResultValue(result: WorkoutResult): string {
-  const v = result.value
-  const type = result.workout.type
-
-  if (type === 'AMRAP') {
-    const rounds = v.rounds as number
-    const reps = v.reps as number
-    return `${rounds} rounds + ${reps} reps`
-  }
-
-  if (type === 'FOR_TIME') {
-    if (v.cappedOut) return 'CAPPED'
-    return formatSeconds(v.seconds as number)
-  }
-
-  return '—'
+  return formatValue(result.value)
 }
 
 export default function WodResultDetail() {

--- a/apps/web/src/test/a11y.test.tsx
+++ b/apps/web/src/test/a11y.test.tsx
@@ -96,7 +96,7 @@ function makeResult(overrides: Record<string, unknown> = {}) {
     user: { id: 'u-1', name: 'Athlete A', firstName: 'Athlete', lastName: 'A', email: 'athlete-a@test.com', avatarUrl: null },
     level: 'RX' as const,
     workoutGender: 'OPEN' as const,
-    value: { seconds: 300, cappedOut: false },
+    value: { score: { kind: 'TIME', seconds: 300, cappedOut: false }, movementResults: [] },
     notes: null,
     createdAt: '2026-04-01T00:00:00.000Z',
     workout: { id: 'workout-1', type: 'FOR_TIME' as const, scheduledAt: '2026-04-15T12:00:00.000Z', title: 'Test Workout' },


### PR DESCRIPTION
## Summary

QA hotfix: results submitted after slice 1 of #3 land correctly in the DB but render as `NaN:NaN` (FOR_TIME) or `undefined rounds + undefined reps` (AMRAP) in `WodDetail`, `WodResultDetail`, and `History`.

## Root cause

Slice 1 reshaped `Result.value` from the legacy `{ type, rounds, reps, seconds, cappedOut }` to the new `{ score: { kind, ... }, movementResults }` and updated the *write* path in `LogResultDrawer`. The *read* path on the three display pages still reached for `v.seconds` / `v.rounds` / `v.cappedOut` on values that no longer carry those keys at the top level — so the formatter built `${undefined}:${'NaN'}` and friends.

## Fix

- New `apps/web/src/lib/formatResult.ts` — single helper that switches on `value.score.kind` and renders the right string per kind. Strength results (no `score`, only `movementResults`) get a `"N sets logged"` summary until the slice-2 sets-table view ships.
- `WodDetail`, `WodResultDetail`, `History` now delegate to the helper.
- Test fixtures in `WodDetail.test.tsx`, `WodResultDetail.test.tsx`, and `a11y.test.tsx` updated to the new shape.
- New `formatResult.test.ts` covers each `score.kind` plus the `movementResults`-only fallback and the empty/null cases.

Part of #3.

## Tests

**Unit** (`apps/web/src/lib/formatResult.test.ts`):
- TIME score → formats as `"M:SS"` (305s → "5:05", 525s → "8:45", 60s → "1:00")
- TIME score with `cappedOut: true` → "CAPPED"
- ROUNDS_REPS with rounds → `"X rounds + Y reps"`
- ROUNDS_REPS with rounds undefined (AMRAP that doesn't track rounds) → `"Y reps"`
- LOAD score → `"value unit"` (lowercase unit)
- DISTANCE score → `"value unit"` (lowercase unit)
- CALORIES score → `"N cal"`
- `movementResults` only (strength path) → `"N sets logged"` (singular vs plural)
- `null` / `undefined` / `{}` / `{ movementResults: [] }` → `"—"`

**Existing pages tests** (re-run, all 138 still passing) — `apps/web/src/pages/WodDetail.test.tsx`, `WodResultDetail.test.tsx`, `History.test.tsx`, plus the page-level `apps/web/src/test/a11y.test.tsx` axe check, all updated to the new shape and still pass.

**Not automated / manual verification needed:**
- [ ] Verify on QA: log a new FOR_TIME result and confirm the time renders correctly on the WOD detail leaderboard, "Your Result" card, /history, and the read-only result detail page.
- [ ] Verify the AMRAP and capped-out cases the same way.
