### PR TITLE
docs: parity-first feature design rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ This file covers cross-cutting topics — anything that spans the monorepo or ap
 
 - **Default to a worktree.** Each Claude session should start by creating a `git worktree` off `main` and working there, unless the user explicitly says to stay in the main checkout. See *Default workflow* below.
 - **Open PRs without asking.** When work is shippable, push the branch and run `gh pr create` directly — share the URL for review rather than asking for permission first.
-- **Member-facing feature? Plan web + mobile together.** See *Parity-first feature design* below. Mobile parity is not a follow-up — it's part of scope. Active mobile-parity backlog: #130.
+- **Phone-suitable feature? Plan web + mobile together.** See *Parity-first feature design* below — surface choice follows task ergonomics (quick on-the-go vs heavy desk authoring), not user role. Mobile parity is not a follow-up; it's part of scope. Active mobile-parity backlog: #130.
 - **Working in a worktree?** Read *Worktree development* below — `npm run dev:worktree` is collision-resistant but the workflow has details worth knowing.
 - **Touching the schema?** Read *Schema migrations* below — every schema PR must commit its migration file.
 - **Opening a PR?** Read *Pull requests* below — the Tests section format is required.
@@ -36,22 +36,26 @@ These two defaults exist because the user runs N parallel Claude sessions and th
 
 ## Parity-first feature design
 
-Web has historically run ahead of mobile, leaving the member-side phone experience perpetually behind. The fix is process: every member-facing feature gets planned for web *and* mobile from the moment the issue is filed, not as a "we'll catch mobile up later" follow-up. The two surfaces ship as siblings.
+Web has historically run ahead of mobile, leaving the phone experience perpetually behind for every role — members, coaches, owners. The fix is process: every feature gets planned for both surfaces from the moment the issue is filed. The right question is not "who uses this?" but **"in what context will they use it?"** Roles cut across both surfaces — a coach making a last-minute workout fix on the class floor needs mobile too, not just members logging results.
 
-**Audience determines scope:**
+**Surface choice follows task ergonomics, not user role:**
 
-- **Member-facing features** (anything a gym member uses on their phone): web + mobile siblings, both planned up front. Examples: feed, workout detail, log result, history, profile, browse programs, browse gyms, register/onboarding, leaderboard filters, result detail.
-- **Trainer/owner-only features**: web-only is acceptable and expected. Examples: gym settings, member admin, programs CRUD, calendar/programmer view, gym creation. The mobile app is member-only by design (#14, #130).
+- **Phone-suitable tasks** — quick, in-the-moment, often hands-on while moving. Plan web + mobile siblings up front; both must ship to call the feature done. Examples: viewing today's WOD, logging a result, browsing the leaderboard, jotting a coach note on a member, fixing a typo or movement substitution on a workout 5 minutes before class, marking attendance, glancing at a member's recent results, editing your own profile.
+- **Desk-suitable tasks** — heavy authoring, multi-step planning, dense data entry that benefits from a keyboard, mouse, and a larger screen. Web-first or web-only is fine. Examples: programming a full week of WODs from scratch, bulk CSV upload, the full-month calendar view, multi-row gym/member admin, gym branding setup, billing/Stripe configuration (when added), CSV exports.
+
+The rule of thumb: if the task lives in someone's "I need this in the next 30 seconds" workflow, it belongs on mobile too — regardless of role. If it's a "block out an hour to plan" workflow, web-first or web-only is fine.
+
+When in doubt, lean toward "phone-suitable." Being too aggressive about web-only is what produced the current parity drift. Some features have *both* shapes — e.g., editing a single workout's text is phone-suitable; authoring a brand-new workout with 8 movements from scratch is desk-suitable. Split them into separate sub-issues if the ergonomics differ that much.
 
 If you can't decide which bucket a feature is in, ask the user before opening sub-issues.
 
 **When opening a new feature issue / planning work:**
 
-1. **Sub-issues mirror across surfaces.** A member-facing feature should produce: an API sub-issue (if needed), a web sub-issue, and a mobile sub-issue — all linked to the parent. Web and mobile can ship in parallel or staggered, but both must exist as tracked work before the feature is "in flight." Don't file the web issue alone and trust that someone will remember mobile.
-2. **Cross-app contracts go in `apps/web/CLAUDE.md` → *Cross-app contracts*** the moment a new persisted-state shape (localStorage key, query string, request/response field) is introduced on web, so the mobile sibling can mirror it without re-deriving. The Program filter contract is the template.
-3. **Web PR descriptions for member-facing changes must include a "Mobile parity" line** in the Tests section — either pointing at the sibling mobile issue/PR, or stating "trainer/owner-only — N/A on mobile." This makes the parity expectation visible at review time, not at launch.
+1. **Sub-issues mirror across surfaces for phone-suitable tasks.** A phone-suitable feature should produce: an API sub-issue (if needed), a web sub-issue, and a mobile sub-issue — all linked to the parent. Web and mobile can ship in parallel or staggered, but both must exist as tracked work before the feature is "in flight." Don't file the web issue alone and trust that someone will remember mobile.
+2. **Cross-app contracts go in `apps/web/CLAUDE.md` → *Cross-app contracts*** the moment a new persisted-state shape (localStorage key, query string, request/response field) is introduced on web for a phone-suitable feature, so the mobile sibling can mirror it without re-deriving. The Program filter contract is the template.
+3. **Web PR descriptions for phone-suitable changes must include a "Mobile parity" line** in the Tests section — either pointing at the sibling mobile issue/PR, or stating "desk-suitable only — N/A on mobile" with a one-line rationale. This makes the parity expectation visible at review time, not at launch.
 
-**Before starting any new web member-facing work:**
+**Before starting any new web phone-suitable work:**
 
 Scan #130 (the active mobile-parity backlog). If a parity gap there has been open for more than ~2 weeks and you're about to widen it with another web slice, surface it to the user before proceeding — the answer may be to close existing gaps first. Don't silently ship more drift.
 
@@ -217,7 +221,7 @@ Every PR must include a **Tests** section that describes what was tested and how
 - If a behaviour is tested by an existing test suite (not new to this PR), note which file covers it rather than leaving it as an unchecked box.
 - The manual checklist should be short. If it's more than 3–4 items, that is a sign more automation is needed.
 - For PRs touching auth, role gates, or visibility rules: always call out which roles were tested and how.
-- **For web PRs that add a member-facing surface:** include a `**Mobile parity:**` line in the body — either link the sibling mobile issue/PR (`#NNN`), or state "trainer/owner-only — no mobile counterpart." This makes the parity expectation visible at review time, not at launch.
+- **For web PRs that add a phone-suitable surface:** include a `**Mobile parity:**` line in the body — either link the sibling mobile issue/PR (`#NNN`), or state "desk-suitable only — no mobile counterpart" with a one-line rationale (e.g. "month-grid calendar relies on a wide viewport"). This makes the parity expectation visible at review time, not at launch.
 
 ### Schema migrations — required pre-merge checklist item
 
@@ -249,7 +253,7 @@ When breaking a large feature issue into sub-issues for implementation:
 
 - **PR size target:** 250–500 lines of production code per PR. Unit tests may push a PR over this limit — that is acceptable.
 - **Break by domain:** Each sub-issue covers one domain (e.g., backend API, web UI, mobile UI). Do not mix backend and frontend changes in the same PR unless trivially small.
-- **Member-facing features need a mobile sub-issue, period.** When breaking down a member-facing feature, file the mobile sub-issue at the same time as the web sub-issue, even if mobile will land weeks later. See *Parity-first feature design* above. Trainer/owner-only features are exempt.
+- **Phone-suitable features need a mobile sub-issue, period.** When breaking down a feature whose primary use cases are quick / in-the-moment, file the mobile sub-issue at the same time as the web sub-issue, even if mobile will land weeks later. Desk-suitable features (heavy authoring, dense admin) can be web-only. See *Parity-first feature design* above for the boundary.
 - **One PR per sub-issue:** Each sub-issue should map to exactly one pull request.
 - **Declare dependencies explicitly:** Note which sub-issues must land first. Safe parallel starting points should be identified so multiple engineers (or AI slices) can work concurrently.
 - **Reuse before building:** Before proposing new utilities or abstractions, search for existing patterns (DB managers, middleware, Zod schemas, API client methods) that can be extended.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ This file covers cross-cutting topics — anything that spans the monorepo or ap
 
 - **Default to a worktree.** Each Claude session should start by creating a `git worktree` off `main` and working there, unless the user explicitly says to stay in the main checkout. See *Default workflow* below.
 - **Open PRs without asking.** When work is shippable, push the branch and run `gh pr create` directly — share the URL for review rather than asking for permission first.
+- **Member-facing feature? Plan web + mobile together.** See *Parity-first feature design* below. Mobile parity is not a follow-up — it's part of scope. Active mobile-parity backlog: #130.
 - **Working in a worktree?** Read *Worktree development* below — `npm run dev:worktree` is collision-resistant but the workflow has details worth knowing.
 - **Touching the schema?** Read *Schema migrations* below — every schema PR must commit its migration file.
 - **Opening a PR?** Read *Pull requests* below — the Tests section format is required.
@@ -32,6 +33,27 @@ These two defaults exist because the user runs N parallel Claude sessions and th
 
 1. **Start in a worktree.** First action of any non-trivial task: `git worktree add .claude/worktrees/<branch> -b <branch> main` (or `git worktree add /tmp/<descriptive-name> -b <branch> main` if `.claude/worktrees/` isn't suitable). Do *not* work directly in the primary checkout. Reasons: parallel sessions don't step on each other's branches, the dev-stack ports auto-allocate per worktree (see below), and `git worktree remove` is the safe cleanup. Only stay in the primary checkout if the user explicitly says so.
 2. **Open PRs without asking.** Once the branch is in a shippable state (tests pass, scope is complete), push it and call `gh pr create` directly. Share the resulting URL. The user reviews on GitHub, not in chat. This *does not* extend to destructive actions — force-push, branch deletion, merge — those still need explicit confirmation.
+
+## Parity-first feature design
+
+Web has historically run ahead of mobile, leaving the member-side phone experience perpetually behind. The fix is process: every member-facing feature gets planned for web *and* mobile from the moment the issue is filed, not as a "we'll catch mobile up later" follow-up. The two surfaces ship as siblings.
+
+**Audience determines scope:**
+
+- **Member-facing features** (anything a gym member uses on their phone): web + mobile siblings, both planned up front. Examples: feed, workout detail, log result, history, profile, browse programs, browse gyms, register/onboarding, leaderboard filters, result detail.
+- **Trainer/owner-only features**: web-only is acceptable and expected. Examples: gym settings, member admin, programs CRUD, calendar/programmer view, gym creation. The mobile app is member-only by design (#14, #130).
+
+If you can't decide which bucket a feature is in, ask the user before opening sub-issues.
+
+**When opening a new feature issue / planning work:**
+
+1. **Sub-issues mirror across surfaces.** A member-facing feature should produce: an API sub-issue (if needed), a web sub-issue, and a mobile sub-issue — all linked to the parent. Web and mobile can ship in parallel or staggered, but both must exist as tracked work before the feature is "in flight." Don't file the web issue alone and trust that someone will remember mobile.
+2. **Cross-app contracts go in `apps/web/CLAUDE.md` → *Cross-app contracts*** the moment a new persisted-state shape (localStorage key, query string, request/response field) is introduced on web, so the mobile sibling can mirror it without re-deriving. The Program filter contract is the template.
+3. **Web PR descriptions for member-facing changes must include a "Mobile parity" line** in the Tests section — either pointing at the sibling mobile issue/PR, or stating "trainer/owner-only — N/A on mobile." This makes the parity expectation visible at review time, not at launch.
+
+**Before starting any new web member-facing work:**
+
+Scan #130 (the active mobile-parity backlog). If a parity gap there has been open for more than ~2 weeks and you're about to widen it with another web slice, surface it to the user before proceeding — the answer may be to close existing gaps first. Don't silently ship more drift.
 
 ## Tech stack
 
@@ -195,6 +217,7 @@ Every PR must include a **Tests** section that describes what was tested and how
 - If a behaviour is tested by an existing test suite (not new to this PR), note which file covers it rather than leaving it as an unchecked box.
 - The manual checklist should be short. If it's more than 3–4 items, that is a sign more automation is needed.
 - For PRs touching auth, role gates, or visibility rules: always call out which roles were tested and how.
+- **For web PRs that add a member-facing surface:** include a `**Mobile parity:**` line in the body — either link the sibling mobile issue/PR (`#NNN`), or state "trainer/owner-only — no mobile counterpart." This makes the parity expectation visible at review time, not at launch.
 
 ### Schema migrations — required pre-merge checklist item
 
@@ -226,6 +249,7 @@ When breaking a large feature issue into sub-issues for implementation:
 
 - **PR size target:** 250–500 lines of production code per PR. Unit tests may push a PR over this limit — that is acceptable.
 - **Break by domain:** Each sub-issue covers one domain (e.g., backend API, web UI, mobile UI). Do not mix backend and frontend changes in the same PR unless trivially small.
+- **Member-facing features need a mobile sub-issue, period.** When breaking down a member-facing feature, file the mobile sub-issue at the same time as the web sub-issue, even if mobile will land weeks later. See *Parity-first feature design* above. Trainer/owner-only features are exempt.
 - **One PR per sub-issue:** Each sub-issue should map to exactly one pull request.
 - **Declare dependencies explicitly:** Note which sub-issues must land first. Safe parallel starting points should be identified so multiple engineers (or AI slices) can work concurrently.
 - **Reuse before building:** Before proposing new utilities or abstractions, search for existing patterns (DB managers, middleware, Zod schemas, API client methods) that can be extended.

--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -41,9 +41,9 @@ npx jest -t "renders feed rows"
 
 ## Cross-app contracts (web parity)
 
-Mobile must mirror the per-user state shapes the web already uses, so a member can switch between web and mobile without losing context. When adding a new piece of persisted state, check `apps/web/CLAUDE.md` → *Cross-app contracts* first and match the storage key + API shape. The active mobile-parity backlog lives at #130; see the root CLAUDE.md → *Parity-first feature design* for the planning rule that governs how mobile and web stay in sync.
+Mobile must mirror the per-user state shapes the web already uses, so a user can switch between web and mobile without losing context. When adding a new piece of persisted state, check `apps/web/CLAUDE.md` → *Cross-app contracts* first and match the storage key + API shape. The active mobile-parity backlog lives at #130; see the root CLAUDE.md → *Parity-first feature design* for the planning rule that governs how mobile and web stay in sync.
 
-When mobile lacks a screen that web has, that's a parity gap, not a "phase 2" — file it against #130 (or whichever issue is the active mobile-parity tracker) so it stays visible.
+When mobile lacks a screen that web has *and the underlying task is phone-suitable* (quick / on-the-go / often used away from a desk), that's a parity gap — file it against #130 (or whichever issue is the active mobile-parity tracker) so it stays visible. Web-only is appropriate for desk-suitable tasks (heavy authoring, multi-step planning); see the root CLAUDE.md for the boundary.
 
 - **Program filter:** `AsyncStorage["programFilter:<gymId>"]` → JSON `string[]`. Same `?programIds=id1,id2` query shape on `GET /api/gyms/:gymId/workouts` as the web.
 

--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -41,7 +41,9 @@ npx jest -t "renders feed rows"
 
 ## Cross-app contracts (web parity)
 
-Mobile must mirror the per-user state shapes the web already uses, so a member can switch between web and mobile without losing context. When adding a new piece of persisted state, check `apps/web/CLAUDE.md` → *Cross-app contracts* first and match the storage key + API shape.
+Mobile must mirror the per-user state shapes the web already uses, so a member can switch between web and mobile without losing context. When adding a new piece of persisted state, check `apps/web/CLAUDE.md` → *Cross-app contracts* first and match the storage key + API shape. The active mobile-parity backlog lives at #130; see the root CLAUDE.md → *Parity-first feature design* for the planning rule that governs how mobile and web stay in sync.
+
+When mobile lacks a screen that web has, that's a parity gap, not a "phase 2" — file it against #130 (or whichever issue is the active mobile-parity tracker) so it stays visible.
 
 - **Program filter:** `AsyncStorage["programFilter:<gymId>"]` → JSON `string[]`. Same `?programIds=id1,id2` query shape on `GET /api/gyms/:gymId/workouts` as the web.
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -76,9 +76,9 @@ If only the visual is shared but the behavior is trivial (e.g., a one-line style
 
 ### Cross-app contracts (mobile parity)
 
-> **Required, not aspirational.** Every member-facing feature ships on web *and* mobile — see the root CLAUDE.md → *Parity-first feature design*. The contracts below pin the persisted-state shapes that both surfaces must agree on, so mobile can mirror web without re-deriving.
+> **Required, not aspirational.** Every phone-suitable feature ships on web *and* mobile — see the root CLAUDE.md → *Parity-first feature design* (the rule is task-ergonomics-driven, not role-driven; trainers and owners use mobile too). The contracts below pin the persisted-state shapes that both surfaces must agree on, so mobile can mirror web without re-deriving.
 
-When you add a new piece of persisted user state (localStorage / query string / cookie) on web for a member-facing feature, **add an entry here in the same PR**. That's the mechanism by which mobile knows what to mirror — skipping this step is how parity drift starts. Active parity backlog: #130.
+When you add a new piece of persisted user state (localStorage / query string / cookie) on web for a phone-suitable feature, **add an entry here in the same PR**. That's the mechanism by which mobile knows what to mirror — skipping this step is how parity drift starts. Active parity backlog: #130.
 
 - **Program filter** (`src/context/ProgramFilterContext.tsx`)
   - Storage: `localStorage["programFilter:<gymId>"]` → JSON `string[]` of program IDs (empty = "all programs")

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -76,7 +76,9 @@ If only the visual is shared but the behavior is trivial (e.g., a one-line style
 
 ### Cross-app contracts (mobile parity)
 
-Patterns we want the React Native client to mirror. Each entry pins a localStorage key shape + the request/response contract, so the mobile app stores per-user state in a shape the web already understands.
+> **Required, not aspirational.** Every member-facing feature ships on web *and* mobile — see the root CLAUDE.md → *Parity-first feature design*. The contracts below pin the persisted-state shapes that both surfaces must agree on, so mobile can mirror web without re-deriving.
+
+When you add a new piece of persisted user state (localStorage / query string / cookie) on web for a member-facing feature, **add an entry here in the same PR**. That's the mechanism by which mobile knows what to mirror — skipping this step is how parity drift starts. Active parity backlog: #130.
 
 - **Program filter** (`src/context/ProgramFilterContext.tsx`)
   - Storage: `localStorage["programFilter:<gymId>"]` → JSON `string[]` of program IDs (empty = "all programs")


### PR DESCRIPTION
Part of #130. Companion to the [parity audit comment](https://github.com/chuckmag/WODalytics/issues/130#issuecomment-4360389637) on #130.

## Why

Web has historically run ahead of mobile, with mobile catching up months later — when it catches up at all. Today's audit (see #130 comment) shows four web member-facing features shipped in the past few days with no mobile counterpart on file: \`WodResultDetail\`, avatar upload, \`BrowsePrograms\`, \`Register\`. The fix is process: every member-facing feature plans for both surfaces from issue creation, not as a follow-up.

## What this PR changes

Documentation only — encodes the rule across the per-app CLAUDE.md files so it's loaded into context wherever a Claude session is working.

- **Root \`CLAUDE.md\`** gains a *Parity-first feature design* section: audience determines scope, member-facing features get sibling sub-issues for web + mobile up front, trainer/owner-only features are exempt. Adds the rule to *If you only read one section*. Adds a bullet to *Issue sizing and breakdown strategy*. Updates the *Tests section format* rules to require a \`**Mobile parity:**\` line on member-facing web PRs.
- **\`apps/web/CLAUDE.md\`** *Cross-app contracts* is reframed as required documentation, not aspirational. New persisted state for member-facing features must add a contract entry in the same PR — that's the mechanism by which mobile knows what to mirror.
- **\`apps/mobile/CLAUDE.md\`** picks up a pointer to the parity-first rule and frames missing screens as parity gaps to file against #130, not phase-2 deferrals.

## Operational ask (separate from this PR)

The audit on #130 lists four new gaps that have appeared since the issue was filed. The biggest member-facing impact is **WodResultDetail** (#167 just shipped on web; mobile can't view per-movement V2 result breakdowns) and **avatar upload** (slice C of #120). Recommend these go on the mobile backlog before more web member-facing surface lands. I haven't edited #130's body — flagging here so you can decide whether to add a *Slices 7+* section there or split into a sister issue.

## Tests

Documentation only — no code, no tests. Verified the rendered markdown reads correctly across the three CLAUDE.md files.

**Mobile parity:** N/A — this PR is documentation that *governs* mobile parity for future work; it doesn't add any user-facing surface itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)