### PR TITLE
feat(web): movement detection as accept/dismiss suggestion pills

### DIFF
--- a/apps/web/src/components/WorkoutDrawer.test.tsx
+++ b/apps/web/src/components/WorkoutDrawer.test.tsx
@@ -21,8 +21,12 @@ vi.mock('../lib/api', () => ({
   },
 }))
 
+// Tests that need a populated catalog (e.g. suggestion-pill flow) override
+// this with vi.doMock or vi.mocked — the default empty list keeps the older
+// autosave / prescription specs unchanged.
+const movementsCatalog: { id: string; name: string; parentId: string | null }[] = []
 vi.mock('../context/MovementsContext.tsx', () => ({
-  useMovements: () => [],
+  useMovements: () => movementsCatalog,
 }))
 
 import { api } from '../lib/api'
@@ -325,6 +329,90 @@ describe('WorkoutDrawer prescription editor', () => {
     expect(payload).toMatchObject({
       movements: [{ movementId: 'mv-1', tracksLoad: false }],
     })
+  })
+})
+
+describe('WorkoutDrawer movement suggestions', () => {
+  const SNATCH_VARIANTS = [
+    { id: 'mv-snatch',          name: 'Snatch',              parentId: null },
+    { id: 'mv-power-snatch',    name: 'Power Snatch',        parentId: null },
+    { id: 'mv-hang-snatch',     name: 'Hang Snatch',         parentId: null },
+    { id: 'mv-muscle-snatch',   name: 'Muscle Snatch',       parentId: null },
+    { id: 'mv-snatch-balance',  name: 'Snatch Balance',      parentId: null },
+  ]
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.clearAllMocks()
+    seedApi()
+    movementsCatalog.length = 0
+    movementsCatalog.push(...SNATCH_VARIANTS)
+    vi.mocked(api.movements.detect).mockResolvedValue(SNATCH_VARIANTS as never)
+  })
+
+  async function typeSnatchAndAwaitSuggestions(user: ReturnType<typeof userEvent.setup>) {
+    await waitFor(() => expect(screen.getByRole('option', { name: 'General' })).toBeInTheDocument())
+    await user.type(screen.getByPlaceholderText('e.g. Fran'), 'Snatch Day')
+    await user.type(screen.getByPlaceholderText(/Workout details/), 'snatch')
+    await act(async () => { vi.advanceTimersByTime(1000) })
+    await waitFor(() => expect(api.movements.detect).toHaveBeenCalled())
+  }
+
+  it('detection populates suggestion pills without auto-adding to selectedMovements', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const props = defaultProps()
+    render(<WorkoutDrawer {...props} />)
+
+    await typeSnatchAndAwaitSuggestions(user)
+
+    // All five matched movements appear as suggestion pills, but NONE has a
+    // PrescriptionRow yet — selectedMovements stays empty until the user
+    // clicks ✓.
+    for (const m of SNATCH_VARIANTS) {
+      expect(screen.getByLabelText(`Add ${m.name}`)).toBeInTheDocument()
+      expect(screen.getByLabelText(`Dismiss ${m.name}`)).toBeInTheDocument()
+    }
+    // No prescription row has rendered (the row exposes a "Sets" input).
+    expect(screen.queryByLabelText('Sets')).not.toBeInTheDocument()
+
+    // Autosave shouldn't have fired purely from suggestions appearing.
+    expect(api.workouts.create).not.toHaveBeenCalled()
+  })
+
+  it('accepting a suggestion promotes it to selectedMovements and removes the pill', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    render(<WorkoutDrawer {...defaultProps()} />)
+
+    await typeSnatchAndAwaitSuggestions(user)
+
+    await user.click(screen.getByLabelText('Add Power Snatch'))
+
+    // Pill is gone.
+    expect(screen.queryByLabelText('Add Power Snatch')).not.toBeInTheDocument()
+    // Movement now has its prescription row (the row's remove button uses
+    // the same "Remove {name}" aria-label as the existing fixtures expect).
+    expect(screen.getByLabelText('Remove Power Snatch')).toBeInTheDocument()
+    // Other suggestions remain available.
+    expect(screen.getByLabelText('Add Snatch')).toBeInTheDocument()
+  })
+
+  it('dismissing a suggestion removes the pill and keeps it dismissed across re-detection', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    render(<WorkoutDrawer {...defaultProps()} />)
+
+    await typeSnatchAndAwaitSuggestions(user)
+
+    await user.click(screen.getByLabelText('Dismiss Hang Snatch'))
+    expect(screen.queryByLabelText('Add Hang Snatch')).not.toBeInTheDocument()
+
+    // Trigger another detection by extending the description; Hang Snatch
+    // must NOT reappear because it is now dismissed.
+    await user.type(screen.getByPlaceholderText(/Workout details/), ' workout')
+    await act(async () => { vi.advanceTimersByTime(1000) })
+    await waitFor(() => expect(api.movements.detect).toHaveBeenCalledTimes(2))
+
+    expect(screen.queryByLabelText('Add Hang Snatch')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Add Snatch')).toBeInTheDocument()
   })
 })
 

--- a/apps/web/src/components/WorkoutDrawer.tsx
+++ b/apps/web/src/components/WorkoutDrawer.tsx
@@ -198,6 +198,7 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
   const [namedWorkouts, setNamedWorkouts] = useState<NamedWorkout[]>([])
   const [namedWorkoutId, setNamedWorkoutId] = useState<string | null>(null)
   const [selectedMovements, setSelectedMovements] = useState<Movement[]>([])
+  const [suggestedMovementIds, setSuggestedMovementIds] = useState<string[]>([])
   const [prescriptions, setPrescriptions] = useState<Record<string, PrescriptionForm>>({})
   const [timeCapInput, setTimeCapInput] = useState<string>('')
   const [tracksRounds, setTracksRounds] = useState<boolean>(false)
@@ -279,6 +280,7 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     setTracksRounds(workout?.tracksRounds ?? false)
     setShowAllColumns(false)
     setDismissedIds(new Set())
+    setSuggestedMovementIds([])
     setMovementSearch('')
     setSearchOpen(false)
     setSuggestError(null)
@@ -431,26 +433,42 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, snapshot, canAutosave, localWorkoutId])
 
-  // Auto-detect movements from description (debounced 800ms)
+  // Auto-detect movements from description (debounced 800ms). Detection
+  // produces suggestions, not auto-tags — the programmer accepts each one
+  // explicitly via the pill ✓ / ✗ controls below the prescription rows.
   useEffect(() => {
     if (!isOpen || !description.trim() || allMovements.length === 0) return
     const timer = setTimeout(() => {
       setDetectLoading(true)
       api.movements.detect(description)
         .then((detected) => {
-          setSelectedMovements((prev) => {
-            const currentIds = new Set(prev.map((m) => m.id))
-            const toAdd = detected.filter((m) => !currentIds.has(m.id) && !dismissedIds.has(m.id))
-            return toAdd.length > 0 ? [...prev, ...toAdd] : prev
-          })
+          const selectedIds = new Set(selectedMovements.map((m) => m.id))
+          const fresh = detected
+            .filter((m) => !selectedIds.has(m.id) && !dismissedIds.has(m.id))
+            .map((m) => m.id)
+          setSuggestedMovementIds(fresh)
         })
         .catch(() => {})
         .finally(() => setDetectLoading(false))
     }, 800)
     return () => clearTimeout(timer)
-    // dismissedIds intentionally omitted — closure captures current value without triggering re-runs on dismiss
+    // selectedMovements + dismissedIds intentionally omitted — captured at
+    // setup time, refreshed on the next description change. Avoids re-firing
+    // the detect API on every accept/dismiss.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [description, isOpen, allMovements.length])
+
+  function acceptSuggestion(id: string) {
+    const movement = allMovements.find((m) => m.id === id)
+    if (!movement) return
+    setSelectedMovements((prev) => (prev.some((m) => m.id === id) ? prev : [...prev, movement]))
+    setSuggestedMovementIds((prev) => prev.filter((sid) => sid !== id))
+  }
+
+  function dismissSuggestion(id: string) {
+    setDismissedIds((prev) => new Set(prev).add(id))
+    setSuggestedMovementIds((prev) => prev.filter((sid) => sid !== id))
+  }
 
   function handleApplyTemplate() {
     const nw = namedWorkouts.find((n) => n.id === namedWorkoutId)
@@ -460,6 +478,7 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     setDescription(nw.templateWorkout.description)
     setSelectedMovements(nw.templateWorkout.workoutMovements?.map((wm) => wm.movement) ?? [])
     setDismissedIds(new Set())
+    setSuggestedMovementIds([])
   }
 
   // When the clipboard carries HTML (e.g., a table copied from a web page), convert
@@ -912,6 +931,39 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
                     >
                       {showAllColumns ? '− Hide unused columns' : '+ Show all columns'}
                     </button>
+                  </div>
+                )}
+
+                {suggestedMovementIds.length > 0 && (
+                  <div className="mb-2 flex flex-wrap gap-1.5" data-testid="movement-suggestions">
+                    {suggestedMovementIds.map((id) => {
+                      const m = allMovements.find((x) => x.id === id)
+                      if (!m) return null
+                      return (
+                        <span
+                          key={id}
+                          className="inline-flex items-center gap-0.5 pl-2.5 pr-0.5 py-0.5 rounded-full text-xs bg-indigo-900/40 border border-indigo-700/40 text-indigo-200"
+                        >
+                          <span className="mr-1">{m.name}</span>
+                          <button
+                            type="button"
+                            onClick={() => acceptSuggestion(id)}
+                            aria-label={`Add ${m.name}`}
+                            className="w-7 h-7 inline-flex items-center justify-center rounded-full text-emerald-400 hover:bg-emerald-500/20 hover:text-emerald-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900"
+                          >
+                            ✓
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => dismissSuggestion(id)}
+                            aria-label={`Dismiss ${m.name}`}
+                            className="w-7 h-7 inline-flex items-center justify-center rounded-full text-rose-400 hover:bg-rose-500/20 hover:text-rose-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900"
+                          >
+                            ✗
+                          </button>
+                        </span>
+                      )
+                    })}
                   </div>
                 )}
 


### PR DESCRIPTION
## Summary

The `WorkoutDrawer` used to auto-tag every movement that `detectMovementsInText` returned, which got noisy after the alias-aware fuzzy match landed in #177 — typing "snatch" auto-added 8+ Snatch variants, each rendering its own sets/reps panel. Detection results now populate a separate `suggestedMovementIds` tray that renders as pills with ✓ / ✗ controls; the programmer accepts each one into the prescription editor explicitly.

- New `suggestedMovementIds` state, separate from `selectedMovements`.
- Each `detect()` response is filtered against current `selectedMovements` + `dismissedIds`, so already-accepted or dismissed movements never reappear.
- Accepting promotes the movement into `selectedMovements` (existing `PrescriptionRow` flow takes over from there).
- Dismissing adds the id to `dismissedIds` and removes the pill — same mechanism the `×` on a row already used. Dismissals reset on drawer close, per the issue's "out of scope" note.
- Autosave snapshot still excludes suggestions, so opening the drawer + typing alone never fires an autosave.

Closes #178

## Tests

**Unit** (`apps/web/src/components/WorkoutDrawer.test.tsx`) — three new specs in the *movement suggestions* describe block, plus the existing 10 still pass:
- `detection populates suggestion pills without auto-adding to selectedMovements` — five Snatch variants surface as pills (✓ / ✗ buttons each), but no `PrescriptionRow` (no `Sets` input) appears, and `api.workouts.create` is not called purely from suggestions appearing.
- `accepting a suggestion promotes it to selectedMovements and removes the pill` — clicking ✓ on Power Snatch makes its pill disappear and a `Remove Power Snatch` row appear; other suggestions are unaffected.
- `dismissing a suggestion removes the pill and keeps it dismissed across re-detection` — ✗ on Hang Snatch removes the pill; typing more description re-fires `detect()` but Hang Snatch is filtered out, while other suggestions still surface.

**API integration / Playwright E2E:** none added. This change is UI-only — no API surface or schema changes — and existing API/E2E suites don't drive the detection-suggestion UX. The detection endpoint itself is already covered by `apps/api/tests/movements.ts` (T11–T13) and unchanged here.

**Not automated / manual verification needed:**
- [x] Visual polish of the indigo pill styling against the dark drawer background (color, spacing, ✓ / ✗ icon weight).

**Mobile parity:** desk-suitable only — `WorkoutDrawer` has no mobile counterpart (the mobile app doesn't expose workout creation). Per #178: file a sibling mobile issue against #130 if/when a mobile authoring surface is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)