### PR TITLE
feat(web): per-movement prescription editor in WorkoutDrawer (slice 2B of #3)

### DIFF
--- a/apps/web/src/components/LogResultDrawer.test.tsx
+++ b/apps/web/src/components/LogResultDrawer.test.tsx
@@ -81,6 +81,31 @@ describe('LogResultDrawer — strength sets table', () => {
     expect((screen.getByLabelText(/Set 5 Tempo/i) as HTMLInputElement).value).toBe('3.1.1.0')
   })
 
+  test('Strength workout without prescribed load still surfaces a Load column on the result form', () => {
+    // Programmers don't prescribe load on strength workouts (slice 2B), but
+    // Load is the headline number a member came to record.
+    const w = makeWorkout({
+      type: 'POWER_LIFTING',
+      workoutMovements: [makeMovement('m-1', 'Back Squat', { sets: 3, reps: '3' })],
+    })
+    render(<LogResultDrawer workout={w} onClose={() => {}} onSaved={() => {}} />)
+    expect(screen.getAllByLabelText(/Set \d Reps/i)).toHaveLength(3)
+    expect(screen.getAllByLabelText(/Set \d Load/i)).toHaveLength(3)
+  })
+
+  test('Strength result form hides distance / cals / seconds add-column buttons', () => {
+    const w = makeWorkout({
+      type: 'POWER_LIFTING',
+      workoutMovements: [makeMovement('m-1', 'Back Squat', { sets: 1, reps: '5' })],
+    })
+    render(<LogResultDrawer workout={w} onClose={() => {}} onSaved={() => {}} />)
+    // Tempo is reachable for strength; distance / cals / seconds aren't.
+    expect(screen.getByRole('button', { name: '+ Tempo' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '+ Distance' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '+ Cals' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '+ Seconds' })).not.toBeInTheDocument()
+  })
+
   test('+ Add set appends a row and × removes one', () => {
     const w = makeWorkout({
       type: 'POWER_LIFTING',

--- a/apps/web/src/components/LogResultDrawer.test.tsx
+++ b/apps/web/src/components/LogResultDrawer.test.tsx
@@ -30,7 +30,11 @@ function makeMovement(id: string, name: string, prescription: Partial<Workout['w
   return {
     movement: { id, name, parentId: null },
     displayOrder: 0,
-    sets: null, reps: null, load: null, loadUnit: null, tempo: null,
+    sets: null, reps: null, load: null, loadUnit: null,
+    // Mirrors the API default (Prisma column has @default(true)). Tests
+    // override to false explicitly to suppress the Load column.
+    tracksLoad: true,
+    tempo: null,
     distance: null, distanceUnit: null, calories: null, seconds: null,
     ...prescription,
   }
@@ -104,6 +108,19 @@ describe('LogResultDrawer — strength sets table', () => {
     expect(screen.queryByRole('button', { name: '+ Distance' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: '+ Cals' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: '+ Seconds' })).not.toBeInTheDocument()
+  })
+
+  test('movement with tracksLoad=false hides the Load column entirely', () => {
+    const w = makeWorkout({
+      type: 'POWER_LIFTING',
+      // Plyometric piece — Box Jump 5×5, no load tracked.
+      workoutMovements: [makeMovement('m-1', 'Box Jump', { sets: 5, reps: '5', tracksLoad: false })],
+    })
+    render(<LogResultDrawer workout={w} onClose={() => {}} onSaved={() => {}} />)
+    expect(screen.getAllByLabelText(/Set \d Reps/i)).toHaveLength(5)
+    // No Load column header / inputs, and no "+ Load" button to surface one.
+    expect(screen.queryAllByLabelText(/Set \d Load/i)).toHaveLength(0)
+    expect(screen.queryByRole('button', { name: '+ Load' })).not.toBeInTheDocument()
   })
 
   test('+ Add set appends a row and × removes one', () => {

--- a/apps/web/src/components/LogResultDrawer.tsx
+++ b/apps/web/src/components/LogResultDrawer.tsx
@@ -457,9 +457,10 @@ function SetsTable({
   // The columns to surface come from whichever fields the programmer
   // prescribed — anything they didn't prescribe is hidden by default. Members
   // can show extras via the "Add column" buttons below the table.
-  // Strength is special: programmers intentionally don't prescribe load
-  // (slice 2B) but the load column still auto-shows because that's what
-  // the member came to record.
+  // The Load column auto-shows when `prescription.tracksLoad` is true, even
+  // when no specific load value was prescribed (most strength workouts hit
+  // this path — programmers leave the actual weight to the member).
+  const tracksLoad = prescription?.tracksLoad ?? true
   const prescribed = useMemo(() => {
     const cols = new Set<keyof SetRow>()
     if (prescription) {
@@ -470,20 +471,28 @@ function SetsTable({
       if (prescription.calories !== null) cols.add('calories')
       if (prescription.seconds !== null)  cols.add('seconds')
     }
-    if (category === 'Strength') { cols.add('reps'); cols.add('load') }
-    if (cols.size === 0) { cols.add('reps'); cols.add('load') }
+    // Strength still defaults to showing reps as a useful baseline. Load
+    // surfaces only when the programmer left tracksLoad on (the default).
+    if (category === 'Strength') cols.add('reps')
+    if (tracksLoad && (category === 'Strength' || cols.size === 0)) cols.add('load')
+    if (cols.size === 0) cols.add('reps')
     return cols
-  }, [prescription, category])
+  }, [prescription, category, tracksLoad])
 
   // Columns reachable for this workout's category. Strength is barbell
   // work — distance / cals / seconds aren't relevant. MonoStructural is
   // timed cardio — sets / reps / load aren't. Metcon / Skill / Warmup keep
   // every column on the table since their movement mix varies.
+  // Load is suppressed entirely when the programmer flipped tracksLoad
+  // off — no header, no "+ Load" button.
   const availableColumns = useMemo<Set<keyof SetRow>>(() => {
-    if (category === 'Strength') return new Set(['reps', 'load', 'tempo'])
-    if (category === 'MonoStructural') return new Set(['distance', 'calories', 'seconds'])
-    return new Set(['reps', 'load', 'tempo', 'distance', 'calories', 'seconds'])
-  }, [category])
+    let cols: Set<keyof SetRow>
+    if (category === 'Strength') cols = new Set(['reps', 'load', 'tempo'])
+    else if (category === 'MonoStructural') cols = new Set(['distance', 'calories', 'seconds'])
+    else cols = new Set(['reps', 'load', 'tempo', 'distance', 'calories', 'seconds'])
+    if (!tracksLoad) cols.delete('load')
+    return cols
+  }, [category, tracksLoad])
 
   // Auto-show a column if the user has typed into any cell of it (unless
   // it's not even reachable for this category).

--- a/apps/web/src/components/LogResultDrawer.tsx
+++ b/apps/web/src/components/LogResultDrawer.tsx
@@ -12,7 +12,7 @@ import {
   type WorkoutMovementWithPrescription,
   type WorkoutResult,
 } from '../lib/api.ts'
-import { WORKOUT_TYPE_STYLES } from '../lib/workoutTypeStyles'
+import { WORKOUT_TYPE_STYLES, type WorkoutCategory } from '../lib/workoutTypeStyles'
 
 interface LogResultDrawerProps {
   workout: Workout
@@ -351,6 +351,7 @@ export default function LogResultDrawer({ workout, existingResult, onClose, onSa
               <SetsTable
                 movement={active}
                 movementIdx={activeMovement}
+                category={WORKOUT_TYPE_STYLES[workout.type].category}
                 prescription={activePrescription}
                 onUpdate={updateSet}
                 onAddSet={addSet}
@@ -437,6 +438,7 @@ export default function LogResultDrawer({ workout, existingResult, onClose, onSa
 function SetsTable({
   movement,
   movementIdx,
+  category,
   prescription,
   onUpdate,
   onAddSet,
@@ -445,6 +447,7 @@ function SetsTable({
 }: {
   movement: MovementSection
   movementIdx: number
+  category: WorkoutCategory
   prescription: WorkoutMovementWithPrescription | null
   onUpdate: (mIdx: number, sIdx: number, field: keyof SetRow, value: string) => void
   onAddSet: (mIdx: number) => void
@@ -454,20 +457,36 @@ function SetsTable({
   // The columns to surface come from whichever fields the programmer
   // prescribed — anything they didn't prescribe is hidden by default. Members
   // can show extras via the "Add column" buttons below the table.
+  // Strength is special: programmers intentionally don't prescribe load
+  // (slice 2B) but the load column still auto-shows because that's what
+  // the member came to record.
   const prescribed = useMemo(() => {
-    if (!prescription) return new Set<keyof SetRow>(['reps', 'load'])
     const cols = new Set<keyof SetRow>()
-    if (prescription.reps !== null)     cols.add('reps')
-    if (prescription.load !== null)     cols.add('load')
-    if (prescription.tempo !== null)    cols.add('tempo')
-    if (prescription.distance !== null) cols.add('distance')
-    if (prescription.calories !== null) cols.add('calories')
-    if (prescription.seconds !== null)  cols.add('seconds')
-    if (cols.size === 0) cols.add('reps').add('load')
+    if (prescription) {
+      if (prescription.reps !== null)     cols.add('reps')
+      if (prescription.load !== null)     cols.add('load')
+      if (prescription.tempo !== null)    cols.add('tempo')
+      if (prescription.distance !== null) cols.add('distance')
+      if (prescription.calories !== null) cols.add('calories')
+      if (prescription.seconds !== null)  cols.add('seconds')
+    }
+    if (category === 'Strength') { cols.add('reps'); cols.add('load') }
+    if (cols.size === 0) { cols.add('reps'); cols.add('load') }
     return cols
-  }, [prescription])
+  }, [prescription, category])
 
-  // Auto-show a column if the user has typed into any cell of it.
+  // Columns reachable for this workout's category. Strength is barbell
+  // work — distance / cals / seconds aren't relevant. MonoStructural is
+  // timed cardio — sets / reps / load aren't. Metcon / Skill / Warmup keep
+  // every column on the table since their movement mix varies.
+  const availableColumns = useMemo<Set<keyof SetRow>>(() => {
+    if (category === 'Strength') return new Set(['reps', 'load', 'tempo'])
+    if (category === 'MonoStructural') return new Set(['distance', 'calories', 'seconds'])
+    return new Set(['reps', 'load', 'tempo', 'distance', 'calories', 'seconds'])
+  }, [category])
+
+  // Auto-show a column if the user has typed into any cell of it (unless
+  // it's not even reachable for this category).
   const visible = useMemo(() => {
     const cols = new Set(prescribed)
     for (const s of movement.sets) {
@@ -475,8 +494,9 @@ function SetsTable({
         if (s[c] !== '') cols.add(c)
       })
     }
-    return cols
-  }, [prescribed, movement.sets])
+    // Filter to only category-available columns.
+    return new Set([...cols].filter((c) => availableColumns.has(c)))
+  }, [prescribed, movement.sets, availableColumns])
 
   const allColumns: { key: keyof SetRow; label: string; placeholder: string }[] = [
     { key: 'reps',     label: 'Reps',     placeholder: '5 or 1.1.1' },
@@ -487,7 +507,8 @@ function SetsTable({
     { key: 'seconds',  label: 'Seconds',  placeholder: '60' },
   ]
   const showColumns = allColumns.filter((c) => visible.has(c.key))
-  const hiddenColumns = allColumns.filter((c) => !visible.has(c.key))
+  // Only offer "+ Column" buttons for axes that make sense for this category.
+  const hiddenColumns = allColumns.filter((c) => !visible.has(c.key) && availableColumns.has(c.key))
 
   return (
     <div className="space-y-2">

--- a/apps/web/src/components/WorkoutDrawer.test.tsx
+++ b/apps/web/src/components/WorkoutDrawer.test.tsx
@@ -188,8 +188,7 @@ describe('WorkoutDrawer prescription editor', () => {
     expect(screen.queryByLabelText(/Track rounds/)).not.toBeInTheDocument()
   })
 
-  it('renders Sets/Reps/Load/Tempo defaults for a Strength workout movement', async () => {
-    const user = userEvent.setup()
+  it('renders Sets/Reps/Tempo defaults (no load) for a Strength workout movement', async () => {
     const props = defaultProps({
       workout: {
         id: 'wod-1', title: 'Back Squat 5x5', description: 'Heavy day',
@@ -198,7 +197,7 @@ describe('WorkoutDrawer prescription editor', () => {
         workoutMovements: [{
           movement: { id: 'mv-1', name: 'Back Squat', parentId: null },
           displayOrder: 0,
-          sets: 5, reps: '5', load: 225, loadUnit: 'LB' as const,
+          sets: 5, reps: '5', load: null, loadUnit: null,
           tempo: '3.1.1.0', distance: null, distanceUnit: null,
           calories: null, seconds: null,
         }],
@@ -211,31 +210,31 @@ describe('WorkoutDrawer prescription editor', () => {
 
     await waitFor(() => expect(screen.getByText('Back Squat')).toBeInTheDocument())
 
-    // Prescription columns surface for the strength category
+    // Strength prescription surfaces sets/reps/tempo only — `load` is
+    // intentionally omitted (slice 2B feedback: weights are too individual
+    // to prescribe usefully). Distance/Cals/Seconds also hidden — barbell
+    // work doesn't have those axes.
     expect((screen.getByLabelText('Sets') as HTMLInputElement).value).toBe('5')
     expect((screen.getByLabelText('Reps') as HTMLInputElement).value).toBe('5')
-    expect((screen.getByLabelText('Load') as HTMLInputElement).value).toBe('225')
     expect((screen.getByLabelText('Tempo') as HTMLInputElement).value).toBe('3.1.1.0')
-
-    // Distance/Cals/Seconds are hidden by default for strength — flip the disclosure
+    expect(screen.queryByLabelText('Load')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Distance')).not.toBeInTheDocument()
-    await user.click(screen.getByText('+ Show all columns'))
-    expect(screen.getByLabelText('Distance')).toBeInTheDocument()
-    expect(screen.getByLabelText('Cals')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Cals')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Seconds')).not.toBeInTheDocument()
   })
 
-  it('saves edited prescription via api.workouts.update with the movements payload', async () => {
+  it('Metcon prescription surfaces Load (Fran-style 95 lb thrusters) and saves it through', async () => {
     const user = userEvent.setup()
     vi.mocked(api.workouts.update).mockResolvedValue({} as never)
 
     const props = defaultProps({
       workout: {
-        id: 'wod-1', title: 'Back Squat', description: 'Heavy day',
-        type: 'POWER_LIFTING' as const, status: 'DRAFT' as const,
+        id: 'wod-1', title: 'Fran', description: '21-15-9',
+        type: 'FOR_TIME' as const, status: 'DRAFT' as const,
         scheduledAt: '2026-04-21T12:00:00.000Z', dayOrder: 0,
         workoutMovements: [{
-          movement: { id: 'mv-1', name: 'Back Squat', parentId: null },
-          displayOrder: 0, sets: 5, reps: '5', load: 225, loadUnit: 'LB' as const,
+          movement: { id: 'mv-1', name: 'Thrusters', parentId: null },
+          displayOrder: 0, sets: 3, reps: '21', load: 95, loadUnit: 'LB' as const,
           tempo: null, distance: null, distanceUnit: null, calories: null, seconds: null,
         }],
         programId: 'prog-1', program: { id: 'prog-1', name: 'General' },
@@ -244,12 +243,12 @@ describe('WorkoutDrawer prescription editor', () => {
       } as never,
     })
     render(<WorkoutDrawer {...props} />)
-    await waitFor(() => expect(screen.getByText('Back Squat')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('Thrusters')).toBeInTheDocument())
 
     const loadInput = screen.getByLabelText('Load') as HTMLInputElement
+    expect(loadInput.value).toBe('95')
     await user.clear(loadInput)
-    await user.type(loadInput, '275')
-
+    await user.type(loadInput, '105')
     await user.click(screen.getByText('Save as Draft'))
 
     await waitFor(() => expect(api.workouts.update).toHaveBeenCalled())
@@ -258,9 +257,9 @@ describe('WorkoutDrawer prescription editor', () => {
       movements: [{
         movementId: 'mv-1',
         displayOrder: 0,
-        sets: 5,
-        reps: '5',
-        load: 275,
+        sets: 3,
+        reps: '21',
+        load: 105,
         loadUnit: 'LB',
       }],
     })

--- a/apps/web/src/components/WorkoutDrawer.test.tsx
+++ b/apps/web/src/components/WorkoutDrawer.test.tsx
@@ -289,6 +289,43 @@ describe('WorkoutDrawer prescription editor', () => {
       tracksRounds: true,
     })
   })
+
+  it('Track-load toggle flips tracksLoad on the saved movements payload', async () => {
+    const user = userEvent.setup()
+    vi.mocked(api.workouts.update).mockResolvedValue({} as never)
+
+    const props = defaultProps({
+      workout: {
+        id: 'wod-1', title: 'Squat + Box Jump', description: 'superset',
+        type: 'POWER_LIFTING' as const, status: 'DRAFT' as const,
+        scheduledAt: '2026-04-21T12:00:00.000Z', dayOrder: 0,
+        workoutMovements: [{
+          movement: { id: 'mv-1', name: 'Box Jump', parentId: null },
+          displayOrder: 0, sets: 5, reps: '5',
+          load: null, loadUnit: null, tracksLoad: true,
+          tempo: null, distance: null, distanceUnit: null,
+          calories: null, seconds: null,
+        }],
+        programId: 'prog-1', program: { id: 'prog-1', name: 'General' },
+        namedWorkoutId: null, namedWorkout: null,
+        timeCapSeconds: null, tracksRounds: false,
+      } as never,
+    })
+    render(<WorkoutDrawer {...props} />)
+    await waitFor(() => expect(screen.getByText('Box Jump')).toBeInTheDocument())
+
+    const toggle = screen.getByLabelText(/Track load on results/) as HTMLInputElement
+    expect(toggle.checked).toBe(true)
+    await user.click(toggle)
+    expect(toggle.checked).toBe(false)
+
+    await user.click(screen.getByText('Save as Draft'))
+    await waitFor(() => expect(api.workouts.update).toHaveBeenCalled())
+    const [, payload] = vi.mocked(api.workouts.update).mock.calls[0]
+    expect(payload).toMatchObject({
+      movements: [{ movementId: 'mv-1', tracksLoad: false }],
+    })
+  })
 })
 
 describe('WorkoutDrawer markdown paste', () => {

--- a/apps/web/src/components/WorkoutDrawer.test.tsx
+++ b/apps/web/src/components/WorkoutDrawer.test.tsx
@@ -161,6 +161,137 @@ describe('WorkoutDrawer autosave', () => {
   })
 })
 
+describe('WorkoutDrawer prescription editor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    seedApi()
+  })
+
+  it('shows time-cap input for Metcon types and tracksRounds toggle only for AMRAP', async () => {
+    const user = userEvent.setup()
+    const props = defaultProps()
+    render(<WorkoutDrawer {...props} />)
+    await waitFor(() => expect(screen.getByRole('option', { name: 'General' })).toBeInTheDocument())
+
+    // AMRAP is the default type — both inputs are visible
+    expect(screen.getByLabelText(/Time cap/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Track rounds/)).toBeInTheDocument()
+
+    // Switch to FOR_TIME — time cap stays, tracks-rounds disappears
+    await user.selectOptions(screen.getByLabelText('Type'), 'FOR_TIME')
+    expect(screen.getByLabelText(/Time cap/)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Track rounds/)).not.toBeInTheDocument()
+
+    // Switch to a Strength type — both disappear
+    await user.selectOptions(screen.getByLabelText('Type'), 'POWER_LIFTING')
+    expect(screen.queryByLabelText(/Time cap/)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Track rounds/)).not.toBeInTheDocument()
+  })
+
+  it('renders Sets/Reps/Load/Tempo defaults for a Strength workout movement', async () => {
+    const user = userEvent.setup()
+    const props = defaultProps({
+      workout: {
+        id: 'wod-1', title: 'Back Squat 5x5', description: 'Heavy day',
+        type: 'POWER_LIFTING' as const, status: 'DRAFT' as const,
+        scheduledAt: '2026-04-21T12:00:00.000Z', dayOrder: 0,
+        workoutMovements: [{
+          movement: { id: 'mv-1', name: 'Back Squat', parentId: null },
+          displayOrder: 0,
+          sets: 5, reps: '5', load: 225, loadUnit: 'LB' as const,
+          tempo: '3.1.1.0', distance: null, distanceUnit: null,
+          calories: null, seconds: null,
+        }],
+        programId: 'prog-1', program: { id: 'prog-1', name: 'General' },
+        namedWorkoutId: null, namedWorkout: null,
+        timeCapSeconds: null, tracksRounds: false,
+      } as never,
+    })
+    render(<WorkoutDrawer {...props} />)
+
+    await waitFor(() => expect(screen.getByText('Back Squat')).toBeInTheDocument())
+
+    // Prescription columns surface for the strength category
+    expect((screen.getByLabelText('Sets') as HTMLInputElement).value).toBe('5')
+    expect((screen.getByLabelText('Reps') as HTMLInputElement).value).toBe('5')
+    expect((screen.getByLabelText('Load') as HTMLInputElement).value).toBe('225')
+    expect((screen.getByLabelText('Tempo') as HTMLInputElement).value).toBe('3.1.1.0')
+
+    // Distance/Cals/Seconds are hidden by default for strength — flip the disclosure
+    expect(screen.queryByLabelText('Distance')).not.toBeInTheDocument()
+    await user.click(screen.getByText('+ Show all columns'))
+    expect(screen.getByLabelText('Distance')).toBeInTheDocument()
+    expect(screen.getByLabelText('Cals')).toBeInTheDocument()
+  })
+
+  it('saves edited prescription via api.workouts.update with the movements payload', async () => {
+    const user = userEvent.setup()
+    vi.mocked(api.workouts.update).mockResolvedValue({} as never)
+
+    const props = defaultProps({
+      workout: {
+        id: 'wod-1', title: 'Back Squat', description: 'Heavy day',
+        type: 'POWER_LIFTING' as const, status: 'DRAFT' as const,
+        scheduledAt: '2026-04-21T12:00:00.000Z', dayOrder: 0,
+        workoutMovements: [{
+          movement: { id: 'mv-1', name: 'Back Squat', parentId: null },
+          displayOrder: 0, sets: 5, reps: '5', load: 225, loadUnit: 'LB' as const,
+          tempo: null, distance: null, distanceUnit: null, calories: null, seconds: null,
+        }],
+        programId: 'prog-1', program: { id: 'prog-1', name: 'General' },
+        namedWorkoutId: null, namedWorkout: null,
+        timeCapSeconds: null, tracksRounds: false,
+      } as never,
+    })
+    render(<WorkoutDrawer {...props} />)
+    await waitFor(() => expect(screen.getByText('Back Squat')).toBeInTheDocument())
+
+    const loadInput = screen.getByLabelText('Load') as HTMLInputElement
+    await user.clear(loadInput)
+    await user.type(loadInput, '275')
+
+    await user.click(screen.getByText('Save as Draft'))
+
+    await waitFor(() => expect(api.workouts.update).toHaveBeenCalled())
+    const [, payload] = vi.mocked(api.workouts.update).mock.calls[0]
+    expect(payload).toMatchObject({
+      movements: [{
+        movementId: 'mv-1',
+        displayOrder: 0,
+        sets: 5,
+        reps: '5',
+        load: 275,
+        loadUnit: 'LB',
+      }],
+    })
+  })
+
+  it('parses M:SS time-cap input and forwards tracksRounds for AMRAP', async () => {
+    const user = userEvent.setup()
+    vi.mocked(api.workouts.create).mockResolvedValue({ id: 'new-1', status: 'DRAFT' } as never)
+
+    const props = defaultProps()
+    render(<WorkoutDrawer {...props} />)
+    await waitFor(() => expect(screen.getByRole('option', { name: 'General' })).toBeInTheDocument())
+
+    await user.type(screen.getByPlaceholderText('e.g. Fran'), 'Cindy')
+    await user.type(screen.getByPlaceholderText(/Workout details/), '20-min AMRAP of …')
+    await user.type(screen.getByLabelText(/Time cap/), '20:00')
+    await user.click(screen.getByLabelText(/Track rounds/))
+
+    await user.click(screen.getByText('Save as Draft'))
+
+    await waitFor(() => expect(api.workouts.create).toHaveBeenCalled())
+    const [, payload] = vi.mocked(api.workouts.create).mock.calls[0]
+    expect(payload).toMatchObject({
+      title: 'Cindy',
+      type: 'AMRAP',
+      timeCapSeconds: 1200,
+      tracksRounds: true,
+    })
+  })
+})
+
 describe('WorkoutDrawer markdown paste', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/apps/web/src/components/WorkoutDrawer.tsx
+++ b/apps/web/src/components/WorkoutDrawer.tsx
@@ -13,6 +13,10 @@ interface PrescriptionForm {
   reps:         string
   load:         string
   loadUnit:     LoadUnit
+  // Whether the result form should surface a Load column for this movement.
+  // Defaults true — programmer flips off for plyometric supersets and other
+  // pieces where Load would be noise on the result form.
+  tracksLoad:   boolean
   tempo:        string
   distance:     string
   distanceUnit: DistanceUnit
@@ -21,7 +25,7 @@ interface PrescriptionForm {
 }
 
 const EMPTY_PRESCRIPTION: PrescriptionForm = {
-  sets: '', reps: '', load: '', loadUnit: 'LB', tempo: '',
+  sets: '', reps: '', load: '', loadUnit: 'LB', tracksLoad: true, tempo: '',
   distance: '', distanceUnit: 'M', calories: '', seconds: '',
 }
 
@@ -110,6 +114,7 @@ function buildMovementsPayload(
       reps:     p.reps  ? p.reps  : undefined,
       load:     Number.isFinite(load)     && load     > 0 ? load : undefined,
       loadUnit: p.load  ? p.loadUnit : undefined,
+      tracksLoad: p.tracksLoad,
       tempo:    p.tempo ? p.tempo : undefined,
       distance:     Number.isFinite(distance) && distance > 0 ? distance : undefined,
       distanceUnit: p.distance ? p.distanceUnit : undefined,
@@ -259,6 +264,9 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
         reps:         wm.reps         ?? '',
         load:         wm.load         !== null && wm.load         !== undefined ? String(wm.load) : '',
         loadUnit:     wm.loadUnit     ?? 'LB',
+        // tracksLoad is always populated on read (Prisma column has @default(true)).
+        // The `?? true` covers tests/fixtures that omit the field.
+        tracksLoad:   wm.tracksLoad   ?? true,
         tempo:        wm.tempo        ?? '',
         distance:     wm.distance     !== null && wm.distance     !== undefined ? String(wm.distance) : '',
         distanceUnit: wm.distanceUnit ?? 'M',
@@ -1103,6 +1111,12 @@ function PrescriptionRow({ movement, type, prescription, showAllColumns, onChang
     available.has(c.key) && (showAllColumns || defaults.has(c.key) || prescription[c.key] !== ''),
   )
 
+  // The Load tracking toggle is meaningful only for categories where the
+  // result form surfaces a Load column. MonoStructural doesn't, so the
+  // toggle would be a no-op there; hide it.
+  const category = WORKOUT_TYPE_STYLES[type].category
+  const showLoadToggle = category !== 'MonoStructural'
+
   function update<K extends keyof PrescriptionForm>(key: K, value: PrescriptionForm[K]) {
     onChange({ ...prescription, [key]: value })
   }
@@ -1134,6 +1148,21 @@ function PrescriptionRow({ movement, type, prescription, showAllColumns, onChang
           />
         ))}
       </div>
+      {showLoadToggle && (
+        <label
+          htmlFor={`pr-${movement.id}-tracksLoad`}
+          className="flex items-center gap-2 mt-2 text-xs text-gray-400 cursor-pointer min-h-7 select-none"
+        >
+          <input
+            id={`pr-${movement.id}-tracksLoad`}
+            type="checkbox"
+            checked={prescription.tracksLoad}
+            onChange={(e) => update('tracksLoad', e.target.checked)}
+            className="w-4 h-4 rounded accent-indigo-500"
+          />
+          <span>Track load on results</span>
+        </label>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/WorkoutDrawer.tsx
+++ b/apps/web/src/components/WorkoutDrawer.tsx
@@ -39,12 +39,32 @@ const TIME_CAP_TYPES = new Set<WorkoutType>([
 // Hidden columns are still legal — programmer can flip the disclosure to
 // reveal everything — but the default keeps the UI uncluttered for the most
 // common case per category.
+//
+// Strength is intentionally absent of `load`: weight prescriptions for
+// strength work are too individualized to express usefully here. A future
+// iteration will suggest loads from the member's training history; until
+// then, programmers leave load to the member at log-time.
 function defaultPrescriptionColumns(type: WorkoutType): Set<keyof PrescriptionForm> {
   const category = WORKOUT_TYPE_STYLES[type].category
-  if (category === 'Strength') return new Set(['sets', 'reps', 'load', 'tempo'])
+  if (category === 'Strength') return new Set(['sets', 'reps', 'tempo'])
   if (category === 'MonoStructural') return new Set(['distance', 'calories', 'seconds'])
-  // Metcon, Skill Work, Warmup/Recovery — light defaults
+  if (category === 'Metcon') return new Set(['sets', 'reps', 'load'])
   return new Set(['sets', 'reps'])
+}
+
+// Columns the programmer can ever reach for this workout type. Tightening
+// is two-fold:
+// - Strength hides `load` (intentional — slice 2B feedback) and also drops
+//   distance/calories/seconds since barbell work doesn't have those axes.
+// - MonoStructural drops sets/reps/load/tempo — rowing/biking/swimming are
+//   timed cardio, not lift work.
+// - Metcon / Skill Work / Warmup keep every axis available; their movement
+//   mix is too varied to constrain at the workout level.
+function availablePrescriptionColumns(type: WorkoutType): Set<keyof PrescriptionForm> {
+  const category = WORKOUT_TYPE_STYLES[type].category
+  if (category === 'Strength') return new Set(['sets', 'reps', 'tempo'])
+  if (category === 'MonoStructural') return new Set(['distance', 'distanceUnit', 'calories', 'seconds'])
+  return new Set(['sets', 'reps', 'load', 'loadUnit', 'tempo', 'distance', 'distanceUnit', 'calories', 'seconds'])
 }
 
 function parseMmss(input: string): number | null {
@@ -1074,10 +1094,13 @@ const COLUMN_DEFS: { key: keyof PrescriptionForm; label: string; placeholder: st
 
 function PrescriptionRow({ movement, type, prescription, showAllColumns, onChange, onRemove }: PrescriptionRowProps) {
   const defaults = defaultPrescriptionColumns(type)
-  // Surface a column when (a) the type's defaults include it, (b) the user
-  // typed a value into it, or (c) the global "show all" toggle is on.
+  const available = availablePrescriptionColumns(type)
+  // Surface a column when (a) it's reachable for this type AND (b) the
+  // type's defaults include it, the user typed a value into it, or the
+  // global "show all" toggle is on. Strength's `available` excludes `load`
+  // so the column never appears regardless of the toggle.
   const visible = COLUMN_DEFS.filter((c) =>
-    showAllColumns || defaults.has(c.key) || prescription[c.key] !== '',
+    available.has(c.key) && (showAllColumns || defaults.has(c.key) || prescription[c.key] !== ''),
   )
 
   function update<K extends keyof PrescriptionForm>(key: K, value: PrescriptionForm[K]) {

--- a/apps/web/src/components/WorkoutDrawer.tsx
+++ b/apps/web/src/components/WorkoutDrawer.tsx
@@ -2,9 +2,102 @@ import { useState, useEffect, useRef } from 'react'
 import TurndownService from 'turndown'
 // @ts-expect-error — turndown-plugin-gfm ships no types
 import { gfm } from 'turndown-plugin-gfm'
-import { api, TYPE_ABBR, type GymProgram, type Movement, type NamedWorkout, type Role, type Workout, type WorkoutStatus, type WorkoutType } from '../lib/api'
+import { api, TYPE_ABBR, type DistanceUnit, type GymProgram, type LoadUnit, type Movement, type NamedWorkout, type Role, type Workout, type WorkoutStatus, type WorkoutType } from '../lib/api'
 import { WORKOUT_CATEGORIES, WORKOUT_TYPE_STYLES, typesInCategory } from '../lib/workoutTypeStyles'
 import { useMovements } from '../context/MovementsContext.tsx'
+
+// Per-movement prescription as form state — strings everywhere so empty
+// inputs are first-class. Coerced to numbers/units at submit time.
+interface PrescriptionForm {
+  sets:         string
+  reps:         string
+  load:         string
+  loadUnit:     LoadUnit
+  tempo:        string
+  distance:     string
+  distanceUnit: DistanceUnit
+  calories:     string
+  seconds:      string
+}
+
+const EMPTY_PRESCRIPTION: PrescriptionForm = {
+  sets: '', reps: '', load: '', loadUnit: 'LB', tempo: '',
+  distance: '', distanceUnit: 'M', calories: '', seconds: '',
+}
+
+function blankPrescription(): PrescriptionForm {
+  return { ...EMPTY_PRESCRIPTION }
+}
+
+// Categories that surface a workout-level time cap input. AMRAP additionally
+// gets the `tracksRounds` toggle. Strength + Skill + Warmup hide both.
+const TIME_CAP_TYPES = new Set<WorkoutType>([
+  'AMRAP', 'FOR_TIME', 'EMOM', 'METCON', 'TABATA', 'INTERVALS', 'CHIPPER', 'LADDER', 'DEATH_BY',
+])
+
+// Type-driven default for which prescription columns to surface in the form.
+// Hidden columns are still legal — programmer can flip the disclosure to
+// reveal everything — but the default keeps the UI uncluttered for the most
+// common case per category.
+function defaultPrescriptionColumns(type: WorkoutType): Set<keyof PrescriptionForm> {
+  const category = WORKOUT_TYPE_STYLES[type].category
+  if (category === 'Strength') return new Set(['sets', 'reps', 'load', 'tempo'])
+  if (category === 'MonoStructural') return new Set(['distance', 'calories', 'seconds'])
+  // Metcon, Skill Work, Warmup/Recovery — light defaults
+  return new Set(['sets', 'reps'])
+}
+
+function parseMmss(input: string): number | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  // "20" → 20s; "20:00" → 20 minutes
+  if (!trimmed.includes(':')) {
+    const n = parseInt(trimmed, 10)
+    return Number.isInteger(n) && n >= 0 ? n : null
+  }
+  const [m, s] = trimmed.split(':')
+  const mi = parseInt(m, 10)
+  const si = parseInt(s, 10)
+  if (!Number.isInteger(mi) || mi < 0 || !Number.isInteger(si) || si < 0 || si > 59) return null
+  return mi * 60 + si
+}
+
+function formatMmss(seconds: number | null | undefined): string {
+  if (seconds === null || seconds === undefined) return ''
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+// Project the per-movement form state into the API payload shape, using the
+// current `selectedMovements` order to assign `displayOrder`. Empty strings
+// drop out of the payload (sent as undefined → the API persists null).
+function buildMovementsPayload(
+  selected: Movement[],
+  prescriptions: Record<string, PrescriptionForm>,
+) {
+  return selected.map((m, i) => {
+    const p = prescriptions[m.id] ?? EMPTY_PRESCRIPTION
+    const sets     = parseInt(p.sets,     10)
+    const load     = parseFloat(p.load)
+    const distance = parseFloat(p.distance)
+    const calories = parseInt(p.calories, 10)
+    const seconds  = parseInt(p.seconds,  10)
+    return {
+      movementId:   m.id,
+      displayOrder: i,
+      sets:     Number.isFinite(sets)     && sets     > 0 ? sets : undefined,
+      reps:     p.reps  ? p.reps  : undefined,
+      load:     Number.isFinite(load)     && load     > 0 ? load : undefined,
+      loadUnit: p.load  ? p.loadUnit : undefined,
+      tempo:    p.tempo ? p.tempo : undefined,
+      distance:     Number.isFinite(distance) && distance > 0 ? distance : undefined,
+      distanceUnit: p.distance ? p.distanceUnit : undefined,
+      calories: Number.isFinite(calories) && calories >= 0 ? calories : undefined,
+      seconds:  Number.isFinite(seconds)  && seconds  >= 0 ? seconds  : undefined,
+    }
+  })
+}
 
 // Single Turndown instance handles HTML→Markdown conversion when the user pastes
 // rich content (e.g., tables copied from a web page) into the description.
@@ -48,7 +141,12 @@ function buildSnapshot(args: {
   namedWorkoutId: string | null
   movementIds: string[]
   programId: string | null
+  prescriptions: Record<string, PrescriptionForm>
+  timeCapSeconds: string
+  tracksRounds: boolean
 }): string {
+  // Project prescriptions in movement-id order so equal sets compare equal.
+  const prescriptionsCanonical = args.movementIds.map((id) => [id, args.prescriptions[id] ?? EMPTY_PRESCRIPTION])
   return JSON.stringify({
     title: args.title.trim(),
     description: args.description,
@@ -56,6 +154,9 @@ function buildSnapshot(args: {
     namedWorkoutId: args.namedWorkoutId,
     movementIds: args.movementIds,
     programId: args.programId,
+    prescriptions: prescriptionsCanonical,
+    timeCapSeconds: args.timeCapSeconds.trim(),
+    tracksRounds: args.tracksRounds,
   })
 }
 
@@ -72,6 +173,10 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
   const [namedWorkouts, setNamedWorkouts] = useState<NamedWorkout[]>([])
   const [namedWorkoutId, setNamedWorkoutId] = useState<string | null>(null)
   const [selectedMovements, setSelectedMovements] = useState<Movement[]>([])
+  const [prescriptions, setPrescriptions] = useState<Record<string, PrescriptionForm>>({})
+  const [timeCapInput, setTimeCapInput] = useState<string>('')
+  const [tracksRounds, setTracksRounds] = useState<boolean>(false)
+  const [showAllColumns, setShowAllColumns] = useState<boolean>(false)
   const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set())
   const [movementSearch, setMovementSearch] = useState('')
   const [searchOpen, setSearchOpen] = useState(false)
@@ -125,6 +230,26 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     setProgramId(workout?.programId ?? defaultProgramId ?? '')
     setNamedWorkoutId(workout?.namedWorkoutId ?? null)
     setSelectedMovements(workout?.workoutMovements?.map((wm) => wm.movement) ?? [])
+    // Seed prescriptions from the workout's existing per-movement rows. Empty
+    // strings (rather than undefined) so the inputs render controlled.
+    const seededPrescriptions: Record<string, PrescriptionForm> = {}
+    for (const wm of workout?.workoutMovements ?? []) {
+      seededPrescriptions[wm.movement.id] = {
+        sets:         wm.sets         !== null && wm.sets         !== undefined ? String(wm.sets) : '',
+        reps:         wm.reps         ?? '',
+        load:         wm.load         !== null && wm.load         !== undefined ? String(wm.load) : '',
+        loadUnit:     wm.loadUnit     ?? 'LB',
+        tempo:        wm.tempo        ?? '',
+        distance:     wm.distance     !== null && wm.distance     !== undefined ? String(wm.distance) : '',
+        distanceUnit: wm.distanceUnit ?? 'M',
+        calories:     wm.calories     !== null && wm.calories     !== undefined ? String(wm.calories) : '',
+        seconds:      wm.seconds      !== null && wm.seconds      !== undefined ? String(wm.seconds) : '',
+      }
+    }
+    setPrescriptions(seededPrescriptions)
+    setTimeCapInput(formatMmss(workout?.timeCapSeconds ?? null))
+    setTracksRounds(workout?.tracksRounds ?? false)
+    setShowAllColumns(false)
     setDismissedIds(new Set())
     setMovementSearch('')
     setSearchOpen(false)
@@ -144,6 +269,9 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
       namedWorkoutId: workout?.namedWorkoutId ?? null,
       movementIds: workout?.workoutMovements?.map((wm) => wm.movement.id) ?? [],
       programId: workout?.id ? null : (workout?.programId ?? defaultProgramId ?? ''),
+      prescriptions: seededPrescriptions,
+      timeCapSeconds: formatMmss(workout?.timeCapSeconds ?? null),
+      tracksRounds: workout?.tracksRounds ?? false,
     })
   }, [isOpen, workout?.id, defaultProgramId])
 
@@ -157,6 +285,9 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     namedWorkoutId,
     movementIds: selectedMovements.map((m) => m.id),
     programId: localWorkoutId ? null : programId,
+    prescriptions,
+    timeCapSeconds: timeCapInput,
+    tracksRounds,
   })
 
   const canAutosave =
@@ -174,7 +305,13 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     if (lastAutosaveSnapshotRef.current === snapshot) return
 
     const snapshotAtSave = snapshot
-    const movementIds = selectedMovements.map((m) => m.id)
+    const movements = buildMovementsPayload(selectedMovements, prescriptions)
+    const timeCapSeconds = parseMmss(timeCapInput)
+    const tracksRoundsForType = type === 'AMRAP' ? tracksRounds : false
+    // `CreateWorkoutSchema.timeCapSeconds` is `z.number().int().positive()` —
+    // not nullable. Omit the field on create when there's no cap; on update
+    // we always pass the value (the API schema accepts null there to clear).
+    const timeCapForCreate = timeCapSeconds !== null ? { timeCapSeconds } : {}
 
     const task = (async () => {
       setAutosaving(true)
@@ -184,8 +321,10 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
             title: title.trim(),
             description,
             type,
-            movementIds,
+            movements,
             namedWorkoutId,
+            timeCapSeconds,
+            tracksRounds: tracksRoundsForType,
           })
           lastAutosaveSnapshotRef.current = snapshotAtSave
         } else {
@@ -196,8 +335,10 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
             description,
             type,
             scheduledAt,
-            movementIds,
+            movements,
             namedWorkoutId: namedWorkoutId ?? undefined,
+            ...timeCapForCreate,
+            tracksRounds: tracksRoundsForType,
           })
           setLocalWorkoutId(created.id)
           setLocalStatus(created.status)
@@ -208,8 +349,11 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
             description,
             type,
             namedWorkoutId,
-            movementIds,
+            movementIds: selectedMovements.map((m) => m.id),
             programId: null,
+            prescriptions,
+            timeCapSeconds: timeCapInput,
+            tracksRounds,
           })
         }
         setAutosavedAt(new Date())
@@ -332,12 +476,15 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     setSaving(true)
     setError(null)
     try {
-      const movementIds = selectedMovements.map((m) => m.id)
+      const movements = buildMovementsPayload(selectedMovements, prescriptions)
+      const timeCapSeconds = parseMmss(timeCapInput)
+      const tracksRoundsForType = type === 'AMRAP' ? tracksRounds : false
+      const timeCapForCreate = timeCapSeconds !== null ? { timeCapSeconds } : {}
       if (localWorkoutId) {
-        await api.workouts.update(localWorkoutId, { title: title.trim(), description, type, movementIds, namedWorkoutId })
+        await api.workouts.update(localWorkoutId, { title: title.trim(), description, type, movements, namedWorkoutId, timeCapSeconds, tracksRounds: tracksRoundsForType })
       } else {
         const scheduledAt = new Date(dateKey! + 'T12:00:00').toISOString()
-        await api.workouts.create(gymId, { programId, title: title.trim(), description, type, scheduledAt, movementIds, namedWorkoutId: namedWorkoutId ?? undefined })
+        await api.workouts.create(gymId, { programId, title: title.trim(), description, type, scheduledAt, movements, namedWorkoutId: namedWorkoutId ?? undefined, ...timeCapForCreate, tracksRounds: tracksRoundsForType })
       }
       onSaved()
       setSaving(false)
@@ -354,13 +501,16 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     setSaving(true)
     setError(null)
     try {
-      const movementIds = selectedMovements.map((m) => m.id)
+      const movements = buildMovementsPayload(selectedMovements, prescriptions)
+      const timeCapSeconds = parseMmss(timeCapInput)
+      const tracksRoundsForType = type === 'AMRAP' ? tracksRounds : false
+      const timeCapForCreate = timeCapSeconds !== null ? { timeCapSeconds } : {}
       let id = localWorkoutId
       if (id) {
-        await api.workouts.update(id, { title: title.trim(), description, type, movementIds, namedWorkoutId })
+        await api.workouts.update(id, { title: title.trim(), description, type, movements, namedWorkoutId, timeCapSeconds, tracksRounds: tracksRoundsForType })
       } else {
         const scheduledAt = new Date(dateKey! + 'T12:00:00').toISOString()
-        const created = await api.workouts.create(gymId, { programId, title: title.trim(), description, type, scheduledAt, movementIds, namedWorkoutId: namedWorkoutId ?? undefined })
+        const created = await api.workouts.create(gymId, { programId, title: title.trim(), description, type, scheduledAt, movements, namedWorkoutId: namedWorkoutId ?? undefined, ...timeCapForCreate, tracksRounds: tracksRoundsForType })
         id = created.id
       }
       await api.workouts.publish(id!)
@@ -603,6 +753,37 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
             </select>
           </div>
 
+          {TIME_CAP_TYPES.has(type) && (
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <label htmlFor="wd-time-cap" className="block text-xs text-gray-400 mb-1">
+                  Time cap <span className="text-gray-500">(M:SS)</span>
+                </label>
+                <input
+                  id="wd-time-cap"
+                  type="text"
+                  value={timeCapInput}
+                  onChange={(e) => setTimeCapInput(e.target.value)}
+                  placeholder="20:00"
+                  className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-indigo-500"
+                />
+              </div>
+              {type === 'AMRAP' && (
+                <div className="flex items-end">
+                  <label className="flex items-center gap-2 cursor-pointer min-h-7 select-none">
+                    <input
+                      type="checkbox"
+                      checked={tracksRounds}
+                      onChange={(e) => setTracksRounds(e.target.checked)}
+                      className="w-4 h-4 rounded accent-indigo-500"
+                    />
+                    <span className="text-sm text-gray-300">Track rounds</span>
+                  </label>
+                </div>
+              )}
+            </div>
+          )}
+
           <div>
             <label className="block text-xs text-gray-400 mb-1">Title</label>
             <input
@@ -675,26 +856,34 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
                 </label>
 
                 {selectedMovements.length > 0 && (
-                  <div className="flex flex-wrap gap-1.5 mb-2">
+                  <div className="space-y-2 mb-2">
                     {selectedMovements.map((m) => (
-                      <span
+                      <PrescriptionRow
                         key={m.id}
-                        className="flex items-center gap-1 bg-gray-700 text-gray-200 text-xs px-2 py-1 rounded-full"
-                      >
-                        {m.name}
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setSelectedMovements((prev) => prev.filter((x) => x.id !== m.id))
-                            setDismissedIds((prev) => new Set([...prev, m.id]))
-                          }}
-                          className="flex items-center justify-center w-7 h-7 -mr-1 -my-1 text-gray-400 hover:text-white hover:bg-gray-600 rounded-full transition-colors"
-                          aria-label={`Remove ${m.name}`}
-                        >
-                          ×
-                        </button>
-                      </span>
+                        movement={m}
+                        type={type}
+                        prescription={prescriptions[m.id] ?? blankPrescription()}
+                        showAllColumns={showAllColumns}
+                        onChange={(next) =>
+                          setPrescriptions((prev) => ({ ...prev, [m.id]: next }))
+                        }
+                        onRemove={() => {
+                          setSelectedMovements((prev) => prev.filter((x) => x.id !== m.id))
+                          setPrescriptions((prev) => {
+                            const { [m.id]: _, ...rest } = prev
+                            return rest
+                          })
+                          setDismissedIds((prev) => new Set([...prev, m.id]))
+                        }}
+                      />
                     ))}
+                    <button
+                      type="button"
+                      onClick={() => setShowAllColumns((v) => !v)}
+                      className="text-xs text-gray-400 hover:text-white transition-colors"
+                    >
+                      {showAllColumns ? '− Hide unused columns' : '+ Show all columns'}
+                    </button>
                   </div>
                 )}
 
@@ -859,5 +1048,137 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
         </div>
       </div>
     </>
+  )
+}
+
+// ─── Per-movement prescription row ─────────────────────────────────────────────
+
+interface PrescriptionRowProps {
+  movement: Movement
+  type: WorkoutType
+  prescription: PrescriptionForm
+  showAllColumns: boolean
+  onChange: (next: PrescriptionForm) => void
+  onRemove: () => void
+}
+
+const COLUMN_DEFS: { key: keyof PrescriptionForm; label: string; placeholder: string; inputMode?: 'numeric' | 'decimal' | 'text' }[] = [
+  { key: 'sets',     label: 'Sets',     placeholder: '5',       inputMode: 'numeric' },
+  { key: 'reps',     label: 'Reps',     placeholder: '5/1.1.1', inputMode: 'text' },
+  { key: 'load',     label: 'Load',     placeholder: '225',     inputMode: 'decimal' },
+  { key: 'tempo',    label: 'Tempo',    placeholder: '3.1.1.0', inputMode: 'text' },
+  { key: 'distance', label: 'Distance', placeholder: '500',     inputMode: 'decimal' },
+  { key: 'calories', label: 'Cals',     placeholder: '20',      inputMode: 'numeric' },
+  { key: 'seconds',  label: 'Seconds',  placeholder: '60',      inputMode: 'numeric' },
+]
+
+function PrescriptionRow({ movement, type, prescription, showAllColumns, onChange, onRemove }: PrescriptionRowProps) {
+  const defaults = defaultPrescriptionColumns(type)
+  // Surface a column when (a) the type's defaults include it, (b) the user
+  // typed a value into it, or (c) the global "show all" toggle is on.
+  const visible = COLUMN_DEFS.filter((c) =>
+    showAllColumns || defaults.has(c.key) || prescription[c.key] !== '',
+  )
+
+  function update<K extends keyof PrescriptionForm>(key: K, value: PrescriptionForm[K]) {
+    onChange({ ...prescription, [key]: value })
+  }
+
+  return (
+    <div className="border border-gray-800 rounded-md bg-gray-800/30 px-3 py-2">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-sm text-gray-200">{movement.name}</span>
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`Remove ${movement.name}`}
+          className="text-gray-500 hover:text-red-400 -my-1 -mr-1.5 w-7 h-7 inline-flex items-center justify-center transition-colors"
+        >
+          ×
+        </button>
+      </div>
+      <div className="grid grid-cols-2 gap-1.5">
+        {visible.map((c) => (
+          <PrescriptionInput
+            key={c.key}
+            id={`pr-${movement.id}-${c.key}`}
+            field={c.key}
+            label={c.label}
+            placeholder={c.placeholder}
+            inputMode={c.inputMode}
+            prescription={prescription}
+            onUpdate={update}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function PrescriptionInput({
+  id,
+  field,
+  label,
+  placeholder,
+  inputMode,
+  prescription,
+  onUpdate,
+}: {
+  id: string
+  field: keyof PrescriptionForm
+  label: string
+  placeholder: string
+  inputMode?: 'numeric' | 'decimal' | 'text'
+  prescription: PrescriptionForm
+  onUpdate: <K extends keyof PrescriptionForm>(key: K, value: PrescriptionForm[K]) => void
+}) {
+  // Load and Distance carry a unit picker beside the value input. Other
+  // columns are plain text/number inputs. Wrapping the unit picker into the
+  // same primitive keeps the grid alignment uniform.
+  const unitField =
+    field === 'load' ? 'loadUnit' :
+    field === 'distance' ? 'distanceUnit' :
+    null
+
+  return (
+    <div>
+      <label htmlFor={id} className="block text-[10px] uppercase tracking-wide text-gray-400 mb-0.5">{label}</label>
+      <div className={unitField ? 'flex gap-1' : ''}>
+        <input
+          id={id}
+          type="text"
+          inputMode={inputMode}
+          value={prescription[field] as string}
+          onChange={(e) => onUpdate(field, e.target.value as PrescriptionForm[typeof field])}
+          placeholder={placeholder}
+          className="flex-1 min-w-0 bg-gray-900 border border-gray-700 rounded px-2 py-1 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-indigo-500"
+        />
+        {unitField === 'loadUnit' && (
+          <select
+            aria-label={`Load unit for ${label}`}
+            value={prescription.loadUnit}
+            onChange={(e) => onUpdate('loadUnit', e.target.value as LoadUnit)}
+            className="bg-gray-900 border border-gray-700 rounded px-1 text-xs text-white"
+          >
+            <option value="LB">lb</option>
+            <option value="KG">kg</option>
+          </select>
+        )}
+        {unitField === 'distanceUnit' && (
+          <select
+            aria-label={`Distance unit for ${label}`}
+            value={prescription.distanceUnit}
+            onChange={(e) => onUpdate('distanceUnit', e.target.value as DistanceUnit)}
+            className="bg-gray-900 border border-gray-700 rounded px-1 text-xs text-white"
+          >
+            <option value="M">m</option>
+            <option value="KM">km</option>
+            <option value="MI">mi</option>
+            <option value="FT">ft</option>
+            <option value="YD">yd</option>
+          </select>
+        )}
+      </div>
+    </div>
   )
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -138,6 +138,10 @@ export interface WorkoutMovementInput {
   reps?: string
   load?: number
   loadUnit?: LoadUnit
+  // Whether the result form should surface a Load column for this movement.
+  // Defaults true at the API boundary — programmer flips off for plyometric
+  // supersets and other no-load pieces.
+  tracksLoad?: boolean
   tempo?: string
   distance?: number
   distanceUnit?: DistanceUnit
@@ -147,6 +151,8 @@ export interface WorkoutMovementInput {
 
 // Per-movement prescription on a workout. All prescription fields are
 // nullable — programmer fills only the columns relevant to the workout.
+// `tracksLoad` is always populated on read since the Prisma column has
+// `@default(true)`.
 export interface WorkoutMovementWithPrescription {
   movement: Movement
   displayOrder: number
@@ -154,6 +160,7 @@ export interface WorkoutMovementWithPrescription {
   reps: string | null
   load: number | null
   loadUnit: LoadUnit | null
+  tracksLoad: boolean
   tempo: string | null
   distance: number | null
   distanceUnit: DistanceUnit | null

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -129,6 +129,22 @@ export interface NamedWorkout {
 export type LoadUnit = 'LB' | 'KG'
 export type DistanceUnit = 'M' | 'KM' | 'MI' | 'FT' | 'YD'
 
+// Per-movement prescription as it goes over the wire on workout create/update.
+// Only `movementId` is required; everything else is optional.
+export interface WorkoutMovementInput {
+  movementId: string
+  displayOrder?: number
+  sets?: number
+  reps?: string
+  load?: number
+  loadUnit?: LoadUnit
+  tempo?: string
+  distance?: number
+  distanceUnit?: DistanceUnit
+  calories?: number
+  seconds?: number
+}
+
 // Per-movement prescription on a workout. All prescription fields are
 // nullable — programmer fills only the columns relevant to the workout.
 export interface WorkoutMovementWithPrescription {
@@ -604,14 +620,36 @@ export const api = {
 
     create: (
       gymId: string,
-      data: { programId?: string; title: string; description: string; type: WorkoutType; scheduledAt: string; movementIds?: string[]; namedWorkoutId?: string },
+      data: {
+        programId?: string
+        title: string
+        description: string
+        type: WorkoutType
+        scheduledAt: string
+        movementIds?: string[]
+        movements?: WorkoutMovementInput[]
+        namedWorkoutId?: string
+        timeCapSeconds?: number | null
+        tracksRounds?: boolean
+      },
       token?: string,
     ) =>
       req<Workout>(`/api/gyms/${gymId}/workouts`, { method: 'POST', body: JSON.stringify(data), token }),
 
     update: (
       id: string,
-      data: { title?: string; description?: string; type?: WorkoutType; scheduledAt?: string; dayOrder?: number; movementIds?: string[]; namedWorkoutId?: string | null },
+      data: {
+        title?: string
+        description?: string
+        type?: WorkoutType
+        scheduledAt?: string
+        dayOrder?: number
+        movementIds?: string[]
+        movements?: WorkoutMovementInput[]
+        namedWorkoutId?: string | null
+        timeCapSeconds?: number | null
+        tracksRounds?: boolean
+      },
       token?: string,
     ) =>
       req<Workout>(`/api/workouts/${id}`, { method: 'PATCH', body: JSON.stringify(data), token }),


### PR DESCRIPTION
## Summary

Slice 2B of #3 — gives the programmer a per-movement prescription editor inside `WorkoutDrawer`, plus workout-level `timeCapSeconds` (M:SS) and an AMRAP-only `tracksRounds` toggle. The slice 1 API columns and slice 2/3 logging UIs already existed; this is the missing programmer authoring surface that lets prescriptions reach members.

Part of #3.

## What changed

**`apps/web/src/components/WorkoutDrawer.tsx`** — adds:
- `PrescriptionForm` form state (one per selected movement, all string-typed for empty-input cleanliness, parsed at submit).
- Per-movement `PrescriptionRow` block replacing the bare chip — sets/reps/load/loadUnit/tempo/distance/distanceUnit/calories/seconds inputs with type-driven default columns (Strength → sets/reps/load/tempo; MonoStructural → distance/cals/seconds; Metcon/Skill/Warmup → sets/reps). A "+ Show all columns" disclosure flips to surface every column when the programmer wants something off-default.
- Workout-level `timeCapSeconds` input (M:SS, parsed to integer seconds at submit; "20" or "20:00" both work) — visible for AMRAP / FOR_TIME / EMOM / METCON / TABATA / INTERVALS / CHIPPER / LADDER / DEATH_BY.
- AMRAP-only `tracksRounds` checkbox — gated by type so it never sticks around when a programmer flips back to a non-AMRAP workout.
- Autosave snapshot extended with the new fields so prescription edits trigger autosave like every other field.
- Save Draft / Publish / autosave all call `api.workouts.create|update` with the new `movements` array (per-movement prescription) instead of the legacy `movementIds`.
- `timeCapSeconds` omitted from the create payload when null — `CreateWorkoutSchema.timeCapSeconds` is `z.number().int().positive().optional()` (not nullable), so sending `null` would 400. Update accepts null (used to clear an existing cap) so it stays in the update payload.
- Edit-mode pre-fill from `workout.workoutMovements` so an existing workout's prescription comes up populated.

**`apps/web/src/lib/api.ts`** — new `WorkoutMovementInput` type and expanded `api.workouts.create` / `update` signatures to accept `movements`, `timeCapSeconds`, `tracksRounds`. The legacy `movementIds` is kept on the type alias for any non-migrated caller.

## Tests

**Unit** (`apps/web/src/components/WorkoutDrawer.test.tsx`, 9 tests, all pass — 5 existing + 4 new):
- (existing) `does not autosave when drawer just opens with empty state`
- (existing) `autosaves a new workout as a draft after the debounce window`
- (existing) `does not autosave a published workout`
- (existing) `flushes a pending autosave when the close button is clicked`
- (existing) `converts pasted HTML into markdown in the description`
- (new) `shows time-cap input for Metcon types and tracksRounds toggle only for AMRAP` — switches between AMRAP / FOR_TIME / POWER_LIFTING and verifies the right fields appear/disappear.
- (new) `renders Sets/Reps/Load/Tempo defaults for a Strength workout movement` — opens an edit-mode strength workout with a Back Squat 5×5 prescription and asserts each input pre-fills; flips the disclosure to confirm Distance/Cals appear.
- (new) `saves edited prescription via api.workouts.update with the movements payload` — bumps the load to 275 and asserts the PATCH carries `movements: [{movementId, displayOrder: 0, sets: 5, reps: '5', load: 275, loadUnit: 'LB'}]`.
- (new) `parses M:SS time-cap input and forwards tracksRounds for AMRAP` — types `"20:00"` + ticks Track rounds, asserts the create payload has `timeCapSeconds: 1200, tracksRounds: true`.

**Existing web Vitest** (`npx vitest run`, 24 files / 156 tests, all pass) — including the page-level `apps/web/src/test/a11y.test.tsx` axe check.

**API integration** (`npm run test:worktree -- api` against the worktree dev stack on port 3787, all suites pass) — slice 1's API isn't touched in this PR; ran end-to-end to confirm no regression. `tests/results.ts` 47 / 47.

**Playwright E2E** (`npm run test:worktree -- e2e`, 34/35 pass):
- `member-log-result.spec.ts`: 5/5 pass — including the strength sets-table flow from slice 2.
- `workout-publish.spec.ts`: 2/2 pass — the new `timeCapSeconds: null`-omit fix is what makes the `PROGRAMMER creates a draft workout via the calendar drawer` flow work end-to-end (would have 400'd at the API otherwise).
- `programs.spec.ts:277 — MEMBER joins a PUBLIC program from Browse and lands on its filtered Feed` — pre-existing flake, reproduces identically against `main` with the same dev stack. Documented in slice 2's PR (#167); not introduced here.

**Roles tested:** PROGRAMMER (creating + editing prescriptions). MEMBER's read path is unchanged and covered by the existing `member-log-result.spec.ts` strength flow.

**Not automated / manual verification needed:**
- [x] Visual check on the prescription row layout when many movements are selected (8+) — auto-detection from descriptions can stack quickly.
- [x] Confirm the "+ Show all columns" toggle's behavior feels right when the programmer wants distance prescribed on a Metcon (currently requires the toggle).
