### PR TITLE
feat(db): tracksLoad flag on WorkoutMovement (default true)

### DIFF
--- a/apps/api/src/db/workoutDbManager.ts
+++ b/apps/api/src/db/workoutDbManager.ts
@@ -12,6 +12,7 @@ export interface MovementPrescriptionInput {
   reps?: string
   load?: number
   loadUnit?: LoadUnit
+  tracksLoad?: boolean
   tempo?: string
   distance?: number
   distanceUnit?: DistanceUnit
@@ -69,6 +70,9 @@ function prescriptionToCreateRow(p: MovementPrescriptionInput, fallbackOrder: nu
     reps:         p.reps ?? null,
     load:         p.load ?? null,
     loadUnit:     p.loadUnit ?? null,
+    // Default true at the API boundary so legacy clients that don't yet
+    // send the field land in the most-common-case state.
+    tracksLoad:   p.tracksLoad ?? true,
     tempo:        p.tempo ?? null,
     distance:     p.distance ?? null,
     distanceUnit: p.distanceUnit ?? null,

--- a/apps/api/tests/workout-prescription.ts
+++ b/apps/api/tests/workout-prescription.ts
@@ -118,8 +118,50 @@ async function runTests() {
     check('BackSquat loadUnit=LB', 'LB', bs.loadUnit)
     check('BackSquat tempo=3.1.1.0', '3.1.1.0', bs.tempo)
     check('BackSquat displayOrder defaults to array index 0', 0, bs.displayOrder)
+    check('BackSquat tracksLoad defaults to true', true, bs.tracksLoad)
     const rdl = wms.find((w) => w.movementId === rdlId)!
     check('RDL displayOrder defaults to array index 1', 1, rdl.displayOrder)
+    check('RDL tracksLoad defaults to true', true, rdl.tracksLoad)
+  }
+
+  console.log('\n=== tracksLoad flag round-trips ===')
+
+  {
+    // Create a workout where one movement explicitly opts out of load
+    // (e.g. a plyometric superset).
+    const r = await api('POST', `/gyms/${gymId}/workouts`, programmerToken, {
+      programId,
+      title: `AT WP TracksLoad ${TS}`,
+      description: 'Squat + Box Jump superset',
+      type: 'POWER_LIFTING',
+      scheduledAt: '2026-03-18T10:00:00Z',
+      movements: [
+        { movementId: backSquatId, sets: 5, reps: '5', tracksLoad: true },
+        { movementId: rdlId,       sets: 5, reps: '10', tracksLoad: false },
+      ],
+    })
+    check('POST with explicit tracksLoad → 201', 201, r.status)
+    const body = r.body as Record<string, unknown>
+    const wms = body.workoutMovements as Array<Record<string, unknown>>
+    const bs = wms.find((w) => w.movementId === backSquatId)!
+    const rdl = wms.find((w) => w.movementId === rdlId)!
+    check('BackSquat tracksLoad=true persisted', true, bs.tracksLoad)
+    check('RDL tracksLoad=false persisted', false, rdl.tracksLoad)
+
+    // Round-trip via PATCH — flip Back Squat off, RDL on.
+    const wodId = body.id as string
+    const r2 = await api('PATCH', `/workouts/${wodId}`, programmerToken, {
+      movements: [
+        { movementId: backSquatId, sets: 5, reps: '5', tracksLoad: false },
+        { movementId: rdlId,       sets: 5, reps: '10', tracksLoad: true },
+      ],
+    })
+    const body2 = r2.body as Record<string, unknown>
+    const wms2 = body2.workoutMovements as Array<Record<string, unknown>>
+    const bs2 = wms2.find((w) => w.movementId === backSquatId)!
+    const rdl2 = wms2.find((w) => w.movementId === rdlId)!
+    check('PATCH BackSquat tracksLoad=false persisted', false, bs2.tracksLoad)
+    check('PATCH RDL tracksLoad=true persisted', true, rdl2.tracksLoad)
   }
 
   {

--- a/packages/db/prisma/migrations/20260501220640_add_tracks_load_to_workout_movement/migration.sql
+++ b/packages/db/prisma/migrations/20260501220640_add_tracks_load_to_workout_movement/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "WorkoutMovement" ADD COLUMN     "tracksLoad" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -464,6 +464,14 @@ model WorkoutMovement {
   reps         String?
   load         Float?
   loadUnit     LoadUnit?
+  // Whether the result form should surface a Load column for this movement.
+  // Defaults true since most prescribed movements involve a weight; the
+  // programmer flips this off for plyometric supersets, bodyweight-only
+  // gymnastics complexes, and similar pieces where load isn't tracked.
+  // Independent of `load` (the prescribed weight) — programmers leave the
+  // strength load to the member at log-time, but still want the Load column
+  // available for them to record what they hit.
+  tracksLoad   Boolean       @default(true)
   // Tempo notation ("3.1.1.0", "x.0.x.0"). Validated at the API layer.
   tempo        String?
   distance     Float?

--- a/packages/types/src/workout.ts
+++ b/packages/types/src/workout.ts
@@ -32,6 +32,10 @@ export const WorkoutMovementPrescriptionSchema = z.object({
   reps:         RepsFieldSchema.optional(),
   load:         z.number().positive().optional(),
   loadUnit:     LoadUnitSchema.optional(),
+  // Whether the result form surfaces a Load column for this movement.
+  // Defaults true on the server; programmer flips off for plyometric
+  // supersets and other no-load movements where the column would be noise.
+  tracksLoad:   z.boolean().optional(),
   tempo:        TempoFieldSchema.optional(),
   distance:     z.number().positive().optional(),
   distanceUnit: DistanceUnitSchema.optional(),


### PR DESCRIPTION
## Summary

Adds a `tracksLoad: Boolean @default(true)` column to `WorkoutMovement` so a programmer can hide the Load column on the result form for movements where load is noise (plyometric supersets, bodyweight gymnastics complexes, etc.).

This is the migration half of an additional slice 2B / slice 3 tweak. Per repo *Isolate migration PRs* policy this lands as a tiny additive PR ahead of the UI work — once it's merged, PR #170 (web) and PR #168 (mobile) get the actual programmer toggle and result-side visibility logic.

Part of #3.

## What changed

**`packages/db/prisma/schema.prisma`** — new `tracksLoad Boolean @default(true)` column on `WorkoutMovement`. Default true keeps the most-common-case behavior unchanged for every existing row + every new row a non-aware client creates. Independent of the prescribed `load` value: programmers leave the actual weight to the member at log-time (per slice 2B), but still want the Load column available for the member to record what they hit.

**Migration** (`20260501220640_add_tracks_load_to_workout_movement/migration.sql`):
```sql
ALTER TABLE "WorkoutMovement" ADD COLUMN "tracksLoad" BOOLEAN NOT NULL DEFAULT true;
```
Additive — no `DROP`, no incompatible `ALTER`. Old code against the new schema keeps working (the column exists with a sane default), and new code against the old schema would only fail on the explicit `tracksLoad: false` case (no current consumer sends that).

**`packages/types/src/workout.ts`** — `WorkoutMovementPrescriptionSchema.tracksLoad: z.boolean().optional()`. Optional at the wire level so legacy callers don't break.

**`apps/api/src/db/workoutDbManager.ts`** — `MovementPrescriptionInput` carries `tracksLoad?: boolean`; `prescriptionToCreateRow` defaults to `true` at the boundary so a legacy client that doesn't send the field lands in the most-common-case state.

## Tests

**API integration** (`apps/api/tests/workout-prescription.ts`, 27 tests / 0 failed — was 20 before, +7 new):

Existing cases still pass; new cases under "tracksLoad flag round-trips":
- `BackSquat tracksLoad defaults to true` — when a payload omits the field, the persisted row has `tracksLoad: true`.
- `RDL tracksLoad defaults to true` — same on the second movement in the same payload.
- `POST with explicit tracksLoad → 201` — payload with explicit `tracksLoad: true` and `tracksLoad: false` on different movements is accepted.
- `BackSquat tracksLoad=true persisted` / `RDL tracksLoad=false persisted` — verify both directions land in the DB.
- `PATCH BackSquat tracksLoad=false persisted` / `PATCH RDL tracksLoad=true persisted` — flipping the flag in either direction round-trips on update.

**Playwright E2E** (`tests/member-log-result.spec.ts` + `tests/workout-publish.spec.ts`, 7/7 pass against the worktree dev stack on port 4655) — sanity check that the schema change doesn't regress any existing flow. The new column doesn't surface in any UI yet; that's PR #170 / #168.

**Not automated / manual verification needed:**
- [ ] None — this PR is schema + types + API only. UI flows are tested via the existing E2E sweep above.

## Follow-ups

- PR #170 (slice 2B): add a per-movement Load toggle in `WorkoutDrawer`'s `PrescriptionRow`; replace the existing "force-show load on Strength" rule in `LogResultDrawer` with "show Load when `prescription.tracksLoad` is true" (defaults to true so existing strength behavior holds).
- PR #168 (slice 3): mirror the LogResultDrawer change in `LogResultScreen` on mobile.
