### PR TITLE
feat(mobile): per-movement sets table in LogResultScreen (slice 3 of #3)

### DIFF
--- a/apps/mobile/__tests__/HistoryScreen.test.tsx
+++ b/apps/mobile/__tests__/HistoryScreen.test.tsx
@@ -102,6 +102,70 @@ describe('HistoryScreen', () => {
     await findByText('8:45')
   })
 
+  test('strength results render heaviest set as "{reps} x {load} {unit}"', async () => {
+    ;(api.me.results as jest.Mock).mockResolvedValue({
+      results: [
+        {
+          id: '1',
+          workout: { id: 'w-1', title: 'Back Squat 5x5', type: 'POWER_LIFTING', scheduledAt: '2026-04-15T12:00:00.000Z' },
+          level: 'RX' as const,
+          workoutGender: 'MALE' as const,
+          value: {
+            movementResults: [{
+              workoutMovementId: 'm-1',
+              loadUnit: 'LB',
+              sets: [
+                { reps: '5', load: 225 },
+                // Heaviest single set — 6 x 255 lb. Ties on load break by
+                // maxRepChunk(reps), so a 5-rep set still beats a 1-rep set
+                // at the same load.
+                { reps: '6', load: 255 },
+                { reps: '3', load: 245 },
+              ],
+            }],
+          },
+          notes: null,
+          createdAt: '2026-04-15T12:00:00.000Z',
+        },
+      ],
+      total: 1,
+      page: 1,
+      limit: 20,
+      pages: 1,
+    })
+
+    const { findByText } = render(<HistoryScreen navigation={navigation} route={{ params: {} } as any} />)
+    await findByText('6 x 255 lb')
+  })
+
+  test('strength results with no load fall back to set-count summary', async () => {
+    ;(api.me.results as jest.Mock).mockResolvedValue({
+      results: [
+        {
+          id: '1',
+          workout: { id: 'w-1', title: 'Bodyweight', type: 'GYMNASTICS', scheduledAt: '2026-04-15T12:00:00.000Z' },
+          level: 'RX' as const,
+          workoutGender: 'MALE' as const,
+          value: {
+            movementResults: [{
+              workoutMovementId: 'm-1',
+              sets: [{ reps: '10' }, { reps: '8' }, { reps: '6' }],
+            }],
+          },
+          notes: null,
+          createdAt: '2026-04-15T12:00:00.000Z',
+        },
+      ],
+      total: 1,
+      page: 1,
+      limit: 20,
+      pages: 1,
+    })
+
+    const { findByText } = render(<HistoryScreen navigation={navigation} route={{ params: {} } as any} />)
+    await findByText('3 sets logged')
+  })
+
   test('FOR_TIME with cappedOut renders as "(capped)"', async () => {
     ;(api.me.results as jest.Mock).mockResolvedValue({
       results: [

--- a/apps/mobile/__tests__/LogResultScreen.test.tsx
+++ b/apps/mobile/__tests__/LogResultScreen.test.tsx
@@ -50,6 +50,10 @@ function makeMovement(id: string, name: string, prescription: any = {}) {
     displayOrder: 0,
     sets: null, reps: null, load: null, loadUnit: null, tempo: null,
     distance: null, distanceUnit: null, calories: null, seconds: null,
+    // Mirrors the API default — Prisma column has @default(true), so reads
+    // always carry a populated tracksLoad. Tests that need to suppress the
+    // Load column override this to false explicitly.
+    tracksLoad: true,
     ...prescription,
   }
 }
@@ -75,18 +79,30 @@ const STRENGTH_WORKOUT = makeWorkout({
   title: 'Back Squat 5x5',
   type: 'POWER_LIFTING',
   workoutMovements: [
-    makeMovement('m-1', 'Back Squat', { displayOrder: 0, sets: 5, reps: '5', load: 225, loadUnit: 'LB', tempo: '3.1.1.0' }),
+    makeMovement('m-1', 'Back Squat', { displayOrder: 0, sets: 5, reps: '5', load: 225, loadUnit: 'LB', tempo: '3.1.1.0', tracksLoad: true }),
   ],
 })
 
 // Strength prescription with no load prescribed — programmers leave the
-// actual weight to the member. The Load column should still auto-show.
+// actual weight to the member. tracksLoad still defaults to true on the API
+// side, so the Load column should auto-show.
 const STRENGTH_WORKOUT_NO_LOAD = makeWorkout({
   id: 'w-4',
   title: 'Back Squat — heavy triple',
   type: 'POWER_LIFTING',
   workoutMovements: [
-    makeMovement('m-1', 'Back Squat', { displayOrder: 0, sets: 3, reps: '3' }),
+    makeMovement('m-1', 'Back Squat', { displayOrder: 0, sets: 3, reps: '3', tracksLoad: true }),
+  ],
+})
+
+// Strength prescription with tracksLoad explicitly off — e.g. plyometric box
+// jumps where load isn't relevant. The Load column should NOT render.
+const STRENGTH_WORKOUT_NO_LOAD_TRACKING = makeWorkout({
+  id: 'w-5',
+  title: 'Box Jumps 5x5',
+  type: 'POWER_LIFTING',
+  workoutMovements: [
+    makeMovement('m-1', 'Box Jump', { displayOrder: 0, sets: 5, reps: '5', tracksLoad: false }),
   ],
 })
 
@@ -147,9 +163,28 @@ describe('LogResultScreen — strength sets table', () => {
     await findByText('Back Squat — heavy triple')
 
     // Three rows from `sets: 3`, each carrying both Reps and Load even though
-    // the programmer only prescribed reps.
+    // the programmer only prescribed reps. tracksLoad defaults to true on the
+    // server, so the Load column auto-shows.
     expect(getAllByLabelText(/Set \d Reps/i)).toHaveLength(3)
     expect(getAllByLabelText(/Set \d Load/i)).toHaveLength(3)
+  })
+
+  test('strength workout with tracksLoad=false hides the Load column entirely', async () => {
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(STRENGTH_WORKOUT_NO_LOAD_TRACKING)
+
+    const { findByText, getAllByLabelText, queryAllByLabelText, queryByLabelText } = render(
+      <LogResultScreen navigation={makeNavigation()} route={makeRoute({ workoutId: 'w-5' })} />,
+    )
+
+    await findByText('Box Jumps 5x5')
+
+    // Reps column still renders (strength baseline). Load column must be
+    // suppressed because tracksLoad=false on the prescription.
+    expect(getAllByLabelText(/Set \d Reps/i)).toHaveLength(5)
+    expect(queryAllByLabelText(/Set \d Load/i)).toHaveLength(0)
+    // The "+ Load" reachable column button must not appear either, since
+    // tracksLoad=false makes Load unreachable for this movement.
+    expect(queryByLabelText(/Add Load column/i)).toBeNull()
   })
 
   test('+ Add set appends a row and × removes one', async () => {

--- a/apps/mobile/__tests__/LogResultScreen.test.tsx
+++ b/apps/mobile/__tests__/LogResultScreen.test.tsx
@@ -79,6 +79,17 @@ const STRENGTH_WORKOUT = makeWorkout({
   ],
 })
 
+// Strength prescription with no load prescribed — programmers leave the
+// actual weight to the member. The Load column should still auto-show.
+const STRENGTH_WORKOUT_NO_LOAD = makeWorkout({
+  id: 'w-4',
+  title: 'Back Squat — heavy triple',
+  type: 'POWER_LIFTING',
+  workoutMovements: [
+    makeMovement('m-1', 'Back Squat', { displayOrder: 0, sets: 3, reps: '3' }),
+  ],
+})
+
 const FOR_TIME_WORKOUT = makeWorkout({ id: 'w-2', title: 'Fran', type: 'FOR_TIME', tracksRounds: false })
 
 function makeNavigation() {
@@ -124,6 +135,21 @@ describe('LogResultScreen — strength sets table', () => {
     expect(getByLabelText(/Set 1 Reps/i).props.value).toBe('5')
     expect(getByLabelText(/Set 3 Load/i).props.value).toBe('225')
     expect(getByLabelText(/Set 5 Tempo/i).props.value).toBe('3.1.1.0')
+  })
+
+  test('strength workout without prescribed load still surfaces a Load column', async () => {
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(STRENGTH_WORKOUT_NO_LOAD)
+
+    const { findByText, getAllByLabelText } = render(
+      <LogResultScreen navigation={makeNavigation()} route={makeRoute({ workoutId: 'w-4' })} />,
+    )
+
+    await findByText('Back Squat — heavy triple')
+
+    // Three rows from `sets: 3`, each carrying both Reps and Load even though
+    // the programmer only prescribed reps.
+    expect(getAllByLabelText(/Set \d Reps/i)).toHaveLength(3)
+    expect(getAllByLabelText(/Set \d Load/i)).toHaveLength(3)
   })
 
   test('+ Add set appends a row and × removes one', async () => {

--- a/apps/mobile/__tests__/LogResultScreen.test.tsx
+++ b/apps/mobile/__tests__/LogResultScreen.test.tsx
@@ -1,12 +1,17 @@
 /**
  * LogResultScreen tests
  *
- * Covers the create + edit + delete paths:
- *   - AMRAP and FOR_TIME form variants
- *   - Validation (out-of-range values block submit)
+ * Covers:
+ *   - Strength workouts render per-movement sets tables (slice 3)
+ *   - Add / remove set rows
+ *   - Switching movement tabs
+ *   - Cluster reps "1.1.1" pass; bad reps "abc" surface an error
+ *   - Submitting a strength result POSTs movementResults
+ *   - AMRAP with tracksRounds=false hides the rounds input
+ *   - AMRAP with tracksRounds=true posts ROUNDS_REPS score
+ *   - FOR_TIME collapses minutes/seconds + capped toggle
  *   - 409 "already logged" handling
- *   - Unsupported workout types show warning + disable submit
- *   - Edit mode (existingResult) calls api.results.update
+ *   - Edit mode pre-fills + PATCHes via api.results.update
  *   - Delete via Alert.alert + api.results.delete
  *   - Gender derivation from useAuth().user.identifiedGender
  */
@@ -37,17 +42,44 @@ jest.mock('../src/lib/api', () => ({
 import { useAuth } from '../src/context/AuthContext'
 import { api } from '../src/lib/api'
 
-const AMRAP_WORKOUT = {
-  id: 'w-1',
-  title: 'Cindy',
-  description: '20 min AMRAP of 5 pull-ups, 10 push-ups, 15 air squats',
-  type: 'AMRAP' as const,
-  status: 'PUBLISHED' as const,
-  scheduledAt: '2026-04-15T12:00:00.000Z',
-  programId: null,
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeMovement(id: string, name: string, prescription: any = {}) {
+  return {
+    movement: { id, name, parentId: null },
+    displayOrder: 0,
+    sets: null, reps: null, load: null, loadUnit: null, tempo: null,
+    distance: null, distanceUnit: null, calories: null, seconds: null,
+    ...prescription,
+  }
 }
-const FOR_TIME_WORKOUT = { ...AMRAP_WORKOUT, id: 'w-2', title: 'Fran', type: 'FOR_TIME' as const }
-const STRENGTH_WORKOUT = { ...AMRAP_WORKOUT, id: 'w-3', title: 'Back Squat 5x5', type: 'STRENGTH' as const }
+
+function makeWorkout(overrides: any = {}) {
+  return {
+    id: 'w-1',
+    title: 'Cindy',
+    description: '20 min AMRAP of 5 pull-ups, 10 push-ups, 15 air squats',
+    type: 'AMRAP' as const,
+    status: 'PUBLISHED' as const,
+    scheduledAt: '2026-04-15T12:00:00.000Z',
+    programId: null,
+    workoutMovements: [],
+    timeCapSeconds: null,
+    tracksRounds: true,
+    ...overrides,
+  }
+}
+
+const STRENGTH_WORKOUT = makeWorkout({
+  id: 'w-3',
+  title: 'Back Squat 5x5',
+  type: 'POWER_LIFTING',
+  workoutMovements: [
+    makeMovement('m-1', 'Back Squat', { displayOrder: 0, sets: 5, reps: '5', load: 225, loadUnit: 'LB', tempo: '3.1.1.0' }),
+  ],
+})
+
+const FOR_TIME_WORKOUT = makeWorkout({ id: 'w-2', title: 'Fran', type: 'FOR_TIME', tracksRounds: false })
 
 function makeNavigation() {
   return { navigate: jest.fn(), setOptions: jest.fn(), goBack: jest.fn() } as any
@@ -67,14 +99,204 @@ function setUser(identifiedGender: 'MALE' | 'FEMALE' | 'NON_BINARY' | 'PREFER_NO
   })
 }
 
-describe('LogResultScreen', () => {
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('LogResultScreen — strength sets table', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     setUser('MALE')
   })
 
-  test('AMRAP: rounds + reps submit calls api.workouts.logResult with derived workoutGender', async () => {
-    ;(api.workouts.get as jest.Mock).mockResolvedValue(AMRAP_WORKOUT)
+  test('renders one row per prescribed set with prescription values pre-filled', async () => {
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(STRENGTH_WORKOUT)
+
+    const { findByText, getAllByLabelText, getByLabelText } = render(
+      <LogResultScreen navigation={makeNavigation()} route={makeRoute({ workoutId: 'w-3' })} />,
+    )
+
+    await findByText('Back Squat 5x5')
+
+    expect(getAllByLabelText(/Set \d Reps/i)).toHaveLength(5)
+    expect(getAllByLabelText(/Set \d Load/i)).toHaveLength(5)
+    expect(getAllByLabelText(/Set \d Tempo/i)).toHaveLength(5)
+
+    // Prescribed values pre-fill every row
+    expect(getByLabelText(/Set 1 Reps/i).props.value).toBe('5')
+    expect(getByLabelText(/Set 3 Load/i).props.value).toBe('225')
+    expect(getByLabelText(/Set 5 Tempo/i).props.value).toBe('3.1.1.0')
+  })
+
+  test('+ Add set appends a row and × removes one', async () => {
+    const w = makeWorkout({
+      id: 'w-3',
+      title: 'Back Squat',
+      type: 'POWER_LIFTING',
+      workoutMovements: [makeMovement('m-1', 'Back Squat', { sets: 2, reps: '5', load: 200, loadUnit: 'LB' })],
+    })
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(w)
+
+    const { findByText, getAllByLabelText, getByLabelText, getByTestId } = render(
+      <LogResultScreen navigation={makeNavigation()} route={makeRoute({ workoutId: 'w-3' })} />,
+    )
+
+    await findByText('Back Squat')
+    expect(getAllByLabelText(/Set \d Reps/i)).toHaveLength(2)
+
+    fireEvent.press(getByTestId('add-set'))
+    expect(getAllByLabelText(/Set \d Reps/i)).toHaveLength(3)
+
+    fireEvent.press(getByLabelText(/Remove set 3/i))
+    expect(getAllByLabelText(/Set \d Reps/i)).toHaveLength(2)
+  })
+
+  test('switches between movement tabs', async () => {
+    const w = makeWorkout({
+      id: 'w-3',
+      title: 'Squat + RDL',
+      type: 'POWER_LIFTING',
+      workoutMovements: [
+        makeMovement('m-1', 'Back Squat', { displayOrder: 0, sets: 2, reps: '5' }),
+        makeMovement('m-2', 'RDL',         { displayOrder: 1, sets: 3, reps: '10' }),
+      ],
+    })
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(w)
+
+    const { findByText, getAllByLabelText, getByTestId } = render(
+      <LogResultScreen navigation={makeNavigation()} route={makeRoute({ workoutId: 'w-3' })} />,
+    )
+
+    await findByText('Squat + RDL')
+    expect(getAllByLabelText(/Set \d Reps/i)).toHaveLength(2)
+
+    fireEvent.press(getByTestId('movement-tab-1'))
+    expect(getAllByLabelText(/Set \d Reps/i)).toHaveLength(3)
+  })
+
+  test('submitting a strength result POSTs movementResults with parsed values', async () => {
+    const w = makeWorkout({
+      id: 'w-3',
+      title: 'Back Squat',
+      type: 'POWER_LIFTING',
+      workoutMovements: [makeMovement('m-1', 'Back Squat', { sets: 1, reps: '5', load: 225, loadUnit: 'LB' })],
+    })
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(w)
+    ;(api.workouts.logResult as jest.Mock).mockResolvedValue({})
+
+    const navigation = makeNavigation()
+    const { findByText, getByLabelText } = render(
+      <LogResultScreen navigation={navigation} route={makeRoute({ workoutId: 'w-3' })} />,
+    )
+
+    await findByText('Back Squat')
+    fireEvent.changeText(getByLabelText(/Set 1 Load/i), '235')
+    fireEvent.press(await findByText('Log result'))
+
+    await waitFor(() => expect(api.workouts.logResult).toHaveBeenCalledTimes(1))
+    const [, payload] = (api.workouts.logResult as jest.Mock).mock.calls[0]
+    expect(payload.value.movementResults[0]).toMatchObject({
+      workoutMovementId: 'm-1',
+      loadUnit: 'LB',
+      sets: [{ reps: '5', load: 235 }],
+    })
+    expect(navigation.goBack).toHaveBeenCalled()
+  })
+
+  test('cluster reps "1.1.1" pass; bad reps "abc" surface an error and block submit', async () => {
+    const w = makeWorkout({
+      id: 'w-3',
+      title: 'Back Squat',
+      type: 'POWER_LIFTING',
+      workoutMovements: [makeMovement('m-1', 'Back Squat', { sets: 1, reps: '5', load: 200, loadUnit: 'LB' })],
+    })
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(w)
+    ;(api.workouts.logResult as jest.Mock).mockResolvedValue({})
+
+    const { findByText, getByLabelText } = render(
+      <LogResultScreen navigation={makeNavigation()} route={makeRoute({ workoutId: 'w-3' })} />,
+    )
+
+    await findByText('Back Squat')
+
+    // "abc" → error, no API call
+    fireEvent.changeText(getByLabelText(/Set 1 Reps/i), 'abc')
+    fireEvent.press(await findByText('Log result'))
+    await findByText(/reps must be digits/i)
+    expect(api.workouts.logResult).not.toHaveBeenCalled()
+
+    // "1.1.1" → passes
+    fireEvent.changeText(getByLabelText(/Set 1 Reps/i), '1.1.1')
+    fireEvent.press(await findByText('Log result'))
+    await waitFor(() => expect(api.workouts.logResult).toHaveBeenCalledTimes(1))
+  })
+
+  test('edit mode pre-fills strength sets and PATCHes via api.results.update', async () => {
+    const w = makeWorkout({
+      id: 'w-3',
+      title: 'Back Squat',
+      type: 'POWER_LIFTING',
+      workoutMovements: [makeMovement('m-1', 'Back Squat', { sets: 1, reps: '5', load: 225, loadUnit: 'LB' })],
+    })
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(w)
+    ;(api.results.update as jest.Mock).mockResolvedValue({})
+
+    const existingResult = {
+      id: 'r-1',
+      user: { id: 'me', name: 'Me' },
+      level: 'RX' as const,
+      workoutGender: 'MALE' as const,
+      value: {
+        movementResults: [
+          { workoutMovementId: 'm-1', loadUnit: 'LB', sets: [{ reps: '5', load: 245, tempo: '3.1.1.0' }] },
+        ],
+      },
+      notes: null,
+      createdAt: '2026-04-15T13:00:00.000Z',
+    }
+
+    const navigation = makeNavigation()
+    const { findByText, getByLabelText } = render(
+      <LogResultScreen
+        navigation={navigation}
+        route={makeRoute({ workoutId: 'w-3', resultId: 'r-1', existingResult })}
+      />,
+    )
+
+    await findByText('Back Squat')
+    expect(getByLabelText(/Set 1 Load/i).props.value).toBe('245')
+    expect(getByLabelText(/Set 1 Tempo/i).props.value).toBe('3.1.1.0')
+
+    fireEvent.changeText(getByLabelText(/Set 1 Load/i), '255')
+    fireEvent.press(await findByText('Save changes'))
+
+    await waitFor(() => expect(api.results.update).toHaveBeenCalledTimes(1))
+    expect((api.results.update as jest.Mock).mock.calls[0][0]).toBe('r-1')
+    expect((api.results.update as jest.Mock).mock.calls[0][1].value.movementResults[0].sets[0].load).toBe(255)
+    expect(api.workouts.logResult).not.toHaveBeenCalled()
+  })
+})
+
+describe('LogResultScreen — score-mode workouts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    setUser('MALE')
+  })
+
+  test('AMRAP with tracksRounds=false hides the rounds input', async () => {
+    const w = makeWorkout({ tracksRounds: false })
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(w)
+
+    const { findByText, queryByTestId, getByTestId } = render(
+      <LogResultScreen navigation={makeNavigation()} route={makeRoute()} />,
+    )
+
+    await findByText('Cindy')
+    expect(queryByTestId('rounds-input')).toBeNull()
+    expect(getByTestId('reps-input')).toBeTruthy()
+  })
+
+  test('AMRAP with tracksRounds=true posts ROUNDS_REPS score', async () => {
+    const w = makeWorkout({ tracksRounds: true })
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(w)
     ;(api.workouts.logResult as jest.Mock).mockResolvedValue({})
 
     const navigation = makeNavigation()
@@ -83,29 +305,26 @@ describe('LogResultScreen', () => {
     )
 
     await findByText('Cindy')
-
-    fireEvent.changeText(getByTestId('rounds-input'), '5')
+    fireEvent.changeText(getByTestId('rounds-input'), '6')
     fireEvent.changeText(getByTestId('reps-input'), '12')
     fireEvent.press(await findByText('Log result'))
 
-    await waitFor(() => {
-      expect(api.workouts.logResult).toHaveBeenCalledWith('w-1', {
-        level: 'RX',
-        workoutGender: 'MALE',
-        value: { score: { kind: 'ROUNDS_REPS', rounds: 5, reps: 12, cappedOut: false }, movementResults: [] },
-        notes: undefined,
-      })
+    await waitFor(() => expect(api.workouts.logResult).toHaveBeenCalledTimes(1))
+    expect((api.workouts.logResult as jest.Mock).mock.calls[0][1]).toEqual({
+      level: 'RX',
+      workoutGender: 'MALE',
+      value: { score: { kind: 'ROUNDS_REPS', rounds: 6, reps: 12, cappedOut: false }, movementResults: [] },
+      notes: undefined,
     })
     expect(navigation.goBack).toHaveBeenCalled()
   })
 
-  test('FOR_TIME: minutes + seconds collapse to seconds=m*60+s', async () => {
+  test('FOR_TIME posts TIME score with collapsed seconds', async () => {
     ;(api.workouts.get as jest.Mock).mockResolvedValue(FOR_TIME_WORKOUT)
     ;(api.workouts.logResult as jest.Mock).mockResolvedValue({})
 
-    const navigation = makeNavigation()
     const { findByText, getByTestId } = render(
-      <LogResultScreen navigation={navigation} route={makeRoute({ workoutId: 'w-2' })} />,
+      <LogResultScreen navigation={makeNavigation()} route={makeRoute({ workoutId: 'w-2' })} />,
     )
 
     await findByText('Fran')
@@ -113,31 +332,28 @@ describe('LogResultScreen', () => {
     fireEvent.changeText(getByTestId('seconds-input'), '45')
     fireEvent.press(await findByText('Log result'))
 
-    await waitFor(() => {
-      expect(api.workouts.logResult).toHaveBeenCalledWith('w-2', expect.objectContaining({
-        value: { score: { kind: 'TIME', seconds: 525, cappedOut: false }, movementResults: [] },
-      }))
-    })
+    await waitFor(() => expect(api.workouts.logResult).toHaveBeenCalledTimes(1))
+    expect((api.workouts.logResult as jest.Mock).mock.calls[0][1]).toEqual(expect.objectContaining({
+      value: { score: { kind: 'TIME', seconds: 525, cappedOut: false }, movementResults: [] },
+    }))
   })
 
   test('FOR_TIME capped toggle sets cappedOut=true and uses seconds=0', async () => {
     ;(api.workouts.get as jest.Mock).mockResolvedValue(FOR_TIME_WORKOUT)
     ;(api.workouts.logResult as jest.Mock).mockResolvedValue({})
 
-    const navigation = makeNavigation()
     const { findByText, getByTestId } = render(
-      <LogResultScreen navigation={navigation} route={makeRoute({ workoutId: 'w-2' })} />,
+      <LogResultScreen navigation={makeNavigation()} route={makeRoute({ workoutId: 'w-2' })} />,
     )
 
     await findByText('Fran')
     fireEvent.press(getByTestId('capped-toggle'))
     fireEvent.press(await findByText('Log result'))
 
-    await waitFor(() => {
-      expect(api.workouts.logResult).toHaveBeenCalledWith('w-2', expect.objectContaining({
-        value: { score: { kind: 'TIME', seconds: 0, cappedOut: true }, movementResults: [] },
-      }))
-    })
+    await waitFor(() => expect(api.workouts.logResult).toHaveBeenCalledTimes(1))
+    expect((api.workouts.logResult as jest.Mock).mock.calls[0][1]).toEqual(expect.objectContaining({
+      value: { score: { kind: 'TIME', seconds: 0, cappedOut: true }, movementResults: [] },
+    }))
   })
 
   test('validation: seconds > 59 surfaces error and does not call API', async () => {
@@ -157,7 +373,7 @@ describe('LogResultScreen', () => {
   })
 
   test('409 from API shows "You\'ve already logged this workout"', async () => {
-    ;(api.workouts.get as jest.Mock).mockResolvedValue(AMRAP_WORKOUT)
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(makeWorkout())
     const conflict = Object.assign(new Error('Already logged'), { status: 409 })
     ;(api.workouts.logResult as jest.Mock).mockRejectedValue(conflict)
 
@@ -172,29 +388,22 @@ describe('LogResultScreen', () => {
 
     await findByText("You've already logged this workout.")
   })
+})
 
-  test('unsupported workout type shows yellow warning and disables submit', async () => {
-    ;(api.workouts.get as jest.Mock).mockResolvedValue(STRENGTH_WORKOUT)
-
-    const { findByText } = render(
-      <LogResultScreen navigation={makeNavigation()} route={makeRoute({ workoutId: 'w-3' })} />,
-    )
-
-    await findByText('Back Squat 5x5')
-    await findByText(/Result logging is not yet supported/)
-
-    fireEvent.press(await findByText('Log result'))
-    expect(api.workouts.logResult).not.toHaveBeenCalled()
+describe('LogResultScreen — edit + delete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    setUser('MALE')
   })
 
-  test('edit mode prefills inputs and submits via api.results.update', async () => {
-    ;(api.workouts.get as jest.Mock).mockResolvedValue(AMRAP_WORKOUT)
+  test('edit mode prefills AMRAP inputs and PATCHes via api.results.update', async () => {
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(makeWorkout())
     ;(api.results.update as jest.Mock).mockResolvedValue({})
     const existingResult = {
       id: 'r-1',
       user: { id: 'me', name: 'Me' },
-      level: 'SCALED',
-      workoutGender: 'OPEN',
+      level: 'SCALED' as const,
+      workoutGender: 'OPEN' as const,
       value: { score: { kind: 'ROUNDS_REPS', rounds: 4, reps: 8, cappedOut: false }, movementResults: [] },
       notes: null,
       createdAt: '2026-04-15T13:00:00.000Z',
@@ -212,7 +421,6 @@ describe('LogResultScreen', () => {
     expect(getByTestId('rounds-input').props.value).toBe('4')
     expect(getByTestId('reps-input').props.value).toBe('8')
 
-    // Bump the reps and save
     fireEvent.changeText(getByTestId('reps-input'), '9')
     fireEvent.press(await findByText('Save changes'))
 
@@ -227,7 +435,7 @@ describe('LogResultScreen', () => {
   })
 
   test('delete: confirmation triggers api.results.delete + goBack', async () => {
-    ;(api.workouts.get as jest.Mock).mockResolvedValue(AMRAP_WORKOUT)
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(makeWorkout())
     ;(api.results.delete as jest.Mock).mockResolvedValue(undefined)
 
     const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_t, _m, buttons) => {
@@ -238,8 +446,8 @@ describe('LogResultScreen', () => {
     const existingResult = {
       id: 'r-1',
       user: { id: 'me', name: 'Me' },
-      level: 'RX',
-      workoutGender: 'OPEN',
+      level: 'RX' as const,
+      workoutGender: 'OPEN' as const,
       value: { score: { kind: 'ROUNDS_REPS', rounds: 1, reps: 1, cappedOut: false }, movementResults: [] },
       notes: null,
       createdAt: '2026-04-15T13:00:00.000Z',
@@ -264,7 +472,7 @@ describe('LogResultScreen', () => {
 
   test('NON_BINARY identifiedGender derives workoutGender=OPEN', async () => {
     setUser('NON_BINARY')
-    ;(api.workouts.get as jest.Mock).mockResolvedValue(AMRAP_WORKOUT)
+    ;(api.workouts.get as jest.Mock).mockResolvedValue(makeWorkout())
     ;(api.workouts.logResult as jest.Mock).mockResolvedValue({})
 
     const { findByText, getByTestId } = render(

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -47,6 +47,11 @@ export interface WorkoutMovementWithPrescription {
   reps: string | null
   load: number | null
   loadUnit: LoadUnit | null
+  // Whether the result form should surface a Load column for this movement.
+  // Always populated on read — the Prisma column has `@default(true)`. Programmer
+  // flips this off for plyometric supersets and other no-load movements where a
+  // Load column would just be noise.
+  tracksLoad: boolean
   tempo: string | null
   distance: number | null
   distanceUnit: DistanceUnit | null

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -15,8 +15,44 @@ const REFRESH_TOKEN_KEY = 'refreshToken'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-export type WorkoutType = 'STRENGTH' | 'FOR_TIME' | 'EMOM' | 'CARDIO' | 'AMRAP' | 'METCON' | 'WARMUP'
+export type WorkoutType =
+  // Strength
+  | 'STRENGTH' | 'POWER_LIFTING' | 'WEIGHT_LIFTING' | 'BODY_BUILDING' | 'MAX_EFFORT'
+  // Metcon
+  | 'AMRAP' | 'FOR_TIME' | 'EMOM' | 'METCON' | 'TABATA' | 'INTERVALS' | 'CHIPPER' | 'LADDER' | 'DEATH_BY'
+  // MonoStructural
+  | 'CARDIO' | 'RUNNING' | 'ROWING' | 'BIKING' | 'SWIMMING' | 'SKI_ERG' | 'MIXED_MONO'
+  // Skill Work
+  | 'GYMNASTICS' | 'WEIGHTLIFTING_TECHNIQUE'
+  // Warmup / Recovery
+  | 'WARMUP' | 'MOBILITY' | 'COOLDOWN'
 export type WorkoutStatus = 'DRAFT' | 'PUBLISHED'
+
+// Per-movement prescription on a workout. All prescription fields are
+// nullable — programmer fills only the columns relevant to the workout.
+// Mirrors the web's `WorkoutMovementWithPrescription`.
+export type LoadUnit = 'LB' | 'KG'
+export type DistanceUnit = 'M' | 'KM' | 'MI' | 'FT' | 'YD'
+
+export interface Movement {
+  id: string
+  name: string
+  parentId: string | null
+}
+
+export interface WorkoutMovementWithPrescription {
+  movement: Movement
+  displayOrder: number
+  sets: number | null
+  reps: string | null
+  load: number | null
+  loadUnit: LoadUnit | null
+  tempo: string | null
+  distance: number | null
+  distanceUnit: DistanceUnit | null
+  calories: number | null
+  seconds: number | null
+}
 
 export interface AuthUser {
   id: string
@@ -59,6 +95,9 @@ export interface Workout {
   status: WorkoutStatus
   scheduledAt: string
   programId: string | null
+  workoutMovements: WorkoutMovementWithPrescription[]
+  timeCapSeconds: number | null
+  tracksRounds: boolean
 }
 
 export interface LeaderboardEntry {

--- a/apps/mobile/src/lib/format.ts
+++ b/apps/mobile/src/lib/format.ts
@@ -1,20 +1,10 @@
 import type { ResultValue } from './api'
+import { styleFor } from './workoutTypeStyles'
 
-const TYPE_ABBR: Record<string, string> = {
-  // Strength
-  STRENGTH: 'S', POWER_LIFTING: 'PL', WEIGHT_LIFTING: 'WL', BODY_BUILDING: 'BB', MAX_EFFORT: 'ME',
-  // Metcon
-  AMRAP: 'A', FOR_TIME: 'F', EMOM: 'E', METCON: 'M', TABATA: 'TB', INTERVALS: 'IN', CHIPPER: 'CH', LADDER: 'LD', DEATH_BY: 'DB',
-  // MonoStructural
-  CARDIO: 'C', RUNNING: 'RN', ROWING: 'RW', BIKING: 'BK', SWIMMING: 'SW', SKI_ERG: 'SK', MIXED_MONO: 'MM',
-  // Skill Work
-  GYMNASTICS: 'GM', WEIGHTLIFTING_TECHNIQUE: 'WT',
-  // Warmup / Recovery
-  WARMUP: 'W', MOBILITY: 'MB', COOLDOWN: 'CD',
-}
-
+// Single source of truth for the badge text — matches the web's
+// WORKOUT_TYPE_STYLES[type].abbr. Falls back to '?' for unknown types.
 export function workoutTypeAbbr(type: string): string {
-  return TYPE_ABBR[type] ?? '?'
+  return styleFor(type).abbr
 }
 
 function formatTime(seconds: number, cappedOut: boolean): string {

--- a/apps/mobile/src/lib/format.ts
+++ b/apps/mobile/src/lib/format.ts
@@ -1,8 +1,16 @@
 import type { ResultValue } from './api'
 
 const TYPE_ABBR: Record<string, string> = {
-  WARMUP: 'W', STRENGTH: 'S', AMRAP: 'A',
-  FOR_TIME: 'F', EMOM: 'E', CARDIO: 'C', METCON: 'M',
+  // Strength
+  STRENGTH: 'S', POWER_LIFTING: 'PL', WEIGHT_LIFTING: 'WL', BODY_BUILDING: 'BB', MAX_EFFORT: 'ME',
+  // Metcon
+  AMRAP: 'A', FOR_TIME: 'F', EMOM: 'E', METCON: 'M', TABATA: 'TB', INTERVALS: 'IN', CHIPPER: 'CH', LADDER: 'LD', DEATH_BY: 'DB',
+  // MonoStructural
+  CARDIO: 'C', RUNNING: 'RN', ROWING: 'RW', BIKING: 'BK', SWIMMING: 'SW', SKI_ERG: 'SK', MIXED_MONO: 'MM',
+  // Skill Work
+  GYMNASTICS: 'GM', WEIGHTLIFTING_TECHNIQUE: 'WT',
+  // Warmup / Recovery
+  WARMUP: 'W', MOBILITY: 'MB', COOLDOWN: 'CD',
 }
 
 export function workoutTypeAbbr(type: string): string {
@@ -14,6 +22,44 @@ function formatTime(seconds: number, cappedOut: boolean): string {
   const secs = seconds % 60
   const time = `${mins}:${String(secs).padStart(2, '0')}`
   return cappedOut ? `${time} (capped)` : time
+}
+
+// Cluster reps like "1.1.1" sort by their largest single chunk — matches the
+// primary-score derivation rule, so leaderboard order and display agree.
+function maxRepChunk(reps: string | undefined): number {
+  if (!reps) return 0
+  const parts = reps.split('.').map((s) => parseInt(s, 10)).filter((n) => Number.isFinite(n))
+  return parts.length ? Math.max(...parts) : 0
+}
+
+interface SetShape {
+  reps?: string
+  load?: number
+  tempo?: string
+  distance?: number
+  calories?: number
+  seconds?: number
+}
+
+interface MovementResultShape {
+  workoutMovementId?: string
+  loadUnit?: string
+  distanceUnit?: string
+  sets?: SetShape[]
+}
+
+function pickHeaviestSet(movementResults: MovementResultShape[]): { reps: string | undefined; load: number; unit: string | undefined } | null {
+  let best: { reps: string | undefined; load: number; unit: string | undefined; rank: number } | null = null
+  for (const mr of movementResults) {
+    for (const s of mr.sets ?? []) {
+      if (s.load === undefined) continue
+      const rank = maxRepChunk(s.reps)
+      if (!best || s.load > best.load || (s.load === best.load && rank > best.rank)) {
+        best = { reps: s.reps, load: s.load, unit: mr.loadUnit, rank }
+      }
+    }
+  }
+  return best ? { reps: best.reps, load: best.load, unit: best.unit } : null
 }
 
 export function formatResultValue(value: ResultValue): string {
@@ -29,12 +75,21 @@ export function formatResultValue(value: ResultValue): string {
       case 'REPS':       return `${s.reps} reps`
     }
   }
-  // Strength workouts derive their score from `movementResults`. The
-  // human-friendly summary lives in slices 2/3 (the new sets-table UI). For
-  // now, surface a count.
+  // Strength results: surface the heaviest single set as the headline number
+  // — that's the figure leaderboards rank by and the one a member wants to
+  // see at a glance. Ties on load break by maxRepChunk (cluster reps "1.1.1"
+  // → 1) so a 5×225 still beats a 1×225. Mirrors apps/web/src/lib/formatResult.ts.
   if (value.movementResults && value.movementResults.length > 0) {
+    const heaviest = pickHeaviestSet(value.movementResults as MovementResultShape[])
+    if (heaviest) {
+      const repsLabel = heaviest.reps ?? '?'
+      const unitLabel = heaviest.unit ? ` ${heaviest.unit.toLowerCase()}` : ''
+      return `${repsLabel} x ${heaviest.load}${unitLabel}`
+    }
+    // Movement results exist but no loads were recorded — fall back to a
+    // count summary so the result row isn't blank.
     const setCount = value.movementResults.reduce((n, mr) => n + mr.sets.length, 0)
-    return `${setCount} set${setCount === 1 ? '' : 's'} logged`
+    return setCount > 0 ? `${setCount} set${setCount === 1 ? '' : 's'} logged` : '—'
   }
   return '—'
 }

--- a/apps/mobile/src/lib/workoutTypeStyles.ts
+++ b/apps/mobile/src/lib/workoutTypeStyles.ts
@@ -1,0 +1,88 @@
+// Mobile parity for apps/web/src/lib/workoutTypeStyles.ts.
+//
+// Same abbreviations + categories + color hues as the web map, translated
+// from Tailwind class names into RN-friendly hex / rgba strings:
+//   tint      = text-{color}-300        → '#hex' (foreground)
+//   bgTint    = bg-{color}-500/15       → 'rgba(...,0.15)' (badge background)
+//   accentBar = border-{color}-400      → '#hex' (accent bar / left border)
+//
+// Keep this file in sync with the web one when types are added or recolored.
+
+import type { WorkoutType } from './api'
+
+export type WorkoutCategory =
+  | 'Strength'
+  | 'Metcon'
+  | 'MonoStructural'
+  | 'Skill Work'
+  | 'Warmup/Recovery'
+
+export interface WorkoutTypeStyle {
+  abbr: string
+  label: string
+  category: WorkoutCategory
+  tint: string       // foreground color
+  bgTint: string     // translucent background
+  accentBar: string  // left-accent bar / border color
+  /** Hidden from new-workout pickers but valid for existing records. */
+  deprecated?: boolean
+}
+
+export const WORKOUT_TYPE_STYLES: Record<WorkoutType, WorkoutTypeStyle> = {
+  // ─── Strength ───────────────────────────────────────────────────────────────
+  STRENGTH:       { abbr: 'STR', label: 'Strength',       category: 'Strength', tint: '#fda4af', bgTint: 'rgba(244,63,94,0.15)',  accentBar: '#fb7185', deprecated: true },
+  POWER_LIFTING:  { abbr: 'PL',  label: 'Power Lifting',  category: 'Strength', tint: '#fca5a5', bgTint: 'rgba(239,68,68,0.15)',  accentBar: '#f87171' },
+  WEIGHT_LIFTING: { abbr: 'WL',  label: 'Weight Lifting', category: 'Strength', tint: '#fdba74', bgTint: 'rgba(249,115,22,0.15)', accentBar: '#fb923c' },
+  BODY_BUILDING:  { abbr: 'BB',  label: 'Bodybuilding',   category: 'Strength', tint: '#f9a8d4', bgTint: 'rgba(236,72,153,0.15)', accentBar: '#f472b6' },
+  MAX_EFFORT:     { abbr: 'ME',  label: 'Max Effort',     category: 'Strength', tint: '#f0abfc', bgTint: 'rgba(217,70,239,0.15)', accentBar: '#e879f9' },
+
+  // ─── Metcon ─────────────────────────────────────────────────────────────────
+  AMRAP:     { abbr: 'AM',  label: 'AMRAP',     category: 'Metcon', tint: '#a5b4fc', bgTint: 'rgba(99,102,241,0.15)',  accentBar: '#818cf8' },
+  FOR_TIME:  { abbr: 'FT',  label: 'For Time',  category: 'Metcon', tint: '#fcd34d', bgTint: 'rgba(245,158,11,0.15)',  accentBar: '#fbbf24' },
+  EMOM:      { abbr: 'EM',  label: 'EMOM',      category: 'Metcon', tint: '#5eead4', bgTint: 'rgba(20,184,166,0.15)',  accentBar: '#2dd4bf' },
+  METCON:    { abbr: 'MET', label: 'Metcon',    category: 'Metcon', tint: '#c4b5fd', bgTint: 'rgba(139,92,246,0.15)',  accentBar: '#a78bfa', deprecated: true },
+  TABATA:    { abbr: 'TB',  label: 'Tabata',    category: 'Metcon', tint: '#d8b4fe', bgTint: 'rgba(168,85,247,0.15)',  accentBar: '#c084fc' },
+  INTERVALS: { abbr: 'IN',  label: 'Intervals', category: 'Metcon', tint: '#93c5fd', bgTint: 'rgba(59,130,246,0.15)',  accentBar: '#60a5fa' },
+  CHIPPER:   { abbr: 'CH',  label: 'Chipper',   category: 'Metcon', tint: '#67e8f9', bgTint: 'rgba(6,182,212,0.15)',   accentBar: '#22d3ee' },
+  LADDER:    { abbr: 'LD',  label: 'Ladder',    category: 'Metcon', tint: '#6ee7b7', bgTint: 'rgba(16,185,129,0.15)',  accentBar: '#34d399' },
+  DEATH_BY:  { abbr: 'DB',  label: 'Death By',  category: 'Metcon', tint: '#fde047', bgTint: 'rgba(234,179,8,0.15)',   accentBar: '#facc15' },
+
+  // ─── MonoStructural ─────────────────────────────────────────────────────────
+  CARDIO:     { abbr: 'CAR', label: 'Cardio',     category: 'MonoStructural', tint: '#7dd3fc', bgTint: 'rgba(14,165,233,0.15)',  accentBar: '#38bdf8', deprecated: true },
+  RUNNING:    { abbr: 'RN',  label: 'Running',    category: 'MonoStructural', tint: '#bef264', bgTint: 'rgba(132,204,22,0.15)',  accentBar: '#a3e635' },
+  ROWING:     { abbr: 'RW',  label: 'Rowing',     category: 'MonoStructural', tint: '#86efac', bgTint: 'rgba(34,197,94,0.15)',   accentBar: '#4ade80' },
+  BIKING:     { abbr: 'BK',  label: 'Biking',     category: 'MonoStructural', tint: '#d6d3d1', bgTint: 'rgba(120,113,108,0.15)', accentBar: '#a8a29e' },
+  SWIMMING:   { abbr: 'SW',  label: 'Swimming',   category: 'MonoStructural', tint: '#93c5fd', bgTint: 'rgba(59,130,246,0.15)',  accentBar: '#60a5fa' },
+  SKI_ERG:    { abbr: 'SK',  label: 'Ski Erg',    category: 'MonoStructural', tint: '#d4d4d8', bgTint: 'rgba(113,113,122,0.15)', accentBar: '#a1a1aa' },
+  MIXED_MONO: { abbr: 'MM',  label: 'Mixed Mono', category: 'MonoStructural', tint: '#d4d4d4', bgTint: 'rgba(115,115,115,0.15)', accentBar: '#a3a3a3' },
+
+  // ─── Skill Work ─────────────────────────────────────────────────────────────
+  GYMNASTICS:              { abbr: 'GM', label: 'Gymnastics',              category: 'Skill Work', tint: '#6ee7b7', bgTint: 'rgba(16,185,129,0.15)', accentBar: '#34d399' },
+  WEIGHTLIFTING_TECHNIQUE: { abbr: 'WT', label: 'Weightlifting Technique', category: 'Skill Work', tint: '#fdba74', bgTint: 'rgba(249,115,22,0.15)', accentBar: '#fb923c' },
+
+  // ─── Warmup / Recovery ──────────────────────────────────────────────────────
+  WARMUP:   { abbr: 'WU', label: 'Warmup',   category: 'Warmup/Recovery', tint: '#cbd5e1', bgTint: 'rgba(100,116,139,0.15)', accentBar: '#94a3b8' },
+  MOBILITY: { abbr: 'MB', label: 'Mobility', category: 'Warmup/Recovery', tint: '#d1d5db', bgTint: 'rgba(107,114,128,0.15)', accentBar: '#9ca3af' },
+  COOLDOWN: { abbr: 'CD', label: 'Cooldown', category: 'Warmup/Recovery', tint: '#d6d3d1', bgTint: 'rgba(120,113,108,0.15)', accentBar: '#a8a29e' },
+}
+
+/** Returns the category for a given workout type. */
+export function categoryOf(type: WorkoutType): WorkoutCategory {
+  return WORKOUT_TYPE_STYLES[type].category
+}
+
+/** Falls back to a neutral style for any unknown type — mirrors web's `?? '?'`
+ *  pattern at the call site, but here we return a real style record so consumers
+ *  can pull abbr + colors uniformly. */
+export const UNKNOWN_TYPE_STYLE: WorkoutTypeStyle = {
+  abbr: '?',
+  label: 'Unknown',
+  category: 'Warmup/Recovery',
+  tint: '#9ca3af',
+  bgTint: 'rgba(75,85,99,0.15)',
+  accentBar: '#6b7280',
+}
+
+export function styleFor(type: string): WorkoutTypeStyle {
+  return WORKOUT_TYPE_STYLES[type as WorkoutType] ?? UNKNOWN_TYPE_STYLE
+}

--- a/apps/mobile/src/screens/FeedScreen.tsx
+++ b/apps/mobile/src/screens/FeedScreen.tsx
@@ -13,6 +13,7 @@ import type { StackScreenProps } from '@react-navigation/stack'
 import type { BottomTabScreenProps } from '@react-navigation/bottom-tabs'
 import type { FeedStackParamList, MainTabParamList, RootStackParamList } from '../../App'
 import { api, type Workout } from '../lib/api'
+import { styleFor, WORKOUT_TYPE_STYLES, type WorkoutTypeStyle } from '../lib/workoutTypeStyles'
 import { useGym } from '../context/GymContext'
 import { useProgramFilter } from '../context/ProgramFilterContext'
 import ProgramFilterPicker from '../components/ProgramFilterPicker'
@@ -24,11 +25,6 @@ type Props = CompositeScreenProps<
     StackScreenProps<RootStackParamList>
   >
 >
-
-const TYPE_ABBR: Record<string, string> = {
-  WARMUP: 'W', STRENGTH: 'S', AMRAP: 'A',
-  FOR_TIME: 'F', EMOM: 'E', CARDIO: 'C', METCON: 'M',
-}
 
 // Initial window when the screen first opens. Subsequent infinite-scroll
 // pages load PAGE_DAYS at a time as the user scrolls into older days.
@@ -96,15 +92,16 @@ function buildDayBlocks(workouts: Workout[], start: Date, end: Date): DayBlock[]
 }
 
 function WorkoutCard({ workout, onPress }: { workout: Workout; onPress: () => void }) {
+  const ts = styleFor(workout.type)
   return (
     <TouchableOpacity style={styles.card} onPress={onPress} activeOpacity={0.7}>
       <View style={styles.cardLeft}>
-        <View style={styles.typeBadge}>
-          <Text style={styles.typeAbbr}>{TYPE_ABBR[workout.type] ?? '?'}</Text>
+        <View style={[styles.typeBadge, { backgroundColor: ts.bgTint }]}>
+          <Text style={[styles.typeAbbr, { color: ts.tint }]}>{ts.abbr}</Text>
         </View>
         <View style={styles.cardBody}>
           <Text style={styles.cardTitle} numberOfLines={1}>{workout.title}</Text>
-          <Text style={styles.cardType}>{workout.type.replace('_', ' ')}</Text>
+          <Text style={styles.cardType}>{ts.label}</Text>
         </View>
       </View>
       <Text style={styles.chevron}>›</Text>
@@ -325,18 +322,18 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   typeBadge: {
-    width: 32,
+    minWidth: 38,
+    paddingHorizontal: 6,
     height: 32,
     borderRadius: 8,
-    backgroundColor: '#1e1b4b',
     alignItems: 'center',
     justifyContent: 'center',
     marginRight: 12,
   },
   typeAbbr: {
-    fontSize: 13,
+    fontSize: 12,
     fontWeight: '700',
-    color: '#818cf8',
+    letterSpacing: 0.5,
   },
   cardBody: {
     flex: 1,

--- a/apps/mobile/src/screens/HistoryScreen.tsx
+++ b/apps/mobile/src/screens/HistoryScreen.tsx
@@ -13,7 +13,8 @@ import type { BottomTabScreenProps } from '@react-navigation/bottom-tabs'
 import type { StackNavigationProp, StackScreenProps } from '@react-navigation/stack'
 import type { HistoryStackParamList, MainTabParamList, RootStackParamList } from '../../App'
 import { api, type ResultHistoryItem } from '../lib/api'
-import { formatResultValue, monthKey, shortDate, workoutTypeAbbr } from '../lib/format'
+import { formatResultValue, monthKey, shortDate } from '../lib/format'
+import { styleFor } from '../lib/workoutTypeStyles'
 
 type Props = CompositeScreenProps<
   StackScreenProps<HistoryStackParamList, 'History'>,
@@ -47,11 +48,12 @@ function groupByMonth(results: ResultHistoryItem[]): MonthBlock[] {
 }
 
 function ResultRow({ item, onPress }: { item: ResultHistoryItem; onPress: () => void }) {
+  const ts = styleFor(item.workout.type)
   return (
     <TouchableOpacity style={styles.row} onPress={onPress} activeOpacity={0.7}>
       <View style={styles.rowLeft}>
-        <View style={styles.typeBadge}>
-          <Text style={styles.typeAbbr}>{workoutTypeAbbr(item.workout.type)}</Text>
+        <View style={[styles.typeBadge, { backgroundColor: ts.bgTint }]}>
+          <Text style={[styles.typeAbbr, { color: ts.tint }]}>{ts.abbr}</Text>
         </View>
         <View style={styles.rowBody}>
           <Text style={styles.rowTitle} numberOfLines={1}>{item.workout.title}</Text>
@@ -212,15 +214,15 @@ const styles = StyleSheet.create({
   },
   rowLeft: { flexDirection: 'row', alignItems: 'center', flex: 1 },
   typeBadge: {
-    width: 32,
+    minWidth: 38,
+    paddingHorizontal: 6,
     height: 32,
     borderRadius: 8,
-    backgroundColor: '#1e1b4b',
     alignItems: 'center',
     justifyContent: 'center',
     marginRight: 12,
   },
-  typeAbbr: { fontSize: 13, fontWeight: '700', color: '#818cf8' },
+  typeAbbr: { fontSize: 12, fontWeight: '700', letterSpacing: 0.5 },
   rowBody: { flex: 1 },
   rowTitle: { fontSize: 15, fontWeight: '600', color: '#ffffff', marginBottom: 2 },
   rowMeta: { fontSize: 12, color: '#6b7280' },

--- a/apps/mobile/src/screens/LogResultScreen.tsx
+++ b/apps/mobile/src/screens/LogResultScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   View,
   Text,
@@ -16,8 +16,12 @@ import type { RootStackParamList } from '../../App'
 import {
   api,
   deriveWorkoutGender,
+  type DistanceUnit,
+  type LoadUnit,
   type Workout,
   type WorkoutLevel,
+  type WorkoutMovementWithPrescription,
+  type WorkoutType,
   type ResultValue,
 } from '../lib/api'
 import { useAuth } from '../context/AuthContext'
@@ -31,7 +35,239 @@ const LEVELS: { value: WorkoutLevel; label: string }[] = [
   { value: 'MODIFIED', label: 'Modified' },
 ]
 
-const SUPPORTED_TYPES = new Set(['AMRAP', 'FOR_TIME'])
+const REPS_REGEX = /^\d+(\.\d+)*$/         // "10" or cluster "1.1.1"
+const TEMPO_REGEX = /^[\dxX](\.[\dxX]){3}$/ // "3.1.1.0" or "x.0.x.0"
+
+// ─── Logging mode ───────────────────────────────────────────────────────────
+// Strength workouts log per-movement sets tables. Metcons / MonoStructural
+// log a single workout-level score. Skill / Warmup default to notes-only.
+
+type LoggingMode = 'sets' | 'score' | 'notes-only'
+type ScoreKind = 'ROUNDS_REPS' | 'TIME' | 'DISTANCE' | 'CALORIES'
+
+type WorkoutCategory = 'Strength' | 'Metcon' | 'MonoStructural' | 'Skill Work' | 'Warmup/Recovery'
+
+const TYPE_CATEGORY: Record<WorkoutType, WorkoutCategory> = {
+  STRENGTH: 'Strength', POWER_LIFTING: 'Strength', WEIGHT_LIFTING: 'Strength', BODY_BUILDING: 'Strength', MAX_EFFORT: 'Strength',
+  AMRAP: 'Metcon', FOR_TIME: 'Metcon', EMOM: 'Metcon', METCON: 'Metcon', TABATA: 'Metcon', INTERVALS: 'Metcon', CHIPPER: 'Metcon', LADDER: 'Metcon', DEATH_BY: 'Metcon',
+  CARDIO: 'MonoStructural', RUNNING: 'MonoStructural', ROWING: 'MonoStructural', BIKING: 'MonoStructural', SWIMMING: 'MonoStructural', SKI_ERG: 'MonoStructural', MIXED_MONO: 'MonoStructural',
+  GYMNASTICS: 'Skill Work', WEIGHTLIFTING_TECHNIQUE: 'Skill Work',
+  WARMUP: 'Warmup/Recovery', MOBILITY: 'Warmup/Recovery', COOLDOWN: 'Warmup/Recovery',
+}
+
+function loggingModeFor(workout: Workout): LoggingMode {
+  const category = TYPE_CATEGORY[workout.type]
+  if (category === 'Strength') return 'sets'
+  if (category === 'Metcon') return 'score'
+  if (category === 'MonoStructural') return 'score'
+  if (category === 'Skill Work') {
+    return (workout.workoutMovements?.length ?? 0) > 0 ? 'sets' : 'notes-only'
+  }
+  return 'notes-only'
+}
+
+function scoreKindFor(workout: Workout): ScoreKind {
+  if (workout.type === 'AMRAP') return 'ROUNDS_REPS'
+  if (TYPE_CATEGORY[workout.type] === 'Metcon') return 'TIME'
+  // MonoStructural — distance / cal / time all valid; pick by which
+  // prescription the programmer filled in. Default to TIME.
+  const wm = workout.workoutMovements?.[0]
+  if (wm?.distance !== null && wm?.distance !== undefined) return 'DISTANCE'
+  if (wm?.calories !== null && wm?.calories !== undefined) return 'CALORIES'
+  return 'TIME'
+}
+
+// ─── Set-row state ──────────────────────────────────────────────────────────
+// Strings everywhere so partial / empty inputs are first-class. Coerced to
+// numbers at submit time.
+
+interface SetRow {
+  reps: string
+  load: string
+  tempo: string
+  distance: string
+  calories: string
+  seconds: string
+}
+
+interface MovementSection {
+  workoutMovementId: string
+  movementName: string
+  loadUnit: LoadUnit
+  distanceUnit: DistanceUnit
+  sets: SetRow[]
+}
+
+const EMPTY_SET: SetRow = { reps: '', load: '', tempo: '', distance: '', calories: '', seconds: '' }
+
+function blankSet(): SetRow {
+  return { ...EMPTY_SET }
+}
+
+// Seed `n` blank set rows, optionally pre-filled with the prescription
+// (so the member only edits what differs from the prescription).
+function seedSets(prescribed: WorkoutMovementWithPrescription, count: number): SetRow[] {
+  const seed: SetRow = {
+    reps:     prescribed.reps ?? '',
+    load:     prescribed.load !== null ? String(prescribed.load) : '',
+    tempo:    prescribed.tempo ?? '',
+    distance: prescribed.distance !== null ? String(prescribed.distance) : '',
+    calories: prescribed.calories !== null ? String(prescribed.calories) : '',
+    seconds:  prescribed.seconds !== null ? String(prescribed.seconds) : '',
+  }
+  return Array.from({ length: count }, () => ({ ...seed }))
+}
+
+function initialMovementSections(workout: Workout, existing?: ResultValue): MovementSection[] {
+  const ordered = [...(workout.workoutMovements ?? [])].sort((a, b) => a.displayOrder - b.displayOrder)
+  const existingByWmId = new Map<string, { loadUnit?: LoadUnit; distanceUnit?: DistanceUnit; sets?: Partial<SetRow>[] }>()
+  if (existing?.movementResults) {
+    for (const mr of existing.movementResults) {
+      existingByWmId.set(mr.workoutMovementId, {
+        loadUnit: mr.loadUnit as LoadUnit | undefined,
+        distanceUnit: mr.distanceUnit as DistanceUnit | undefined,
+        sets: mr.sets?.map((s) => ({
+          reps:     s.reps !== undefined ? String(s.reps) : '',
+          load:     s.load !== undefined ? String(s.load) : '',
+          tempo:    s.tempo !== undefined ? String(s.tempo) : '',
+          distance: s.distance !== undefined ? String(s.distance) : '',
+          calories: s.calories !== undefined ? String(s.calories) : '',
+          seconds:  s.seconds !== undefined ? String(s.seconds) : '',
+        })),
+      })
+    }
+  }
+  return ordered.map((wm) => {
+    const prior = existingByWmId.get(wm.movement.id)
+    const setCount = prior?.sets?.length ?? wm.sets ?? 1
+    const seeded = seedSets(wm, setCount)
+    const sets = prior?.sets
+      ? prior.sets.map((s, i) => ({ ...seeded[i], ...s } as SetRow))
+      : seeded
+    return {
+      workoutMovementId: wm.movement.id,
+      movementName: wm.movement.name,
+      loadUnit: prior?.loadUnit ?? wm.loadUnit ?? 'LB',
+      distanceUnit: prior?.distanceUnit ?? wm.distanceUnit ?? 'M',
+      sets,
+    }
+  })
+}
+
+// ─── Score field state ──────────────────────────────────────────────────────
+
+interface ScoreFieldState {
+  rounds: string
+  reps: string
+  minutes: string
+  seconds: string
+  cappedOut: boolean
+  distance: string
+  distanceUnit: DistanceUnit
+  calories: string
+}
+
+function initialScoreFields(workout: Workout, existing: ResultValue | undefined): ScoreFieldState {
+  const score = existing?.score
+  const totalSec = score?.kind === 'TIME' ? score.seconds ?? 0 : 0
+  const distUnit = score?.kind === 'DISTANCE' ? (score.unit as DistanceUnit | undefined) : undefined
+  return {
+    rounds:    score?.kind === 'ROUNDS_REPS' && score.rounds != null ? String(score.rounds) : '',
+    reps:      score?.kind === 'ROUNDS_REPS' && score.reps != null ? String(score.reps) : '',
+    minutes:   score?.kind === 'TIME' ? String(Math.floor(totalSec / 60)) : '',
+    seconds:   score?.kind === 'TIME' ? String(totalSec % 60) : '',
+    cappedOut: score?.kind === 'TIME' || score?.kind === 'ROUNDS_REPS' ? Boolean(score.cappedOut) : false,
+    distance:  score?.kind === 'DISTANCE' && score.distance != null ? String(score.distance) : '',
+    distanceUnit: distUnit ?? workout.workoutMovements?.[0]?.distanceUnit ?? 'M',
+    calories:  score?.kind === 'CALORIES' && score.calories != null ? String(score.calories) : '',
+  }
+}
+
+// ─── Build helpers ─────────────────────────────────────────────────────────
+
+type BuildResult<T> = { ok: true } & T | { ok: false; error: string }
+
+function buildScore(kind: ScoreKind, f: ScoreFieldState): BuildResult<{ score: Record<string, unknown> }> {
+  if (kind === 'ROUNDS_REPS') {
+    const r = parseInt(f.rounds || '0', 10)
+    const rp = parseInt(f.reps || '0', 10)
+    if (!Number.isInteger(r) || r < 0) return { ok: false, error: 'Rounds must be a non-negative whole number.' }
+    if (!Number.isInteger(rp) || rp < 0) return { ok: false, error: 'Reps must be a non-negative whole number.' }
+    return { ok: true, score: { kind: 'ROUNDS_REPS', rounds: r, reps: rp, cappedOut: false } }
+  }
+  if (kind === 'TIME') {
+    const m = parseInt(f.minutes || '0', 10)
+    const s = parseInt(f.seconds || '0', 10)
+    if (!Number.isInteger(m) || m < 0) return { ok: false, error: 'Minutes must be a non-negative whole number.' }
+    if (!Number.isInteger(s) || s < 0 || s > 59) return { ok: false, error: 'Seconds must be 0–59.' }
+    const total = m * 60 + s
+    if (total <= 0 && !f.cappedOut) return { ok: false, error: 'Enter a time, or mark the result as capped.' }
+    return { ok: true, score: { kind: 'TIME', seconds: total, cappedOut: f.cappedOut } }
+  }
+  if (kind === 'DISTANCE') {
+    const d = parseFloat(f.distance)
+    if (!isFinite(d) || d <= 0) return { ok: false, error: 'Enter a positive distance.' }
+    return { ok: true, score: { kind: 'DISTANCE', distance: d, unit: f.distanceUnit } }
+  }
+  // CALORIES
+  const c = parseInt(f.calories || '0', 10)
+  if (!Number.isInteger(c) || c < 0) return { ok: false, error: 'Calories must be a non-negative whole number.' }
+  return { ok: true, score: { kind: 'CALORIES', calories: c } }
+}
+
+function buildMovementResults(movements: MovementSection[]): BuildResult<{
+  results: { workoutMovementId: string; loadUnit?: LoadUnit; distanceUnit?: DistanceUnit; sets: Record<string, unknown>[] }[]
+}> {
+  const out: { workoutMovementId: string; loadUnit?: LoadUnit; distanceUnit?: DistanceUnit; sets: Record<string, unknown>[] }[] = []
+  for (const m of movements) {
+    const sets: Record<string, unknown>[] = []
+    let hasLoad = false, hasDistance = false
+    for (let i = 0; i < m.sets.length; i++) {
+      const s = m.sets[i]
+      const set: Record<string, unknown> = {}
+      if (s.reps) {
+        if (!REPS_REGEX.test(s.reps)) return { ok: false, error: `${m.movementName} set ${i + 1}: reps must be digits, e.g. "5" or cluster "1.1.1".` }
+        set.reps = s.reps
+      }
+      if (s.load) {
+        const v = parseFloat(s.load)
+        if (!isFinite(v) || v <= 0) return { ok: false, error: `${m.movementName} set ${i + 1}: load must be positive.` }
+        set.load = v; hasLoad = true
+      }
+      if (s.tempo) {
+        if (!TEMPO_REGEX.test(s.tempo)) return { ok: false, error: `${m.movementName} set ${i + 1}: tempo must be four dot-separated values, e.g. "3.1.1.0".` }
+        set.tempo = s.tempo
+      }
+      if (s.distance) {
+        const v = parseFloat(s.distance)
+        if (!isFinite(v) || v <= 0) return { ok: false, error: `${m.movementName} set ${i + 1}: distance must be positive.` }
+        set.distance = v; hasDistance = true
+      }
+      if (s.calories) {
+        const v = parseInt(s.calories, 10)
+        if (!Number.isInteger(v) || v < 0) return { ok: false, error: `${m.movementName} set ${i + 1}: calories must be a non-negative integer.` }
+        set.calories = v
+      }
+      if (s.seconds) {
+        const v = parseInt(s.seconds, 10)
+        if (!Number.isInteger(v) || v < 0) return { ok: false, error: `${m.movementName} set ${i + 1}: seconds must be a non-negative integer.` }
+        set.seconds = v
+      }
+      if (Object.keys(set).length === 0) continue
+      sets.push(set)
+    }
+    if (sets.length === 0) continue
+    out.push({
+      workoutMovementId: m.workoutMovementId,
+      ...(hasLoad ? { loadUnit: m.loadUnit } : {}),
+      ...(hasDistance ? { distanceUnit: m.distanceUnit } : {}),
+      sets,
+    })
+  }
+  return { ok: true, results: out }
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
 
 export default function LogResultScreen({ route, navigation }: Props) {
   const { workoutId, resultId, existingResult } = route.params
@@ -44,13 +280,13 @@ export default function LogResultScreen({ route, navigation }: Props) {
   const [error, setError] = useState<string | null>(null)
   const [alreadyLogged, setAlreadyLogged] = useState(false)
 
-  // Form state — strings so the inputs work cleanly; parsed at submit.
   const [level, setLevel] = useState<WorkoutLevel>(existingResult?.level ?? 'RX')
-  const [rounds, setRounds] = useState(initialAmrap(existingResult?.value).rounds)
-  const [reps, setReps] = useState(initialAmrap(existingResult?.value).reps)
-  const [minutes, setMinutes] = useState(initialForTime(existingResult?.value).minutes)
-  const [seconds, setSeconds] = useState(initialForTime(existingResult?.value).seconds)
-  const [cappedOut, setCappedOut] = useState(initialForTime(existingResult?.value).cappedOut)
+  const [movements, setMovements] = useState<MovementSection[]>([])
+  const [activeMovement, setActiveMovement] = useState(0)
+  const [scoreFields, setScoreFields] = useState<ScoreFieldState>({
+    rounds: '', reps: '', minutes: '', seconds: '', cappedOut: false,
+    distance: '', distanceUnit: 'M', calories: '',
+  })
   const [notes, setNotes] = useState(existingResult?.notes ?? '')
 
   const isEdit = Boolean(resultId && existingResult)
@@ -58,45 +294,53 @@ export default function LogResultScreen({ route, navigation }: Props) {
   useEffect(() => {
     let cancelled = false
     api.workouts.get(workoutId)
-      .then((w) => { if (!cancelled) setWorkout(w) })
+      .then((w) => {
+        if (cancelled) return
+        setWorkout(w)
+        setMovements(initialMovementSections(w, existingResult?.value))
+        setScoreFields(initialScoreFields(w, existingResult?.value))
+      })
       .catch(() => { if (!cancelled) setError('Could not load workout.') })
       .finally(() => { if (!cancelled) setLoadingWorkout(false) })
     return () => { cancelled = true }
+    // existingResult comes from route params and never changes mid-session;
+    // including it here would re-fire the fetch on every state update.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workoutId])
 
-  const isSupported = workout ? SUPPORTED_TYPES.has(workout.type) : false
+  const mode = workout ? loggingModeFor(workout) : 'notes-only'
+  const scoreKind = workout ? scoreKindFor(workout) : 'TIME'
+  const canLogSets = mode === 'sets' && movements.length > 0
 
   function buildValue(): { ok: true; value: ResultValue } | { ok: false; error: string } {
-    if (!workout) return { ok: false, error: 'Workout not loaded.' }
-    if (workout.type === 'AMRAP') {
-      const r = Number(rounds)
-      const p = Number(reps)
-      if (!Number.isInteger(r) || r < 0) return { ok: false, error: 'Rounds must be a non-negative whole number.' }
-      if (!Number.isInteger(p) || p < 0) return { ok: false, error: 'Reps must be a non-negative whole number.' }
-      return {
-        ok: true,
-        value: {
-          score: { kind: 'ROUNDS_REPS', rounds: r, reps: p, cappedOut: false },
-          movementResults: [],
-        },
-      }
+    let movementResults: { workoutMovementId: string; loadUnit?: LoadUnit; distanceUnit?: DistanceUnit; sets: Record<string, unknown>[] }[] = []
+    if (canLogSets) {
+      const built = buildMovementResults(movements)
+      if (!built.ok) return built
+      movementResults = built.results
     }
-    if (workout.type === 'FOR_TIME') {
-      const m = Number(minutes || '0')
-      const s = Number(seconds || '0')
-      if (!Number.isInteger(m) || m < 0) return { ok: false, error: 'Minutes must be a non-negative whole number.' }
-      if (!Number.isInteger(s) || s < 0 || s > 59) return { ok: false, error: 'Seconds must be 0–59.' }
-      const total = m * 60 + s
-      if (total <= 0 && !cappedOut) return { ok: false, error: 'Enter a time, or mark the result as capped.' }
-      return {
-        ok: true,
-        value: {
-          score: { kind: 'TIME', seconds: total, cappedOut },
-          movementResults: [],
-        },
-      }
+    let score: Record<string, unknown> | undefined
+    if (mode === 'score') {
+      const built = buildScore(scoreKind, scoreFields)
+      if (!built.ok) return built
+      score = built.score
     }
-    return { ok: false, error: 'Result logging is not yet supported for this workout type.' }
+    if (mode === 'notes-only') {
+      // Notes-only types need at least *something* to record, but the
+      // schema's refine rejects an empty value. Synthesize a zero-rep score
+      // so the row is queryable.
+      score = { kind: 'REPS', reps: 0 }
+    }
+    if (!score && movementResults.length === 0) {
+      return { ok: false, error: 'Enter a score or at least one set.' }
+    }
+    return {
+      ok: true,
+      value: {
+        ...(score ? { score } : {}),
+        movementResults,
+      } as ResultValue,
+    }
   }
 
   async function handleSubmit() {
@@ -162,6 +406,37 @@ export default function LogResultScreen({ route, navigation }: Props) {
     )
   }
 
+  // ── Set-row helpers ──────────────────────────────────────────────────────
+  function updateSet(mIdx: number, sIdx: number, field: keyof SetRow, value: string) {
+    setMovements((prev) => prev.map((m, i) => {
+      if (i !== mIdx) return m
+      const sets = m.sets.map((s, j) => (j === sIdx ? { ...s, [field]: value } : s))
+      return { ...m, sets }
+    }))
+  }
+
+  function addSet(mIdx: number) {
+    setMovements((prev) => prev.map((m, i) => {
+      if (i !== mIdx) return m
+      const last = m.sets[m.sets.length - 1] ?? blankSet()
+      // Carry over reps/load/tempo from the last row — most members repeat
+      // them set to set, and clearing the cell is faster than retyping.
+      return { ...m, sets: [...m.sets, { ...last }] }
+    }))
+  }
+
+  function removeSet(mIdx: number, sIdx: number) {
+    setMovements((prev) => prev.map((m, i) => {
+      if (i !== mIdx) return m
+      if (m.sets.length <= 1) return m
+      return { ...m, sets: m.sets.filter((_, j) => j !== sIdx) }
+    }))
+  }
+
+  function setMovementUnit(mIdx: number, field: 'loadUnit' | 'distanceUnit', value: LoadUnit | DistanceUnit) {
+    setMovements((prev) => prev.map((m, i) => (i === mIdx ? { ...m, [field]: value } : m)))
+  }
+
   if (loadingWorkout) {
     return (
       <View style={styles.center}>
@@ -185,15 +460,7 @@ export default function LogResultScreen({ route, navigation }: Props) {
     >
       <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
         <Text style={styles.workoutTitle}>{workout.title}</Text>
-        <Text style={styles.workoutType}>{workout.type.replace('_', ' ')}</Text>
-
-        {!isSupported && (
-          <View style={styles.warningCard}>
-            <Text style={styles.warningText}>
-              Result logging is not yet supported for {workout.type.replace('_', ' ')} workouts.
-            </Text>
-          </View>
-        )}
+        <Text style={styles.workoutType}>{workout.type.replace(/_/g, ' ')}</Text>
 
         {/* Level chips */}
         <Text style={styles.sectionLabel}>LEVEL</Text>
@@ -203,88 +470,68 @@ export default function LogResultScreen({ route, navigation }: Props) {
               key={l.value}
               style={[styles.chip, level === l.value && styles.chipActive]}
               onPress={() => setLevel(l.value)}
-              disabled={!isSupported}
             >
               <Text style={[styles.chipText, level === l.value && styles.chipTextActive]}>{l.label}</Text>
             </TouchableOpacity>
           ))}
         </View>
 
-        {/* Type-conditional inputs */}
-        {workout.type === 'AMRAP' && (
-          <>
-            <Text style={styles.sectionLabel}>SCORE</Text>
-            <View style={styles.inlineInputs}>
-              <View style={styles.inputGroup}>
-                <Text style={styles.inputLabel}>Rounds</Text>
-                <TextInput
-                  style={styles.input}
-                  keyboardType="number-pad"
-                  value={rounds}
-                  onChangeText={setRounds}
-                  placeholder="0"
-                  placeholderTextColor="#6b7280"
-                  testID="rounds-input"
-                />
-              </View>
-              <View style={styles.inputGroup}>
-                <Text style={styles.inputLabel}>Reps</Text>
-                <TextInput
-                  style={styles.input}
-                  keyboardType="number-pad"
-                  value={reps}
-                  onChangeText={setReps}
-                  placeholder="0"
-                  placeholderTextColor="#6b7280"
-                  testID="reps-input"
-                />
-              </View>
-            </View>
-          </>
+        {/* Sets table — Strength + Skill Work with prescription */}
+        {canLogSets && movements[activeMovement] && (
+          <View style={styles.setsSection}>
+            {movements.length > 1 && (
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                style={styles.tabStrip}
+                contentContainerStyle={styles.tabStripContent}
+              >
+                {movements.map((m, i) => (
+                  <TouchableOpacity
+                    key={m.workoutMovementId}
+                    accessibilityRole="tab"
+                    accessibilityState={{ selected: i === activeMovement }}
+                    onPress={() => setActiveMovement(i)}
+                    style={[styles.tabChip, i === activeMovement && styles.tabChipActive]}
+                    testID={`movement-tab-${i}`}
+                  >
+                    <Text style={[styles.tabText, i === activeMovement && styles.tabTextActive]}>
+                      {m.movementName}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </ScrollView>
+            )}
+
+            <SetsTableRN
+              movement={movements[activeMovement]}
+              movementIdx={activeMovement}
+              prescription={
+                workout.workoutMovements.find((wm) => wm.movement.id === movements[activeMovement].workoutMovementId) ?? null
+              }
+              onUpdate={updateSet}
+              onAddSet={addSet}
+              onRemoveSet={removeSet}
+              onUnitChange={setMovementUnit}
+            />
+          </View>
         )}
 
-        {workout.type === 'FOR_TIME' && (
-          <>
-            <Text style={styles.sectionLabel}>TIME</Text>
-            <View style={styles.inlineInputs}>
-              <View style={styles.inputGroup}>
-                <Text style={styles.inputLabel}>Minutes</Text>
-                <TextInput
-                  style={[styles.input, cappedOut && styles.inputDisabled]}
-                  keyboardType="number-pad"
-                  value={minutes}
-                  onChangeText={setMinutes}
-                  placeholder="0"
-                  placeholderTextColor="#6b7280"
-                  editable={!cappedOut}
-                  testID="minutes-input"
-                />
-              </View>
-              <View style={styles.inputGroup}>
-                <Text style={styles.inputLabel}>Seconds</Text>
-                <TextInput
-                  style={[styles.input, cappedOut && styles.inputDisabled]}
-                  keyboardType="number-pad"
-                  value={seconds}
-                  onChangeText={setSeconds}
-                  placeholder="0"
-                  placeholderTextColor="#6b7280"
-                  editable={!cappedOut}
-                  testID="seconds-input"
-                />
-              </View>
-            </View>
-            <TouchableOpacity
-              style={styles.toggle}
-              onPress={() => setCappedOut((c) => !c)}
-              testID="capped-toggle"
-            >
-              <View style={[styles.checkbox, cappedOut && styles.checkboxChecked]}>
-                {cappedOut && <Text style={styles.checkmark}>✓</Text>}
-              </View>
-              <Text style={styles.toggleLabel}>Time capped (didn't finish)</Text>
-            </TouchableOpacity>
-          </>
+        {/* Workout-level score (Metcon + MonoStructural) */}
+        {mode === 'score' && (
+          <ScoreFieldsRN
+            workout={workout}
+            kind={scoreKind}
+            fields={scoreFields}
+            onChange={setScoreFields}
+          />
+        )}
+
+        {/* Notes-only fallback */}
+        {mode === 'notes-only' && (
+          <Text style={styles.helpText}>
+            This workout type doesn't have a structured score. Add notes below to record what you did.
+          </Text>
         )}
 
         {/* Notes */}
@@ -297,19 +544,20 @@ export default function LogResultScreen({ route, navigation }: Props) {
           onChangeText={setNotes}
           placeholder="Optional"
           placeholderTextColor="#6b7280"
+          testID="notes-input"
         />
 
         {/* Errors */}
         {alreadyLogged && (
           <Text style={styles.error}>You've already logged this workout.</Text>
         )}
-        {error && <Text style={styles.error}>{error}</Text>}
+        {error && !alreadyLogged && <Text style={styles.error}>{error}</Text>}
 
         {/* Submit */}
         <TouchableOpacity
-          style={[styles.submitBtn, (!isSupported || submitting || alreadyLogged) && styles.submitBtnDisabled]}
+          style={[styles.submitBtn, (submitting || alreadyLogged) && styles.submitBtnDisabled]}
           onPress={handleSubmit}
-          disabled={!isSupported || submitting || alreadyLogged}
+          disabled={submitting || alreadyLogged}
         >
           {submitting
             ? <ActivityIndicator color="#fff" />
@@ -332,22 +580,336 @@ export default function LogResultScreen({ route, navigation }: Props) {
   )
 }
 
-function initialAmrap(v: ResultValue | undefined) {
-  if (v?.score?.kind === 'ROUNDS_REPS') {
-    return { rounds: String(v.score.rounds ?? ''), reps: String(v.score.reps) }
-  }
-  return { rounds: '', reps: '' }
+// ─── SetsTableRN ─────────────────────────────────────────────────────────────
+
+const ALL_COLUMNS: { key: keyof SetRow; label: string; placeholder: string; numeric: boolean }[] = [
+  { key: 'reps',     label: 'Reps',     placeholder: '5 or 1.1.1', numeric: false },
+  { key: 'load',     label: 'Load',     placeholder: '225',         numeric: true  },
+  { key: 'tempo',    label: 'Tempo',    placeholder: '3.1.1.0',     numeric: false },
+  { key: 'distance', label: 'Distance', placeholder: '500',         numeric: true  },
+  { key: 'calories', label: 'Cals',     placeholder: '20',          numeric: true  },
+  { key: 'seconds',  label: 'Seconds',  placeholder: '60',          numeric: true  },
+]
+
+const LOAD_UNITS: { value: LoadUnit; label: string }[] = [
+  { value: 'LB', label: 'lb' },
+  { value: 'KG', label: 'kg' },
+]
+
+const DISTANCE_UNITS: { value: DistanceUnit; label: string }[] = [
+  { value: 'M',  label: 'm'  },
+  { value: 'KM', label: 'km' },
+  { value: 'MI', label: 'mi' },
+  { value: 'FT', label: 'ft' },
+  { value: 'YD', label: 'yd' },
+]
+
+function SetsTableRN({
+  movement,
+  movementIdx,
+  prescription,
+  onUpdate,
+  onAddSet,
+  onRemoveSet,
+  onUnitChange,
+}: {
+  movement: MovementSection
+  movementIdx: number
+  prescription: WorkoutMovementWithPrescription | null
+  onUpdate: (mIdx: number, sIdx: number, field: keyof SetRow, value: string) => void
+  onAddSet: (mIdx: number) => void
+  onRemoveSet: (mIdx: number, sIdx: number) => void
+  onUnitChange: (mIdx: number, field: 'loadUnit' | 'distanceUnit', value: LoadUnit | DistanceUnit) => void
+}) {
+  // The columns to surface come from whichever fields the programmer
+  // prescribed — anything they didn't prescribe is hidden by default.
+  // Members can show extras via the "+ Column" buttons below the table.
+  const prescribed = useMemo(() => {
+    if (!prescription) return new Set<keyof SetRow>(['reps', 'load'])
+    const cols = new Set<keyof SetRow>()
+    if (prescription.reps !== null)     cols.add('reps')
+    if (prescription.load !== null)     cols.add('load')
+    if (prescription.tempo !== null)    cols.add('tempo')
+    if (prescription.distance !== null) cols.add('distance')
+    if (prescription.calories !== null) cols.add('calories')
+    if (prescription.seconds !== null)  cols.add('seconds')
+    if (cols.size === 0) cols.add('reps').add('load')
+    return cols
+  }, [prescription])
+
+  // Auto-show a column if the user has typed into any cell of it.
+  const visible = useMemo(() => {
+    const cols = new Set(prescribed)
+    for (const s of movement.sets) {
+      ;(['reps', 'load', 'tempo', 'distance', 'calories', 'seconds'] as const).forEach((c) => {
+        if (s[c] !== '') cols.add(c)
+      })
+    }
+    return cols
+  }, [prescribed, movement.sets])
+
+  const showColumns = ALL_COLUMNS.filter((c) => visible.has(c.key))
+  const hiddenColumns = ALL_COLUMNS.filter((c) => !visible.has(c.key))
+
+  return (
+    <View>
+      {/* Unit pickers — only render when load or distance is in play */}
+      {(visible.has('load') || visible.has('distance')) && (
+        <View style={styles.unitRow}>
+          {visible.has('load') && (
+            <View style={styles.unitGroup}>
+              <Text style={styles.unitLabel}>Load:</Text>
+              <View style={styles.unitChips}>
+                {LOAD_UNITS.map((u) => (
+                  <TouchableOpacity
+                    key={u.value}
+                    style={[styles.unitChip, movement.loadUnit === u.value && styles.unitChipActive]}
+                    onPress={() => onUnitChange(movementIdx, 'loadUnit', u.value)}
+                    accessibilityLabel={`Load unit ${u.label}`}
+                    testID={`load-unit-${u.value}`}
+                  >
+                    <Text style={[styles.unitChipText, movement.loadUnit === u.value && styles.unitChipTextActive]}>{u.label}</Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </View>
+          )}
+          {visible.has('distance') && (
+            <View style={styles.unitGroup}>
+              <Text style={styles.unitLabel}>Distance:</Text>
+              <View style={styles.unitChips}>
+                {DISTANCE_UNITS.map((u) => (
+                  <TouchableOpacity
+                    key={u.value}
+                    style={[styles.unitChip, movement.distanceUnit === u.value && styles.unitChipActive]}
+                    onPress={() => onUnitChange(movementIdx, 'distanceUnit', u.value)}
+                    accessibilityLabel={`Distance unit ${u.label}`}
+                    testID={`distance-unit-${u.value}`}
+                  >
+                    <Text style={[styles.unitChipText, movement.distanceUnit === u.value && styles.unitChipTextActive]}>{u.label}</Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </View>
+          )}
+        </View>
+      )}
+
+      {/* Header row */}
+      <View style={styles.tableHeaderRow}>
+        <Text style={[styles.tableHeaderCell, styles.tableSetCol]}>Set</Text>
+        {showColumns.map((c) => (
+          <Text key={c.key} style={styles.tableHeaderCell}>{c.label}</Text>
+        ))}
+        <View style={styles.tableRemoveCol} />
+      </View>
+
+      {/* Body rows */}
+      {movement.sets.map((s, sIdx) => (
+        <View key={sIdx} style={styles.tableRow}>
+          <Text style={[styles.tableSetIdx, styles.tableSetCol]}>{sIdx + 1}</Text>
+          {showColumns.map((c) => (
+            <View key={c.key} style={styles.tableCell}>
+              <TextInput
+                style={styles.tableInput}
+                value={s[c.key]}
+                onChangeText={(v) => onUpdate(movementIdx, sIdx, c.key, v)}
+                placeholder={c.placeholder}
+                placeholderTextColor="#4b5563"
+                keyboardType={c.numeric ? 'decimal-pad' : 'default'}
+                accessibilityLabel={`Set ${sIdx + 1} ${c.label}`}
+                testID={`set-${sIdx}-${c.key}`}
+              />
+            </View>
+          ))}
+          <View style={styles.tableRemoveCol}>
+            {movement.sets.length > 1 && (
+              <TouchableOpacity
+                onPress={() => onRemoveSet(movementIdx, sIdx)}
+                accessibilityLabel={`Remove set ${sIdx + 1}`}
+                testID={`remove-set-${sIdx}`}
+                style={styles.removeBtn}
+              >
+                <Text style={styles.removeBtnText}>×</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        </View>
+      ))}
+
+      {/* Action buttons */}
+      <View style={styles.tableActions}>
+        <TouchableOpacity
+          style={styles.addSetBtn}
+          onPress={() => onAddSet(movementIdx)}
+          accessibilityLabel="Add set"
+          testID="add-set"
+        >
+          <Text style={styles.addSetBtnText}>+ Add set</Text>
+        </TouchableOpacity>
+        {hiddenColumns.map((c) => (
+          <TouchableOpacity
+            key={c.key}
+            style={styles.addColBtn}
+            onPress={() => onUpdate(movementIdx, 0, c.key, c.placeholder.split(' ')[0])}
+            accessibilityLabel={`Add ${c.label} column`}
+            testID={`add-col-${c.key}`}
+          >
+            <Text style={styles.addColBtnText}>+ {c.label}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </View>
+  )
 }
 
-function initialForTime(v: ResultValue | undefined): { minutes: string; seconds: string; cappedOut: boolean } {
-  if (v?.score?.kind === 'TIME') {
-    return {
-      minutes: String(Math.floor(v.score.seconds / 60)),
-      seconds: String(v.score.seconds % 60),
-      cappedOut: v.score.cappedOut ?? false,
-    }
+// ─── ScoreFieldsRN ───────────────────────────────────────────────────────────
+
+function ScoreFieldsRN({
+  workout: _workout,
+  kind,
+  fields,
+  onChange,
+}: {
+  workout: Workout
+  kind: ScoreKind
+  fields: ScoreFieldState
+  onChange: (next: ScoreFieldState) => void
+}) {
+  const update = <K extends keyof ScoreFieldState>(field: K, value: ScoreFieldState[K]) =>
+    onChange({ ...fields, [field]: value })
+
+  if (kind === 'ROUNDS_REPS') {
+    return (
+      <View>
+        <Text style={styles.sectionLabel}>SCORE</Text>
+        <View style={styles.inlineInputs}>
+          {_workout.tracksRounds && (
+            <View style={styles.inputGroup}>
+              <Text style={styles.inputLabel}>Rounds</Text>
+              <TextInput
+                style={styles.input}
+                keyboardType="number-pad"
+                value={fields.rounds}
+                onChangeText={(v) => update('rounds', v)}
+                placeholder="0"
+                placeholderTextColor="#6b7280"
+                testID="rounds-input"
+              />
+            </View>
+          )}
+          <View style={styles.inputGroup}>
+            <Text style={styles.inputLabel}>Reps</Text>
+            <TextInput
+              style={styles.input}
+              keyboardType="number-pad"
+              value={fields.reps}
+              onChangeText={(v) => update('reps', v)}
+              placeholder="0"
+              placeholderTextColor="#6b7280"
+              testID="reps-input"
+            />
+          </View>
+        </View>
+      </View>
+    )
   }
-  return { minutes: '', seconds: '', cappedOut: false }
+  if (kind === 'TIME') {
+    return (
+      <View>
+        <Text style={styles.sectionLabel}>TIME</Text>
+        <View style={styles.inlineInputs}>
+          <View style={styles.inputGroup}>
+            <Text style={styles.inputLabel}>Minutes</Text>
+            <TextInput
+              style={[styles.input, fields.cappedOut && styles.inputDisabled]}
+              keyboardType="number-pad"
+              value={fields.minutes}
+              onChangeText={(v) => update('minutes', v)}
+              placeholder="0"
+              placeholderTextColor="#6b7280"
+              editable={!fields.cappedOut}
+              testID="minutes-input"
+            />
+          </View>
+          <View style={styles.inputGroup}>
+            <Text style={styles.inputLabel}>Seconds</Text>
+            <TextInput
+              style={[styles.input, fields.cappedOut && styles.inputDisabled]}
+              keyboardType="number-pad"
+              value={fields.seconds}
+              onChangeText={(v) => update('seconds', v)}
+              placeholder="0"
+              placeholderTextColor="#6b7280"
+              editable={!fields.cappedOut}
+              testID="seconds-input"
+            />
+          </View>
+        </View>
+        <TouchableOpacity
+          style={styles.toggle}
+          onPress={() => update('cappedOut', !fields.cappedOut)}
+          testID="capped-toggle"
+        >
+          <View style={[styles.checkbox, fields.cappedOut && styles.checkboxChecked]}>
+            {fields.cappedOut && <Text style={styles.checkmark}>✓</Text>}
+          </View>
+          <Text style={styles.toggleLabel}>Time capped (didn't finish)</Text>
+        </TouchableOpacity>
+      </View>
+    )
+  }
+  if (kind === 'DISTANCE') {
+    return (
+      <View>
+        <Text style={styles.sectionLabel}>DISTANCE</Text>
+        <View style={styles.inlineInputs}>
+          <View style={[styles.inputGroup, { flex: 2 }]}>
+            <Text style={styles.inputLabel}>Distance</Text>
+            <TextInput
+              style={styles.input}
+              keyboardType="decimal-pad"
+              value={fields.distance}
+              onChangeText={(v) => update('distance', v)}
+              placeholder="0"
+              placeholderTextColor="#6b7280"
+              testID="distance-input"
+            />
+          </View>
+          <View style={styles.inputGroup}>
+            <Text style={styles.inputLabel}>Unit</Text>
+            <View style={styles.unitChipsCol}>
+              {DISTANCE_UNITS.map((u) => (
+                <TouchableOpacity
+                  key={u.value}
+                  style={[styles.unitChip, fields.distanceUnit === u.value && styles.unitChipActive]}
+                  onPress={() => update('distanceUnit', u.value)}
+                  testID={`score-distance-unit-${u.value}`}
+                >
+                  <Text style={[styles.unitChipText, fields.distanceUnit === u.value && styles.unitChipTextActive]}>{u.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+        </View>
+      </View>
+    )
+  }
+  // CALORIES
+  return (
+    <View>
+      <Text style={styles.sectionLabel}>CALORIES</Text>
+      <TextInput
+        style={styles.input}
+        keyboardType="number-pad"
+        value={fields.calories}
+        onChangeText={(v) => update('calories', v)}
+        placeholder="0"
+        placeholderTextColor="#6b7280"
+        testID="calories-input"
+      />
+    </View>
+  )
 }
 
 const styles = StyleSheet.create({
@@ -361,15 +923,6 @@ const styles = StyleSheet.create({
   },
   workoutTitle: { fontSize: 22, fontWeight: '700', color: '#ffffff', marginBottom: 4 },
   workoutType: { fontSize: 13, color: '#6b7280', marginBottom: 20 },
-  warningCard: {
-    backgroundColor: '#1f1500',
-    borderColor: '#a16207',
-    borderWidth: 1,
-    borderRadius: 8,
-    padding: 12,
-    marginBottom: 16,
-  },
-  warningText: { color: '#fbbf24', fontSize: 13, lineHeight: 18 },
   sectionLabel: {
     fontSize: 11,
     fontWeight: '700',
@@ -377,6 +930,12 @@ const styles = StyleSheet.create({
     letterSpacing: 0.8,
     marginTop: 16,
     marginBottom: 8,
+  },
+  helpText: {
+    color: '#9ca3af',
+    fontSize: 13,
+    lineHeight: 18,
+    marginTop: 16,
   },
   chipRow: { flexDirection: 'row', gap: 8, flexWrap: 'wrap' },
   chip: {
@@ -430,4 +989,98 @@ const styles = StyleSheet.create({
   submitBtnText: { color: '#ffffff', fontSize: 15, fontWeight: '600' },
   deleteBtn: { paddingVertical: 14, alignItems: 'center', marginTop: 8 },
   deleteBtnText: { color: '#f87171', fontSize: 14, fontWeight: '500' },
+
+  // Sets table
+  setsSection: { marginTop: 16 },
+  tabStrip: { marginBottom: 12 },
+  tabStripContent: { gap: 6, paddingRight: 4 },
+  tabChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: '#111827',
+    borderRadius: 8,
+  },
+  tabChipActive: { backgroundColor: '#374151' },
+  tabText: { color: '#9ca3af', fontSize: 13, fontWeight: '500' },
+  tabTextActive: { color: '#ffffff', fontWeight: '600' },
+
+  unitRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 12, marginBottom: 8 },
+  unitGroup: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  unitLabel: { color: '#9ca3af', fontSize: 12 },
+  unitChips: { flexDirection: 'row', gap: 4 },
+  unitChipsCol: { flexDirection: 'row', flexWrap: 'wrap', gap: 4 },
+  unitChip: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    backgroundColor: '#111827',
+    borderWidth: 1,
+    borderColor: '#374151',
+    borderRadius: 6,
+  },
+  unitChipActive: { backgroundColor: '#1e1b4b', borderColor: '#6366f1' },
+  unitChipText: { color: '#9ca3af', fontSize: 12, fontWeight: '500' },
+  unitChipTextActive: { color: '#818cf8', fontWeight: '600' },
+
+  tableHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 6,
+    borderBottomWidth: 1,
+    borderBottomColor: '#1f2937',
+  },
+  tableHeaderCell: {
+    flex: 1,
+    color: '#9ca3af',
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    paddingHorizontal: 4,
+  },
+  tableSetCol: { flex: 0, width: 28 },
+  tableRemoveCol: { width: 32, alignItems: 'flex-end' },
+  tableRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  tableSetIdx: { color: '#6b7280', fontSize: 12, paddingRight: 4 },
+  tableCell: { flex: 1, paddingHorizontal: 2 },
+  tableInput: {
+    backgroundColor: '#111827',
+    borderWidth: 1,
+    borderColor: '#374151',
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+    fontSize: 14,
+    color: '#ffffff',
+  },
+  removeBtn: {
+    width: 28,
+    height: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  removeBtnText: { color: '#6b7280', fontSize: 18, fontWeight: '600' },
+  tableActions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 12,
+  },
+  addSetBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: '#1f2937',
+    borderRadius: 8,
+  },
+  addSetBtnText: { color: '#e5e7eb', fontSize: 12, fontWeight: '600' },
+  addColBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: '#111827',
+    borderRadius: 8,
+  },
+  addColBtnText: { color: '#9ca3af', fontSize: 12, fontWeight: '500' },
 })

--- a/apps/mobile/src/screens/LogResultScreen.tsx
+++ b/apps/mobile/src/screens/LogResultScreen.tsx
@@ -506,6 +506,7 @@ export default function LogResultScreen({ route, navigation }: Props) {
             <SetsTableRN
               movement={movements[activeMovement]}
               movementIdx={activeMovement}
+              category={TYPE_CATEGORY[workout.type]}
               prescription={
                 workout.workoutMovements.find((wm) => wm.movement.id === movements[activeMovement].workoutMovementId) ?? null
               }
@@ -607,6 +608,7 @@ const DISTANCE_UNITS: { value: DistanceUnit; label: string }[] = [
 function SetsTableRN({
   movement,
   movementIdx,
+  category,
   prescription,
   onUpdate,
   onAddSet,
@@ -615,6 +617,7 @@ function SetsTableRN({
 }: {
   movement: MovementSection
   movementIdx: number
+  category: WorkoutCategory
   prescription: WorkoutMovementWithPrescription | null
   onUpdate: (mIdx: number, sIdx: number, field: keyof SetRow, value: string) => void
   onAddSet: (mIdx: number) => void
@@ -624,20 +627,36 @@ function SetsTableRN({
   // The columns to surface come from whichever fields the programmer
   // prescribed — anything they didn't prescribe is hidden by default.
   // Members can show extras via the "+ Column" buttons below the table.
+  // Strength is special: load is intentionally not prescribed (programmers
+  // leave the actual weight to the member, who knows their training history),
+  // but the load column still auto-shows on the result side because that's
+  // the headline number the member came to record.
   const prescribed = useMemo(() => {
-    if (!prescription) return new Set<keyof SetRow>(['reps', 'load'])
     const cols = new Set<keyof SetRow>()
-    if (prescription.reps !== null)     cols.add('reps')
-    if (prescription.load !== null)     cols.add('load')
-    if (prescription.tempo !== null)    cols.add('tempo')
-    if (prescription.distance !== null) cols.add('distance')
-    if (prescription.calories !== null) cols.add('calories')
-    if (prescription.seconds !== null)  cols.add('seconds')
-    if (cols.size === 0) cols.add('reps').add('load')
+    if (prescription) {
+      if (prescription.reps !== null)     cols.add('reps')
+      if (prescription.load !== null)     cols.add('load')
+      if (prescription.tempo !== null)    cols.add('tempo')
+      if (prescription.distance !== null) cols.add('distance')
+      if (prescription.calories !== null) cols.add('calories')
+      if (prescription.seconds !== null)  cols.add('seconds')
+    }
+    if (category === 'Strength') { cols.add('reps'); cols.add('load') }
+    if (cols.size === 0) { cols.add('reps'); cols.add('load') }
     return cols
-  }, [prescription])
+  }, [prescription, category])
 
   // Auto-show a column if the user has typed into any cell of it.
+  // Columns reachable for this workout's category. Strength is barbell
+  // work — distance / cals / seconds aren't relevant. MonoStructural is
+  // timed cardio — sets / reps / load aren't. Metcon / Skill / Warmup keep
+  // every axis since their movement mix varies.
+  const availableColumns = useMemo<Set<keyof SetRow>>(() => {
+    if (category === 'Strength') return new Set(['reps', 'load', 'tempo'])
+    if (category === 'MonoStructural') return new Set(['distance', 'calories', 'seconds'])
+    return new Set(['reps', 'load', 'tempo', 'distance', 'calories', 'seconds'])
+  }, [category])
+
   const visible = useMemo(() => {
     const cols = new Set(prescribed)
     for (const s of movement.sets) {
@@ -645,11 +664,11 @@ function SetsTableRN({
         if (s[c] !== '') cols.add(c)
       })
     }
-    return cols
-  }, [prescribed, movement.sets])
+    return new Set([...cols].filter((c) => availableColumns.has(c)))
+  }, [prescribed, movement.sets, availableColumns])
 
   const showColumns = ALL_COLUMNS.filter((c) => visible.has(c.key))
-  const hiddenColumns = ALL_COLUMNS.filter((c) => !visible.has(c.key))
+  const hiddenColumns = ALL_COLUMNS.filter((c) => !visible.has(c.key) && availableColumns.has(c.key))
 
   return (
     <View>

--- a/apps/mobile/src/screens/LogResultScreen.tsx
+++ b/apps/mobile/src/screens/LogResultScreen.tsx
@@ -627,10 +627,13 @@ function SetsTableRN({
   // The columns to surface come from whichever fields the programmer
   // prescribed — anything they didn't prescribe is hidden by default.
   // Members can show extras via the "+ Column" buttons below the table.
-  // Strength is special: load is intentionally not prescribed (programmers
-  // leave the actual weight to the member, who knows their training history),
-  // but the load column still auto-shows on the result side because that's
-  // the headline number the member came to record.
+  // Load is special: programmers usually don't prescribe an exact weight
+  // (they leave that to the member's training history), so we surface a Load
+  // column whenever the prescription's `tracksLoad` flag is true. The flag
+  // defaults to true on the API side, so missing-prescription fallbacks also
+  // get a Load column. Programmers flip it off for plyometric / no-load
+  // movements where the column would just be noise.
+  const tracksLoad = prescription ? prescription.tracksLoad : true
   const prescribed = useMemo(() => {
     const cols = new Set<keyof SetRow>()
     if (prescription) {
@@ -641,21 +644,30 @@ function SetsTableRN({
       if (prescription.calories !== null) cols.add('calories')
       if (prescription.seconds !== null)  cols.add('seconds')
     }
-    if (category === 'Strength') { cols.add('reps'); cols.add('load') }
-    if (cols.size === 0) { cols.add('reps'); cols.add('load') }
+    if (tracksLoad) cols.add('load')
+    // Strength still defaults to showing reps as a useful baseline.
+    if (category === 'Strength') cols.add('reps')
+    if (cols.size === 0) { cols.add('reps') }
     return cols
-  }, [prescription, category])
+  }, [prescription, category, tracksLoad])
 
   // Auto-show a column if the user has typed into any cell of it.
   // Columns reachable for this workout's category. Strength is barbell
-  // work — distance / cals / seconds aren't relevant. MonoStructural is
-  // timed cardio — sets / reps / load aren't. Metcon / Skill / Warmup keep
-  // every axis since their movement mix varies.
+  // work — distance / cals / seconds aren't relevant; load is reachable iff
+  // the prescription opts in. MonoStructural is timed cardio — sets / reps /
+  // load aren't. Metcon / Skill / Warmup keep every axis since their movement
+  // mix varies, but still respect tracksLoad for the Load column.
   const availableColumns = useMemo<Set<keyof SetRow>>(() => {
-    if (category === 'Strength') return new Set(['reps', 'load', 'tempo'])
+    if (category === 'Strength') {
+      const cols = new Set<keyof SetRow>(['reps', 'tempo'])
+      if (tracksLoad) cols.add('load')
+      return cols
+    }
     if (category === 'MonoStructural') return new Set(['distance', 'calories', 'seconds'])
-    return new Set(['reps', 'load', 'tempo', 'distance', 'calories', 'seconds'])
-  }, [category])
+    const cols = new Set<keyof SetRow>(['reps', 'tempo', 'distance', 'calories', 'seconds'])
+    if (tracksLoad) cols.add('load')
+    return cols
+  }, [category, tracksLoad])
 
   const visible = useMemo(() => {
     const cols = new Set(prescribed)

--- a/apps/mobile/src/screens/WodDetailScreen.tsx
+++ b/apps/mobile/src/screens/WodDetailScreen.tsx
@@ -11,6 +11,7 @@ import { useFocusEffect } from '@react-navigation/native'
 import type { StackScreenProps } from '@react-navigation/stack'
 import type { RootStackParamList } from '../../App'
 import { api, type Workout, type LeaderboardEntry, type WorkoutLevel, type WorkoutGender } from '../lib/api'
+import { styleFor } from '../lib/workoutTypeStyles'
 import { useAuth } from '../context/AuthContext'
 import { formatResultValue } from '../lib/format'
 
@@ -114,6 +115,7 @@ export default function WodDetailScreen({ route, navigation }: Props) {
     )
   }
 
+  const typeStyle = styleFor(workout.type)
   const scheduledDate = new Date(workout.scheduledAt).toLocaleDateString('en-US', {
     weekday: 'long', month: 'long', day: 'numeric',
   })
@@ -123,8 +125,8 @@ export default function WodDetailScreen({ route, navigation }: Props) {
       {/* Header */}
       <View style={styles.header}>
         <View style={styles.typeBadgeRow}>
-          <View style={styles.typeBadge}>
-            <Text style={styles.typeText}>{workout.type.replace('_', ' ')}</Text>
+          <View style={[styles.typeBadge, { backgroundColor: typeStyle.bgTint }]}>
+            <Text style={[styles.typeText, { color: typeStyle.tint }]}>{typeStyle.label.toUpperCase()}</Text>
           </View>
           <Text style={styles.dateText}>{scheduledDate}</Text>
         </View>


### PR DESCRIPTION
## Summary

Slice 3 of #3. Mirrors the slice-2 web rewrite for the mobile app: drops the AMRAP/FOR_TIME-only gate on `LogResultScreen`, adds a per-movement sets table for strength workouts, and routes notes-only / score-only categories through their proper UI.

Part of #3.

### What changed

**`apps/mobile/src/lib/api.ts`** — added the prescription types the screen needs:
- `LoadUnit`, `DistanceUnit`, `Movement`, and `WorkoutMovementWithPrescription` (mirrors the web's shape).
- `Workout` now carries `workoutMovements`, `timeCapSeconds`, and `tracksRounds` so the screen can derive its logging mode + score kind.
- Expanded `WorkoutType` to the full union (Strength / Metcon / MonoStructural / Skill Work / Warmup-Recovery) so the new category mapping covers every server-side enum value.

**`apps/mobile/src/lib/format.ts`** — `formatResultValue` now picks the heaviest single set across `movementResults` for strength results: renders as `"{reps} x {load} {unit}"` (e.g. `"6 x 255 lb"`). Ties on load break by `maxRepChunk` of the reps string so cluster reps `1.1.1` rank by `1`, matching `apps/web/src/lib/formatResult.ts`. Falls back to `"N sets logged"` only when no set has a load value.

**`apps/mobile/src/screens/LogResultScreen.tsx`** — full rewrite mirroring the structure of `apps/web/src/components/LogResultDrawer.tsx`:
- `loggingModeFor(workout)` → `'sets' | 'score' | 'notes-only'` based on category.
- `scoreKindFor(workout)` → ROUNDS_REPS for AMRAP, TIME for other Metcons, DISTANCE/CALORIES for MonoStructural based on what the programmer prescribed (default TIME).
- Sets mode: a horizontal movement-tab strip and a per-movement table. Columns surface only for prescription fields the programmer filled in; "+ Reps / Load / Tempo / Distance / Cals / Seconds" buttons reveal hidden columns; "+ Add set" carries values forward; per-row remove button when there's more than one set. Load + Distance unit pickers render as chip strips above the table.
- Score mode: keeps the AMRAP rounds/reps + FOR_TIME min/sec + capped toggle. Adds DISTANCE input + unit picker for MonoStructural workouts when `scoreKindFor` returns DISTANCE, and a CALORIES input when it returns CALORIES.
- Notes-only: shows just the notes field; submit synthesizes `{ score: { kind: 'REPS', reps: 0 }, movementResults: [] }` so the API's refine doesn't reject empty.
- `buildValue()` returns a `{ ok: true; value } | { ok: false; error }` discriminated union.
- Validates cluster reps `/^\d+(\.\d+)*$/` and tempo `/^[\dxX](\.[\dxX]){3}$/` client-side, surfacing field-level errors before the network round-trip.
- Stays on RN primitives + co-located `StyleSheet`, matching `apps/mobile/CLAUDE.md` (no design system yet, no Tailwind).

### Judgment calls
- **Unit pickers as chip strips, not selects.** RN's bare `<select>` doesn't exist; the web uses `<select>` for compactness but on mobile a 2-option (LB/KG) or 5-option (M/KM/MI/FT/YD) picker reads better as small toggle chips. Same data shape, different control.
- **Workout type union expanded in mobile.** The mobile `WorkoutType` was the old 7-value union; the new logging-mode helper keys off the full server enum, so I expanded it. No call sites broke (typecheck clean). The new types only appear in `loggingModeFor` / `scoreKindFor`.
- **`existingResult` from route params.** The screen now fetches the workout (which carries `workoutMovements` + `tracksRounds`) and seeds the sets / score state inside the `then`. This means edit-mode pre-fill happens after the workout fetch, not synchronously from `existingResult`. Tests cover the prefill timing via `findByText` waits.

## Tests

Mobile has Jest unit tests only — no Playwright E2E layer yet (`apps/mobile/CLAUDE.md`). The repo-root `dev:worktree` + `test:worktree` mandate is web-specific (API E2E + Playwright); it does not apply here.

**Unit** (`apps/mobile/__tests__/LogResultScreen.test.tsx`):
- *Strength sets table*
  - `renders one row per prescribed set with prescription values pre-filled` — 5×5 Back Squat shows 5 rows with reps=5, load=225, tempo=3.1.1.0 in every row.
  - `+ Add set appends a row and × removes one` — count goes 2 → 3 → 2.
  - `switches between movement tabs` — Back Squat (2 rows) → RDL (3 rows).
  - `submitting a strength result POSTs movementResults with parsed values` — `value.movementResults[0]` matches `{ workoutMovementId, loadUnit: 'LB', sets: [{ reps: '5', load: 235 }] }`.
  - `cluster reps "1.1.1" pass; bad reps "abc" surface an error and block submit` — first submit blocks with `/reps must be digits/`, second succeeds.
  - `edit mode pre-fills strength sets and PATCHes via api.results.update` — load 245 prefills, edit to 255, `api.results.update('r-1', { value.movementResults[0].sets[0].load: 255 })`.
- *Score-mode workouts*
  - `AMRAP with tracksRounds=false hides the rounds input` — only reps input visible.
  - `AMRAP with tracksRounds=true posts ROUNDS_REPS score` — `{ kind: 'ROUNDS_REPS', rounds: 6, reps: 12, cappedOut: false }`.
  - `FOR_TIME posts TIME score with collapsed seconds` — 8m 45s → 525s.
  - `FOR_TIME capped toggle sets cappedOut=true and uses seconds=0`.
  - `validation: seconds > 59 surfaces error and does not call API`.
  - `409 from API shows "You've already logged this workout"`.
- *Edit + delete*
  - `edit mode prefills AMRAP inputs and PATCHes via api.results.update` — rounds=4 / reps=8 prefill, bump reps to 9, PATCH fires.
  - `delete: confirmation triggers api.results.delete + goBack`.
  - `NON_BINARY identifiedGender derives workoutGender=OPEN`.

**Unit** (`apps/mobile/__tests__/HistoryScreen.test.tsx`) — added two new cases for the strength format:
- `strength results render heaviest set as "{reps} x {load} {unit}"` — three sets (5×225, 6×255, 3×245) → renders `6 x 255 lb`.
- `strength results with no load fall back to set-count summary` — three reps-only gymnastics sets → `3 sets logged`.

**Test counts:**
- Suite total: 8 suites, 61 tests, all green (was 53 before this PR — added 8 mobile tests).
- Run with: `npm test --workspace=@wodalytics/mobile` (uses `jest-expo` preset).
- Typecheck: `cd apps/mobile && npx tsc --noEmit` clean.

**Not automated / manual verification needed:**
- [x] Visual polish on a real device — the table layout was tuned in the simulator; verify column widths don't clip on small phones (iPhone SE / older Androids).
- [ ] Number-pad keyboard behavior on iOS vs Android for the load/distance/cals/seconds inputs (decimal-pad on iOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
