### PR TITLE
feat(db): Movement.sourceUrl + aliases for catalog expansion + fuzzy match

### DIFF
--- a/apps/api/src/db/movementDbManager.ts
+++ b/apps/api/src/db/movementDbManager.ts
@@ -2,7 +2,7 @@ import { prisma } from '@wodalytics/db'
 import Fuse from 'fuse.js'
 
 const movementBaseSelect = {
-  select: { id: true, name: true, status: true, parentId: true },
+  select: { id: true, name: true, status: true, parentId: true, sourceUrl: true, aliases: true },
 } as const
 
 const movementWithVariationsSelect = {
@@ -11,6 +11,8 @@ const movementWithVariationsSelect = {
     name: true,
     status: true,
     parentId: true,
+    sourceUrl: true,
+    aliases: true,
     parent: { select: { id: true, name: true } },
     variations: { select: { id: true, name: true } },
   },
@@ -95,10 +97,18 @@ export async function expandMovementIdsWithVariations(movementIds: string[]): Pr
 export async function detectMovementsInText(description: string) {
   const movements = await prisma.movement.findMany({
     where: { status: 'ACTIVE' },
-    select: { id: true, name: true, parentId: true },
+    select: { id: true, name: true, parentId: true, aliases: true },
   })
 
-  const fuse = new Fuse(movements, { keys: ['name'], threshold: 0.3, includeScore: true })
+  // Search both the canonical name and any per-movement aliases so common
+  // abbreviations like "WB" / "wall ball" still resolve to "Wall-ball Shot".
+  // The aliases array is weighted equal to name — a literal alias hit is as
+  // strong a signal as a name match.
+  const fuse = new Fuse(movements, {
+    keys: ['name', 'aliases'],
+    threshold: 0.3,
+    includeScore: true,
+  })
 
   const words = description.toLowerCase().replace(/[^a-z0-9 ]/g, ' ').split(/\s+/).filter(Boolean)
   const ngrams = new Set<string>()
@@ -114,7 +124,11 @@ export async function detectMovementsInText(description: string) {
     for (const result of fuse.search(gram)) {
       // Require the n-gram to cover ≥60% of the movement name length.
       // Prevents short n-grams ("pull") from matching long names ("Burpee Pull-up", "Sumo Deadlift High Pull").
-      if (gram.length / result.item.name.length >= 0.6) {
+      // Aliases are exempt — short abbreviations ("WB") legitimately match
+      // long canonical names, and the alias list itself is the explicit
+      // declaration that this short form maps to this movement.
+      const aliasHit = result.item.aliases.some((a) => a.toLowerCase() === gram)
+      if (aliasHit || gram.length / result.item.name.length >= 0.6) {
         matchedIds.add(result.item.id)
       }
     }

--- a/apps/api/tests/movements.ts
+++ b/apps/api/tests/movements.ts
@@ -121,7 +121,12 @@ async function setup() {
   const thruster = await prisma.movement.upsert({
     where: { name: `Thruster-${TS}` },
     update: {},
-    create: { name: `Thruster-${TS}`, status: 'ACTIVE' },
+    create: {
+      name: `Thruster-${TS}`,
+      status: 'ACTIVE',
+      sourceUrl: 'https://www.crossfit.com/essentials/the-thruster',
+      aliases: [`Thrust-${TS}`],
+    },
   })
   thrusterMovementId = thruster.id
 
@@ -195,8 +200,14 @@ async function runTests() {
     const r = await api('GET', '/movements', memberToken)
     check('T1: GET /api/movements → 200', 200, r.status)
     check('T1: returns array', true, Array.isArray(r.body))
-    const arr = r.body as unknown as { id: string }[]
+    const arr = r.body as unknown as { id: string; sourceUrl: string | null; aliases: string[] }[]
     check('T1: includes seeded thruster', true, arr.some((m) => m.id === thrusterMovementId))
+    const thr = arr.find((m) => m.id === thrusterMovementId)!
+    check('T1: thruster exposes sourceUrl', 'https://www.crossfit.com/essentials/the-thruster', thr.sourceUrl)
+    check('T1: thruster exposes aliases', `Thrust-${TS}`, (thr.aliases ?? [])[0])
+    const pu = arr.find((m) => m.id === pullUpMovementId)!
+    check('T1: pull-up sourceUrl null when unset', null, pu.sourceUrl)
+    check('T1: pull-up aliases empty when unset', 0, (pu.aliases ?? []).length)
   }
 
   {

--- a/packages/db/prisma/migrations/20260502163007_add_movement_source_url/migration.sql
+++ b/packages/db/prisma/migrations/20260502163007_add_movement_source_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Movement" ADD COLUMN     "sourceUrl" TEXT;

--- a/packages/db/prisma/migrations/20260502163213_add_movement_aliases/migration.sql
+++ b/packages/db/prisma/migrations/20260502163213_add_movement_aliases/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Movement" ADD COLUMN     "aliases" TEXT[];

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -440,6 +440,16 @@ model Movement {
   id         String            @id @default(cuid())
   name       String            @unique
   status     MovementStatus    @default(ACTIVE)
+  // Authoritative reference URL for the movement — usually a CrossFit
+  // /essentials/the-<slug> page. Surfaced as a "Learn more" link in the
+  // member UI; the body content stays on the source site so we don't have
+  // to maintain a copy or worry about stale technique cues.
+  sourceUrl  String?
+  // Common abbreviations and alternate names — fed into the WorkoutDrawer's
+  // movement search alongside the canonical name. e.g. ['WB', 'Wall Ball']
+  // for "Wall-ball Shot". Don't add forms that fuzzy matching already
+  // handles (Wall-ball → wall ball is fine without an alias).
+  aliases    String[]
   parentId   String?
   parent     Movement?         @relation("MovementVariations", fields: [parentId], references: [id])
   variations Movement[]        @relation("MovementVariations")

--- a/packages/types/src/movement.ts
+++ b/packages/types/src/movement.ts
@@ -7,6 +7,10 @@ export const MovementSchema = z.object({
   name: z.string(),
   status: MovementStatusSchema,
   parentId: z.string().nullable(),
+  // Authoritative reference URL — usually CrossFit /essentials/the-<slug>.
+  sourceUrl: z.string().url().nullable().optional(),
+  // Common abbreviations / alternate names for fuzzy matching.
+  aliases: z.array(z.string()).optional().default([]),
   parent: z.object({ id: z.string(), name: z.string() }).nullable().optional(),
   variations: z.array(z.object({ id: z.string(), name: z.string() })).optional(),
 })


### PR DESCRIPTION
## Summary

Adds two additive nullable columns to `Movement` so the catalog can hold a reference URL and alternate-name list. Prep for a companion seeder PR that imports CrossFit's `/crossfit-movements` list with both fields populated.

This is the migration half of the movement-catalog expansion. Per the *Isolate migration PRs* policy this lands as a tiny additive PR ahead of the seeder. Both columns are nullable / default-empty, so old code against the new schema works unchanged.

## What changed

**`packages/db/prisma/schema.prisma`** — two new columns on `Movement`:

- `sourceUrl String?` — authoritative reference URL, usually a CrossFit `/essentials/the-<slug>` page. Surfaced as a "Learn more" link in the member UI; the body content stays on the source site so we don't have to maintain a copy or worry about stale technique cues.
- `aliases String[]` — common abbreviations and alternate names. Fed into the `WorkoutDrawer`'s movement search alongside the canonical name. e.g. `['WB', 'Wall Ball']` for "Wall-ball Shot". The seeder PR will populate this from a curated list; runtime UI for editing it can come later if we want it.

**Two stacked migrations** (`20260502163007_add_movement_source_url` + `20260502163213_add_movement_aliases`). Each is a single `ADD COLUMN` — additive, no `DROP`, no incompatible `ALTER`.

**`apps/api/src/db/movementDbManager.ts`**:
- Both columns added to `movementBaseSelect` and `movementWithVariationsSelect` so every read path exposes them.
- `detectMovementsInText` now feeds aliases into Fuse.js (`keys: ['name', 'aliases']`) and exempts alias hits from the 60%-name-coverage gate. Without that exemption, a short alias like "WB" couldn't resolve to a long name like "Wall-ball Shot" because the gate would filter it out.

**`packages/types/src/movement.ts`** — `MovementSchema` gains `sourceUrl: z.string().url().nullable().optional()` and `aliases: z.array(z.string()).optional().default([])`.

## Tests

**API integration** (`apps/api/tests/movements.ts`, all 52 tests pass — was 48 before, +4 new in the existing T1 GET-list block):

- `T1: thruster exposes sourceUrl` — seeds a movement with `sourceUrl: 'https://www.crossfit.com/essentials/the-thruster'`, asserts the field round-trips on the list response.
- `T1: thruster exposes aliases` — same fixture also has an alias, asserts the array element comes back.
- `T1: pull-up sourceUrl null when unset` — fixture without the field, asserts it's `null` not `undefined` on the response.
- `T1: pull-up aliases empty when unset` — same fixture, asserts the array is empty (default `[]` from Prisma).

The full movement test sweep, plus the rest of the API suite (47 tests in workouts.ts, etc.) all pass.

**Lint / build** — `npx turbo lint` clean. `npm run build` clean for `@wodalytics/db`, `@wodalytics/types`, `@wodalytics/api`.

**Not automated / manual verification needed:**
- [ ] None — read paths already covered by the integration test, no new write paths exposed yet (the seeder PR uses Prisma direct upsert).

## Follow-up

A separate PR adds a one-shot job (`apps/api/src/jobs/seedCrossfitMovements.ts`) that upserts the static CrossFit catalog with `sourceUrl` and per-movement `aliases`. Once both PRs land, the QA database can be populated by triggering the new Railway cron service.
