### PR TITLE
feat(admin): read-only admin program list + detail (slice 2 of #160)

### DIFF
--- a/apps/api/src/db/programDbManager.ts
+++ b/apps/api/src/db/programDbManager.ts
@@ -65,6 +65,35 @@ export async function ensureProgramIsPublic(programId: string) {
 }
 
 /**
+ * Lists every program with no `GymProgram` link, regardless of caller
+ * subscription. Used by the WODalytics admin surface (#160) to enumerate
+ * programs that need curation. Differs from `findUnaffiliatedPublicProgramsForUser`
+ * which excludes the caller's own subscriptions for the public-catalog browse
+ * use case — admins need the full list.
+ */
+export async function findAllUnaffiliatedPrograms() {
+  return prisma.program.findMany({
+    where: { gyms: { none: {} } },
+    orderBy: { createdAt: 'desc' },
+    include: { _count: { select: { members: true, workouts: true } } },
+  })
+}
+
+/**
+ * Look up a single unaffiliated program by id with the same `_count` shape
+ * the list endpoint returns. Returns null when the program either does not
+ * exist or has any `GymProgram` link — that second case keeps the admin
+ * surface from straying onto gym-affiliated programs (a separate auth
+ * boundary). Callers should treat null as 404.
+ */
+export async function findUnaffiliatedProgramByIdWithCounts(id: string) {
+  return prisma.program.findFirst({
+    where: { id, gyms: { none: {} } },
+    include: { _count: { select: { members: true, workouts: true } } },
+  })
+}
+
+/**
  * Lists PUBLIC programs that are NOT linked to any gym (e.g. the CrossFit
  * Mainsite WOD program created by the ingest job) and that the caller has
  * not already subscribed to. Drives the "Public programs" section of the

--- a/apps/api/src/db/workoutDbManager.ts
+++ b/apps/api/src/db/workoutDbManager.ts
@@ -229,6 +229,22 @@ export async function countWorkoutsByProgramId(programId: string): Promise<numbe
   return prisma.workout.count({ where: { programId } })
 }
 
+// Used by the WODalytics admin surface (#160) to list every workout under a
+// program without gym scoping. Newest first by scheduledAt — admins typically
+// want to see the latest entry from an ingest job at the top.
+export async function findWorkoutsByProgramId(programId: string) {
+  return prisma.workout.findMany({
+    where: { programId },
+    orderBy: [{ scheduledAt: 'desc' }, { dayOrder: 'asc' }, { createdAt: 'asc' }],
+    include: {
+      program: programSelect,
+      namedWorkout: namedWorkoutSelect,
+      _count: { select: { results: true } },
+      ...workoutMovementsInclude,
+    },
+  })
+}
+
 export async function updateWorkout(id: string, data: UpdateWorkoutData) {
   const { movementIds, movements, ...rest } = data
   const prescriptions = toPrescriptionList(movementIds, movements)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -14,6 +14,7 @@ import userProfileRouter from './routes/userProfile'
 import membershipRequestsRouter from './routes/membershipRequests'
 import avatarRouter from './routes/avatar'
 import gymLogoRouter from './routes/gymLogo'
+import adminRouter from './routes/admin'
 import { createLogger } from './lib/logger.js'
 import { requestLogger } from './middleware/requestLogger.js'
 
@@ -64,6 +65,7 @@ app.use('/api', userProfileRouter)
 app.use('/api', membershipRequestsRouter)
 app.use('/api', avatarRouter)
 app.use('/api', gymLogoRouter)
+app.use('/api', adminRouter)
 
 // Static-file route for the LocalFsImageStorage backend (dev-only). When
 // AWS_S3_BUCKET is set we never write here; the route is harmless to leave

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,0 +1,63 @@
+/**
+ * WODalytics admin surface (#160). Curates unaffiliated/public-catalog
+ * programs (e.g. the CrossFit Mainsite ingest) without granting access to any
+ * gym-scoped data. Slice 2 is read-only — list, detail, workouts. Slice 3
+ * adds mutations behind the same `requireWodalyticsAdmin` gate.
+ *
+ * Every route is gated by `requireAuth + requireWodalyticsAdmin`. Empty /
+ * unset `WODALYTICS_ADMIN_EMAILS` → 403 (deny by default).
+ */
+import { Router } from 'express'
+import type { Request, Response } from 'express'
+import { requireAuth, requireWodalyticsAdmin } from '../middleware/auth.js'
+import {
+  findAllUnaffiliatedPrograms,
+  findUnaffiliatedProgramByIdWithCounts,
+} from '../db/programDbManager.js'
+import { findWorkoutsByProgramId } from '../db/workoutDbManager.js'
+
+const router = Router()
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+router.get('/admin/programs', requireAuth, requireWodalyticsAdmin, listAdminPrograms)
+router.get('/admin/programs/:id', requireAuth, requireWodalyticsAdmin, getAdminProgramById)
+router.get(
+  '/admin/programs/:id/workouts',
+  requireAuth,
+  requireWodalyticsAdmin,
+  listAdminProgramWorkouts,
+)
+
+export default router
+
+// ─── Handler functions ────────────────────────────────────────────────────────
+
+async function listAdminPrograms(_req: Request, res: Response) {
+  const programs = await findAllUnaffiliatedPrograms()
+  res.json(programs)
+}
+
+async function getAdminProgramById(req: Request, res: Response) {
+  const id = req.params.id as string
+  const program = await findUnaffiliatedProgramByIdWithCounts(id)
+  if (!program) {
+    res.status(404).json({ error: 'Program not found' })
+    return
+  }
+  res.json(program)
+}
+
+async function listAdminProgramWorkouts(req: Request, res: Response) {
+  const id = req.params.id as string
+  // Re-check the program is unaffiliated. Without this an admin could read
+  // a gym-scoped program's workouts via the admin path, which would muddle
+  // the auth boundary.
+  const program = await findUnaffiliatedProgramByIdWithCounts(id)
+  if (!program) {
+    res.status(404).json({ error: 'Program not found' })
+    return
+  }
+  const workouts = await findWorkoutsByProgramId(id)
+  res.json(workouts)
+}

--- a/apps/api/tests/admin-programs.ts
+++ b/apps/api/tests/admin-programs.ts
@@ -1,0 +1,231 @@
+/**
+ * Integration tests for the WODalytics admin program endpoints (slice 2 of #160).
+ *
+ * Covers:
+ *   - Auth gates (401 / 403 / 200) on /api/admin/programs[/<id>[/workouts]]
+ *   - Listing returns unaffiliated programs but excludes gym-affiliated ones
+ *   - Detail returns 404 for gym-affiliated or unknown programs
+ *   - Workouts endpoint returns workouts for an unaffiliated program and
+ *     404s for an affiliated one
+ *
+ * Requires: API running (default localhost:3000, or worktree-picked port via
+ * API_URL), DB accessible via DATABASE_URL, WODALYTICS_ADMIN_EMAILS set in
+ * .env to match what the API server is reading at request time.
+ *
+ * Run: cd apps/api && npx tsx tests/admin-programs.ts
+ */
+
+import { prisma } from '@wodalytics/db'
+import { signTokenPair } from '../src/lib/jwt.js'
+import { parseAdminEmails } from '../src/middleware/auth.js'
+
+const BASE = process.env.API_URL ?? 'http://localhost:3000/api'
+let pass = 0
+let fail = 0
+
+function check(label: string, expected: unknown, actual: unknown) {
+  if (String(expected) === String(actual)) {
+    console.log(`  ✓ ${label}`)
+    pass++
+  } else {
+    console.log(`  ✗ ${label}  [expected=${expected} actual=${actual}]`)
+    fail++
+  }
+}
+
+async function api(method: string, path: string, token?: string) {
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  const res = await fetch(`${BASE}${path}`, { method, headers })
+  const text = await res.text()
+  let json: unknown
+  try {
+    json = JSON.parse(text)
+  } catch {
+    json = text
+  }
+  return { status: res.status, body: json as Record<string, unknown> | unknown[] }
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const TS = Date.now()
+let adminUserId = ''
+let nonAdminUserId = ''
+let adminUserCreated = false
+let adminToken = ''
+let nonAdminToken = ''
+let unaffiliatedProgramId = ''
+let affiliatedProgramId = ''
+let unaffiliatedWorkoutId = ''
+let affiliatedGymId = ''
+
+async function setup() {
+  console.log('\n=== Setup ===')
+
+  const allowed = [...parseAdminEmails(process.env.WODALYTICS_ADMIN_EMAILS)]
+  if (allowed.length === 0) {
+    throw new Error('WODALYTICS_ADMIN_EMAILS must be set in .env to run admin-programs tests')
+  }
+  const adminEmail = allowed[0]
+
+  const existingAdmin = await prisma.user.findUnique({ where: { email: adminEmail } })
+  if (existingAdmin) {
+    adminUserId = existingAdmin.id
+  } else {
+    const created = await prisma.user.create({ data: { email: adminEmail } })
+    adminUserId = created.id
+    adminUserCreated = true
+  }
+
+  const nonAdmin = await prisma.user.create({ data: { email: `admin-prog-nonadmin-${TS}@test.com` } })
+  nonAdminUserId = nonAdmin.id
+
+  adminToken = signTokenPair(adminUserId, 'OWNER').accessToken
+  nonAdminToken = signTokenPair(nonAdminUserId, 'MEMBER').accessToken
+
+  // Unaffiliated program (admin should see it).
+  const unaffiliated = await prisma.program.create({
+    data: {
+      name: `Admin-Unaffiliated-${TS}`,
+      visibility: 'PUBLIC',
+      startDate: new Date('2026-04-01'),
+    },
+  })
+  unaffiliatedProgramId = unaffiliated.id
+
+  // Workout under the unaffiliated program.
+  const workout = await prisma.workout.create({
+    data: {
+      programId: unaffiliated.id,
+      title: `Admin-Workout-${TS}`,
+      description: 'For Time: 21-15-9 Thrusters / Pull-ups',
+      type: 'FOR_TIME',
+      status: 'PUBLISHED',
+      scheduledAt: new Date('2026-04-15T10:00:00Z'),
+    },
+  })
+  unaffiliatedWorkoutId = workout.id
+
+  // Affiliated program (admin should NOT see it via this surface).
+  const gym = await prisma.gym.create({
+    data: { name: `Admin-Test-Gym-${TS}`, slug: `admin-test-gym-${TS}`, timezone: 'UTC' },
+  })
+  affiliatedGymId = gym.id
+  const affiliated = await prisma.program.create({
+    data: {
+      name: `Admin-Affiliated-${TS}`,
+      visibility: 'PUBLIC',
+      startDate: new Date('2026-04-01'),
+      gyms: { create: { gymId: gym.id } },
+    },
+  })
+  affiliatedProgramId = affiliated.id
+
+  console.log(`  admin=${adminUserId} (${adminEmail})`)
+  console.log(`  unaffiliated=${unaffiliatedProgramId}  workout=${unaffiliatedWorkoutId}`)
+  console.log(`  affiliated=${affiliatedProgramId}  gym=${affiliatedGymId}`)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+async function runTests() {
+  console.log('\n=== GET /api/admin/programs ===')
+
+  {
+    const r = await api('GET', '/admin/programs')
+    check('T1: no auth → 401', 401, r.status)
+  }
+  {
+    const r = await api('GET', '/admin/programs', nonAdminToken)
+    check('T2: non-admin → 403', 403, r.status)
+  }
+  {
+    const r = await api('GET', '/admin/programs', adminToken)
+    check('T3: admin → 200', 200, r.status)
+    const arr = r.body as Array<{ id: string; name: string }>
+    check('T3: returns array', true, Array.isArray(arr))
+    check('T3: includes unaffiliated program', true, arr.some((p) => p.id === unaffiliatedProgramId))
+    check('T3: excludes affiliated program', false, arr.some((p) => p.id === affiliatedProgramId))
+  }
+
+  console.log('\n=== GET /api/admin/programs/:id ===')
+  {
+    const r = await api('GET', `/admin/programs/${unaffiliatedProgramId}`)
+    check('T4: no auth → 401', 401, r.status)
+  }
+  {
+    const r = await api('GET', `/admin/programs/${unaffiliatedProgramId}`, nonAdminToken)
+    check('T5: non-admin → 403', 403, r.status)
+  }
+  {
+    const r = await api('GET', `/admin/programs/${unaffiliatedProgramId}`, adminToken)
+    check('T6: admin → 200', 200, r.status)
+    const body = r.body as { id: string; _count: { workouts: number } }
+    check('T6: id matches', unaffiliatedProgramId, body.id)
+    check('T6: _count.workouts present', true, typeof body._count?.workouts === 'number')
+  }
+  {
+    const r = await api('GET', `/admin/programs/${affiliatedProgramId}`, adminToken)
+    check('T7: admin GET on affiliated program → 404', 404, r.status)
+  }
+  {
+    const r = await api('GET', `/admin/programs/does-not-exist-${TS}`, adminToken)
+    check('T8: admin GET unknown id → 404', 404, r.status)
+  }
+
+  console.log('\n=== GET /api/admin/programs/:id/workouts ===')
+  {
+    const r = await api('GET', `/admin/programs/${unaffiliatedProgramId}/workouts`)
+    check('T9: no auth → 401', 401, r.status)
+  }
+  {
+    const r = await api('GET', `/admin/programs/${unaffiliatedProgramId}/workouts`, nonAdminToken)
+    check('T10: non-admin → 403', 403, r.status)
+  }
+  {
+    const r = await api('GET', `/admin/programs/${unaffiliatedProgramId}/workouts`, adminToken)
+    check('T11: admin → 200', 200, r.status)
+    const arr = r.body as Array<{ id: string; programId: string }>
+    check('T11: returns array', true, Array.isArray(arr))
+    check('T11: includes seeded workout', true, arr.some((w) => w.id === unaffiliatedWorkoutId))
+    check('T11: every row tagged with the program', true, arr.every((w) => w.programId === unaffiliatedProgramId))
+  }
+  {
+    const r = await api('GET', `/admin/programs/${affiliatedProgramId}/workouts`, adminToken)
+    check('T12: admin workouts on affiliated program → 404', 404, r.status)
+  }
+}
+
+// ─── Teardown ─────────────────────────────────────────────────────────────────
+
+async function teardown() {
+  console.log('\n=== Teardown ===')
+  await prisma.workout.deleteMany({ where: { programId: { in: [unaffiliatedProgramId, affiliatedProgramId] } } }).catch(() => {})
+  await prisma.gymProgram.deleteMany({ where: { programId: affiliatedProgramId } }).catch(() => {})
+  await prisma.program.delete({ where: { id: unaffiliatedProgramId } }).catch(() => {})
+  await prisma.program.delete({ where: { id: affiliatedProgramId } }).catch(() => {})
+  await prisma.gym.delete({ where: { id: affiliatedGymId } }).catch(() => {})
+  await prisma.user.delete({ where: { id: nonAdminUserId } }).catch(() => {})
+  if (adminUserCreated) await prisma.user.delete({ where: { id: adminUserId } }).catch(() => {})
+  console.log('  cleaned up')
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  try {
+    await setup()
+    await runTests()
+  } finally {
+    await teardown()
+    await prisma.$disconnect()
+  }
+  console.log(`\n=== Results: ${pass} passed, ${fail} failed ===\n`)
+  if (fail > 0) process.exit(1)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -27,6 +27,8 @@ import Feed from './pages/Feed.tsx'
 import WodDetail from './pages/WodDetail.tsx'
 import WodResultDetail from './pages/WodResultDetail.tsx'
 import History from './pages/History.tsx'
+import AdminProgramsIndex from './pages/AdminProgramsIndex.tsx'
+import AdminProgramDetail from './pages/AdminProgramDetail.tsx'
 
 export function PageErrorFallback({ error, resetErrorBoundary }: { error: unknown; resetErrorBoundary: () => void }) {
   const navigate = useNavigate()
@@ -79,6 +81,15 @@ function AppLayout() {
               <Route path="/gyms/new" element={<GymCreate />} />
               <Route path="/profile" element={<Profile />} />
               <Route path="/gym-settings" element={<GymSettings />} />
+              {/*
+                * WODalytics admin (#160). Server enforces the admin gate; the
+                * sidebar additionally hides the entry point for non-admins.
+                * Direct navigation to these routes for a non-admin will load
+                * the page shell, then 403 on the API call and surface the
+                * error inline (no redirect — failure is visible).
+                */}
+              <Route path="/admin/programs" element={<AdminProgramsIndex />} />
+              <Route path="/admin/programs/:id" element={<AdminProgramDetail />} />
               {/* Legacy aliases — old bookmarks and deep links still resolve. */}
               <Route path="/settings" element={<Navigate to="/gym-settings" replace />} />
               <Route path="/members" element={<Navigate to="/gym-settings#members" replace />} />

--- a/apps/web/src/components/ProgramCard.tsx
+++ b/apps/web/src/components/ProgramCard.tsx
@@ -1,0 +1,53 @@
+import { Link } from 'react-router-dom'
+import type { Program } from '../lib/api'
+import { VisibilityBadge, DefaultBadge } from '../pages/ProgramDetail'
+
+function formatDateRange(start: string, end: string | null): string {
+  const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', year: 'numeric' }
+  const s = new Date(start).toLocaleDateString(undefined, opts)
+  if (!end) return `From ${s}`
+  const e = new Date(end).toLocaleDateString(undefined, opts)
+  return `${s} – ${e}`
+}
+
+interface ProgramCardProps {
+  program: Program
+  // The card's URL. Gym-scoped + admin lists both link to a program detail
+  // page but at different paths, so the consumer supplies the link.
+  to: string
+  // Gym-default star — only shown when the program is the gym's default program.
+  // null/undefined for admin (unaffiliated programs have no gym default).
+  isDefault?: boolean
+}
+
+export default function ProgramCard({ program, to, isDefault }: ProgramCardProps) {
+  const stripe = program.coverColor ?? '#374151'
+  const memberCount = program._count?.members ?? 0
+  const workoutCount = program._count?.workouts ?? 0
+  return (
+    <Link
+      to={to}
+      className="group bg-gray-900 border border-gray-800 rounded-lg overflow-hidden hover:border-gray-700 transition-colors"
+    >
+      <div style={{ backgroundColor: stripe }} className="h-1.5 w-full" />
+      <div className="p-4">
+        <div className="flex items-start gap-2 flex-wrap">
+          <h3 className="font-semibold text-white truncate group-hover:text-indigo-300 transition-colors flex-1 min-w-0">
+            {program.name}
+          </h3>
+          {isDefault && <DefaultBadge className="shrink-0" />}
+          <VisibilityBadge visibility={program.visibility} className="shrink-0" />
+        </div>
+        {program.description && (
+          <p className="mt-1 text-xs text-gray-400 line-clamp-2">{program.description}</p>
+        )}
+        <p className="mt-3 text-xs text-gray-400">{formatDateRange(program.startDate, program.endDate)}</p>
+        <div className="mt-3 flex items-center gap-3 text-xs text-gray-400">
+          <span>{memberCount} {memberCount === 1 ? 'member' : 'members'}</span>
+          <span className="text-gray-700" aria-hidden="true">·</span>
+          <span>{workoutCount} {workoutCount === 1 ? 'workout' : 'workouts'}</span>
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/apps/web/src/components/ProgramOverviewMeta.tsx
+++ b/apps/web/src/components/ProgramOverviewMeta.tsx
@@ -1,0 +1,56 @@
+import type { Program } from '../lib/api'
+
+function fmt(d: string | null) {
+  return d ? new Date(d).toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' }) : '—'
+}
+
+interface ProgramOverviewMetaProps {
+  program: Program
+  // When provided, the members count becomes a button that fires `onOpenMembers`.
+  // Used by the gym-scoped page to jump to the Members tab. Admin path passes
+  // neither prop since unaffiliated programs don't surface members.
+  onOpenMembers?: () => void
+}
+
+/**
+ * Read-only overview block shared by gym-scoped `ProgramDetail` and the
+ * admin `AdminProgramDetail` page (#160). Renders start/end dates plus
+ * member + workout counts. Visual surface only — no scope-specific
+ * affordances live here.
+ */
+export default function ProgramOverviewMeta({ program, onOpenMembers }: ProgramOverviewMetaProps) {
+  const memberCount = program._count?.members ?? 0
+  const workoutCount = program._count?.workouts ?? 0
+  return (
+    <dl className="grid grid-cols-1 sm:grid-cols-2 gap-6 text-sm mb-8">
+      <div>
+        <dt className="text-xs uppercase tracking-wider text-gray-400 mb-1">Start date</dt>
+        <dd className="text-white">{fmt(program.startDate)}</dd>
+      </div>
+      <div>
+        <dt className="text-xs uppercase tracking-wider text-gray-400 mb-1">End date</dt>
+        <dd className="text-white">{fmt(program.endDate)}</dd>
+      </div>
+      <div>
+        <dt className="text-xs uppercase tracking-wider text-gray-400 mb-1">Members</dt>
+        <dd className="text-white">
+          {onOpenMembers ? (
+            <button
+              type="button"
+              onClick={onOpenMembers}
+              className="text-white hover:text-indigo-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 rounded"
+            >
+              {memberCount}
+            </button>
+          ) : (
+            memberCount
+          )}
+        </dd>
+      </div>
+      <div>
+        <dt className="text-xs uppercase tracking-wider text-gray-400 mb-1">Workouts</dt>
+        <dd className="text-white">{workoutCount}</dd>
+      </div>
+    </dl>
+  )
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -16,6 +16,12 @@ const staffLinks = [
   { to: '/gym-settings', label: 'Gym Settings' },
 ]
 
+// WODalytics admin (#160) — visible only to users on the WODALYTICS_ADMIN_EMAILS
+// allowlist (server checks via requireWodalyticsAdmin).
+const adminLinks = [
+  { to: '/admin/programs', label: 'Programs' },
+]
+
 interface SidebarProps {
   isOpen: boolean
   onClose: () => void
@@ -73,6 +79,31 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
               <span className="text-xs text-gray-400 uppercase tracking-widest">Staff</span>
             </div>
             {staffLinks.map(({ to, label }) => (
+              <NavLink
+                key={to}
+                to={to}
+                onClick={onClose}
+                className={({ isActive }) =>
+                  [
+                    'flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors',
+                    isActive
+                      ? 'bg-gray-800 text-white'
+                      : 'text-gray-400 hover:bg-gray-800 hover:text-white',
+                  ].join(' ')
+                }
+              >
+                {label}
+              </NavLink>
+            ))}
+          </>
+        )}
+
+        {user?.isWodalyticsAdmin && (
+          <>
+            <div className="pt-3 pb-1 px-3">
+              <span className="text-xs text-gray-400 uppercase tracking-widest">WODalytics Admin</span>
+            </div>
+            {adminLinks.map(({ to, label }) => (
               <NavLink
                 key={to}
                 to={to}

--- a/apps/web/src/lib/adminProgramScope.ts
+++ b/apps/web/src/lib/adminProgramScope.ts
@@ -1,0 +1,24 @@
+/**
+ * `ProgramScope` implementation for the WODalytics admin surface (#160).
+ * Wires the admin REST namespace into the shared program/workout components.
+ *
+ * Capabilities are static here: an authenticated admin (verified server-side
+ * by `requireWodalyticsAdmin`) has full read+write+delete on every
+ * unaffiliated program. The members tab and gym-default toggles are gym
+ * concepts and are deliberately off so the shared components hide them.
+ */
+import { api } from './api'
+import type { ProgramScope } from './programScope'
+
+export const adminProgramScope: ProgramScope = {
+  kind: 'admin',
+  capabilities: {
+    canWrite: true,
+    canDelete: true,
+    canSeeMembers: false,
+    canSetDefault: false,
+  },
+  list: () => api.admin.programs.list(),
+  get: (id) => api.admin.programs.get(id),
+  listWorkouts: (programId) => api.admin.programs.listWorkouts(programId),
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -830,4 +830,21 @@ export const api = {
     unsubscribe: (id: string, token?: string) =>
       req<void>(`/api/programs/${id}/subscribe`, { method: 'DELETE', token }),
   },
+
+  /**
+   * WODalytics admin surface (#160). Curates unaffiliated/public-catalog
+   * programs. Every endpoint is gated server-side by `requireWodalyticsAdmin`.
+   * The web app keys off `user.isWodalyticsAdmin` to render the entry point;
+   * this client surface is the data layer underneath.
+   */
+  admin: {
+    programs: {
+      list: (token?: string) =>
+        req<Program[]>(`/api/admin/programs`, { token }),
+      get: (id: string, token?: string) =>
+        req<Program>(`/api/admin/programs/${id}`, { token }),
+      listWorkouts: (id: string, token?: string) =>
+        req<Workout[]>(`/api/admin/programs/${id}/workouts`, { token }),
+    },
+  },
 }

--- a/apps/web/src/lib/programScope.ts
+++ b/apps/web/src/lib/programScope.ts
@@ -1,0 +1,40 @@
+/**
+ * ProgramScope — the contract that lets the same program / workout editing
+ * components serve both the gym-scoped path (`/programs/:id`) and the
+ * WODalytics admin path (`/admin/programs/:id`). Spec lives in #160.
+ *
+ * **Hard requirement (#160):** there must be exactly one set of editor
+ * components. The two routes mount the same components with different
+ * scope implementations — the components only see the scope interface, not
+ * gym vs admin specifics.
+ *
+ * Slice 2 (this slice) establishes the read-only surface — list, get,
+ * listWorkouts — and only the admin path uses it. The gym-scoped pages
+ * still call the `api.gyms.*` / `api.programs.*` clients directly. Slice 3
+ * grows the contract with mutations (`updateProgram`, `createWorkout`,
+ * `updateWorkout`, `deleteWorkout`, ...) and migrates the gym-scoped pages
+ * onto it as a side-effect of building the shared editor.
+ */
+import type { Program, Workout } from './api'
+
+export type ProgramScopeKind = 'gym' | 'admin'
+
+export interface ProgramScopeCapabilities {
+  canWrite: boolean
+  canDelete: boolean
+  canSeeMembers: boolean
+  canSetDefault: boolean
+}
+
+export interface ProgramScope {
+  kind: ProgramScopeKind
+  /**
+   * Caller-relative capability flags. The components keying off these are
+   * authoritative for hiding affordances; the API still enforces auth on
+   * every mutating call.
+   */
+  capabilities: ProgramScopeCapabilities
+  list(): Promise<Program[]>
+  get(id: string): Promise<Program>
+  listWorkouts(programId: string): Promise<Workout[]>
+}

--- a/apps/web/src/pages/AdminProgramDetail.test.tsx
+++ b/apps/web/src/pages/AdminProgramDetail.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { vi, describe, it, beforeEach, expect } from 'vitest'
+import AdminProgramDetail from './AdminProgramDetail'
+import type { Program, Workout } from '../lib/api'
+
+vi.mock('../lib/api', () => ({
+  api: {
+    admin: {
+      programs: { list: vi.fn(), get: vi.fn(), listWorkouts: vi.fn() },
+    },
+  },
+}))
+
+import { api } from '../lib/api'
+
+function makeProgram(): Program {
+  return {
+    id: 'p-1',
+    name: 'CrossFit Mainsite',
+    description: 'Daily WOD from CrossFit.com',
+    startDate: '2026-01-01T00:00:00.000Z',
+    endDate: null,
+    coverColor: null,
+    visibility: 'PUBLIC',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    _count: { members: 0, workouts: 1 },
+  }
+}
+
+function makeWorkout(overrides: Partial<Workout> = {}): Workout {
+  return {
+    id: overrides.id ?? 'w-1',
+    title: overrides.title ?? 'Fran',
+    description: '21-15-9 thrusters / pull-ups',
+    type: 'FOR_TIME',
+    status: 'PUBLISHED',
+    scheduledAt: '2026-04-15T10:00:00.000Z',
+    dayOrder: 0,
+    workoutMovements: [],
+    programId: 'p-1',
+    program: { id: 'p-1', name: 'CrossFit Mainsite' },
+    namedWorkoutId: null,
+    namedWorkout: null,
+    _count: { results: 0 },
+    createdAt: '2026-04-15T10:00:00.000Z',
+    updatedAt: '2026-04-15T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/admin/programs/p-1']}>
+      <Routes>
+        <Route path="/admin/programs/:id" element={<AdminProgramDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('AdminProgramDetail', () => {
+  beforeEach(() => {
+    vi.mocked(api.admin.programs.get).mockResolvedValue(makeProgram())
+    vi.mocked(api.admin.programs.listWorkouts).mockResolvedValue([])
+  })
+
+  it('renders without crashing', async () => {
+    renderPage()
+    expect(await screen.findByRole('heading', { name: 'CrossFit Mainsite' })).toBeInTheDocument()
+  })
+
+  it('renders the workouts section header', async () => {
+    renderPage()
+    expect(await screen.findByRole('heading', { name: 'Workouts' })).toBeInTheDocument()
+  })
+
+  it('lists workouts when present', async () => {
+    vi.mocked(api.admin.programs.listWorkouts).mockResolvedValue([
+      makeWorkout({ id: 'w-1', title: 'Fran' }),
+      makeWorkout({ id: 'w-2', title: 'Helen' }),
+    ])
+    renderPage()
+    expect(await screen.findByText('Fran')).toBeInTheDocument()
+    expect(await screen.findByText('Helen')).toBeInTheDocument()
+  })
+
+  it('shows empty-state copy when no workouts', async () => {
+    renderPage()
+    expect(await screen.findByText('No workouts yet.')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/pages/AdminProgramDetail.tsx
+++ b/apps/web/src/pages/AdminProgramDetail.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import type { Program, Workout } from '../lib/api'
+import { adminProgramScope } from '../lib/adminProgramScope'
+import { WORKOUT_TYPE_STYLES } from '../lib/workoutTypeStyles'
+import Skeleton from '../components/ui/Skeleton'
+import ProgramOverviewMeta from '../components/ProgramOverviewMeta'
+import { VisibilityBadge } from './ProgramDetail'
+
+/**
+ * WODalytics admin: program detail + workouts list (#160).
+ * Mounted at `/admin/programs/:id`. Read-only in slice 2; edit affordances
+ * land in slice 3 along with the shared editor components driven by the
+ * `ProgramScope` adapter.
+ *
+ * Reuses `ProgramOverviewMeta` and `VisibilityBadge` so the visual surface
+ * matches the gym-scoped `ProgramDetail` page exactly. The data shape
+ * differs (admin gets `Program`, gym path gets `GymProgram`) but the
+ * components only see fields that exist on both.
+ */
+export default function AdminProgramDetail() {
+  const { id } = useParams<{ id: string }>()
+  const [program, setProgram] = useState<Program | null>(null)
+  const [workouts, setWorkouts] = useState<Workout[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    const signal = { cancelled: false }
+    load(id, signal)
+    return () => { signal.cancelled = true }
+  }, [id])
+
+  async function load(programId: string, signal?: { cancelled: boolean }) {
+    setLoading(true)
+    setError(null)
+    try {
+      const [p, ws] = await Promise.all([
+        adminProgramScope.get(programId),
+        adminProgramScope.listWorkouts(programId),
+      ])
+      if (!signal?.cancelled) {
+        setProgram(p)
+        setWorkouts(ws)
+      }
+    } catch (e) {
+      if (!signal?.cancelled) setError((e as Error).message)
+    } finally {
+      if (!signal?.cancelled) setLoading(false)
+    }
+  }
+
+  if (loading) return <Skeleton variant="feed-row" count={3} />
+
+  if (!program) {
+    return (
+      <div>
+        <p className="text-red-400 mb-3">{error ?? 'Program not found.'}</p>
+        <Link to="/admin/programs" className="text-indigo-400 hover:text-indigo-300 text-sm">← Back to Admin · Programs</Link>
+      </div>
+    )
+  }
+
+  const stripe = program.coverColor ?? '#374151'
+
+  return (
+    <div>
+      <div className="mb-4">
+        <Link to="/admin/programs" className="text-xs text-indigo-400 hover:text-indigo-300">← Admin · Programs</Link>
+      </div>
+
+      <div className="flex items-start gap-4 mb-6">
+        <div style={{ backgroundColor: stripe }} className="w-1.5 h-12 rounded-full shrink-0" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h1 className="text-2xl font-bold truncate">{program.name}</h1>
+            <VisibilityBadge visibility={program.visibility} />
+          </div>
+          {program.description && (
+            <p className="mt-1 text-sm text-gray-400">{program.description}</p>
+          )}
+        </div>
+      </div>
+
+      {error && <p className="text-red-400 mb-4">{error}</p>}
+
+      <ProgramOverviewMeta program={program} />
+
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Workouts</h2>
+        {workouts.length === 0 ? (
+          <p className="text-sm text-gray-500">No workouts yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {workouts.map((w) => (
+              <AdminWorkoutRow key={w.id} workout={w} />
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}
+
+function AdminWorkoutRow({ workout }: { workout: Workout }) {
+  const style = WORKOUT_TYPE_STYLES[workout.type]
+  const date = new Date(workout.scheduledAt).toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+  return (
+    <li className="bg-gray-900 border border-gray-800 rounded-lg p-3 flex items-start gap-3">
+      <span
+        className={`shrink-0 inline-flex items-center justify-center w-10 h-10 rounded-md text-xs font-bold ${style.bg} ${style.tint}`}
+        aria-label={style.label}
+      >
+        {style.abbr}
+      </span>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <h3 className="font-medium text-white truncate">{workout.title}</h3>
+          {workout.status === 'DRAFT' && (
+            <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-300">
+              Draft
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-gray-400 mt-0.5">{date}</p>
+      </div>
+    </li>
+  )
+}

--- a/apps/web/src/pages/AdminProgramsIndex.test.tsx
+++ b/apps/web/src/pages/AdminProgramsIndex.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, beforeEach, expect } from 'vitest'
+import AdminProgramsIndex from './AdminProgramsIndex'
+import type { Program } from '../lib/api'
+
+vi.mock('../lib/api', () => ({
+  api: {
+    admin: {
+      programs: { list: vi.fn(), get: vi.fn(), listWorkouts: vi.fn() },
+    },
+  },
+}))
+
+import { api } from '../lib/api'
+
+function makeProgram(overrides: Partial<Program> = {}): Program {
+  return {
+    id: overrides.id ?? 'p-1',
+    name: overrides.name ?? 'CrossFit Mainsite',
+    description: overrides.description ?? null,
+    startDate: '2026-01-01T00:00:00.000Z',
+    endDate: null,
+    coverColor: null,
+    visibility: 'PUBLIC',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    _count: { members: 0, workouts: 42 },
+    ...overrides,
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/admin/programs']}>
+      <AdminProgramsIndex />
+    </MemoryRouter>,
+  )
+}
+
+describe('AdminProgramsIndex', () => {
+  beforeEach(() => {
+    vi.mocked(api.admin.programs.list).mockResolvedValue([])
+  })
+
+  it('renders without crashing', async () => {
+    renderPage()
+    expect(await screen.findByRole('heading', { name: /Admin · Programs/ })).toBeInTheDocument()
+  })
+
+  it('shows the empty state when no unaffiliated programs exist', async () => {
+    renderPage()
+    expect(await screen.findByText('No unaffiliated programs')).toBeInTheDocument()
+  })
+
+  it('lists program cards when the API returns programs', async () => {
+    vi.mocked(api.admin.programs.list).mockResolvedValue([
+      makeProgram({ id: 'p-1', name: 'CrossFit Mainsite' }),
+      makeProgram({ id: 'p-2', name: 'Hero WODs' }),
+    ])
+    renderPage()
+    expect(await screen.findByText('CrossFit Mainsite')).toBeInTheDocument()
+    expect(await screen.findByText('Hero WODs')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/pages/AdminProgramsIndex.tsx
+++ b/apps/web/src/pages/AdminProgramsIndex.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import type { Program } from '../lib/api'
+import { adminProgramScope } from '../lib/adminProgramScope'
+import EmptyState from '../components/ui/EmptyState'
+import Skeleton from '../components/ui/Skeleton'
+import ProgramCard from '../components/ProgramCard'
+
+/**
+ * WODalytics admin: list of unaffiliated/public-catalog programs (#160).
+ * Mounted at `/admin/programs`. Server gates via `requireWodalyticsAdmin`;
+ * the web app additionally hides the route from the sidebar for non-admins.
+ *
+ * Uses the shared `ProgramCard` component, same as the gym-scoped Programs
+ * page. The scope adapter (`adminProgramScope`) is the only piece that knows
+ * we're on the admin path.
+ */
+export default function AdminProgramsIndex() {
+  const [programs, setPrograms] = useState<Program[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const signal = { cancelled: false }
+    load(signal)
+    return () => { signal.cancelled = true }
+  }, [])
+
+  async function load(signal?: { cancelled: boolean }) {
+    setLoading(true)
+    setError(null)
+    try {
+      const list = await adminProgramScope.list()
+      if (!signal?.cancelled) setPrograms(list)
+    } catch (e) {
+      if (!signal?.cancelled) setError((e as Error).message)
+    } finally {
+      if (!signal?.cancelled) setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <div className="mb-6">
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl font-bold">Admin · Programs</h1>
+          <span className="bg-gray-700 text-sm px-2 py-0.5 rounded-full">{programs.length}</span>
+        </div>
+        <p className="mt-1 text-sm text-gray-400">
+          Unaffiliated programs surfaced from public sources (e.g. CrossFit Mainsite). Editable by WODalytics staff.
+        </p>
+      </div>
+
+      {error && <p className="text-red-400 mb-4">{error}</p>}
+      {loading && <Skeleton variant="feed-row" count={3} />}
+
+      {!loading && programs.length === 0 && !error && (
+        <EmptyState
+          title="No unaffiliated programs"
+          body="Programs imported from external sources will appear here once an ingest job runs."
+        />
+      )}
+
+      {programs.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {programs.map((p) => (
+            <ProgramCard key={p.id} program={p} to={`/admin/programs/${p.id}`} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/ProgramDetail.tsx
+++ b/apps/web/src/pages/ProgramDetail.tsx
@@ -6,6 +6,7 @@ import Button from '../components/ui/Button'
 import Skeleton from '../components/ui/Skeleton'
 import ProgramFormDrawer from '../components/ProgramFormDrawer'
 import ProgramMembersTab from '../components/ProgramMembersTab'
+import ProgramOverviewMeta from '../components/ProgramOverviewMeta'
 
 type Tab = 'overview' | 'members' | 'workouts'
 
@@ -197,11 +198,6 @@ function OverviewTab({
   onOpenMembers: () => void
   onDefaultChanged: () => void
 }) {
-  const memberCount = program._count?.members ?? 0
-  const workoutCount = program._count?.workouts ?? 0
-  const fmt = (d: string | null) =>
-    d ? new Date(d).toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' }) : '—'
-
   const [setDefaultLoading, setSetDefaultLoading] = useState(false)
   const [setDefaultError, setSetDefaultError] = useState<string | null>(null)
 
@@ -230,36 +226,10 @@ function OverviewTab({
 
   return (
     <>
-      <dl className="grid grid-cols-1 sm:grid-cols-2 gap-6 text-sm mb-8">
-        <div>
-          <dt className="text-xs uppercase tracking-wider text-gray-400 mb-1">Start date</dt>
-          <dd className="text-white">{fmt(program.startDate)}</dd>
-        </div>
-        <div>
-          <dt className="text-xs uppercase tracking-wider text-gray-400 mb-1">End date</dt>
-          <dd className="text-white">{fmt(program.endDate)}</dd>
-        </div>
-        <div>
-          <dt className="text-xs uppercase tracking-wider text-gray-400 mb-1">Members</dt>
-          <dd className="text-white">
-            {canSeeMembers ? (
-              <button
-                type="button"
-                onClick={onOpenMembers}
-                className="text-white hover:text-indigo-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 rounded"
-              >
-                {memberCount}
-              </button>
-            ) : (
-              memberCount
-            )}
-          </dd>
-        </div>
-        <div>
-          <dt className="text-xs uppercase tracking-wider text-gray-400 mb-1">Workouts</dt>
-          <dd className="text-white">{workoutCount}</dd>
-        </div>
-      </dl>
+      <ProgramOverviewMeta
+        program={program}
+        onOpenMembers={canSeeMembers ? onOpenMembers : undefined}
+      />
 
       {canSetDefault && (
         <div className="mb-6">

--- a/apps/web/src/pages/ProgramsIndex.tsx
+++ b/apps/web/src/pages/ProgramsIndex.tsx
@@ -1,20 +1,11 @@
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { api, type GymProgram, type Program } from '../lib/api'
 import { useGym } from '../context/GymContext.tsx'
 import Button from '../components/ui/Button'
 import EmptyState from '../components/ui/EmptyState'
 import Skeleton from '../components/ui/Skeleton'
 import ProgramFormDrawer from '../components/ProgramFormDrawer'
-import { VisibilityBadge, DefaultBadge } from './ProgramDetail'
-
-function formatDateRange(start: string, end: string | null): string {
-  const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', year: 'numeric' }
-  const s = new Date(start).toLocaleDateString(undefined, opts)
-  if (!end) return `From ${s}`
-  const e = new Date(end).toLocaleDateString(undefined, opts)
-  return `${s} – ${e}`
-}
+import ProgramCard from '../components/ProgramCard'
 
 export default function ProgramsIndex() {
   const { gymId, gymRole } = useGym()
@@ -88,7 +79,12 @@ export default function ProgramsIndex() {
       {gymPrograms.length > 0 && (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {gymPrograms.map((gp) => (
-            <ProgramCard key={gp.program.id} program={gp.program} isDefault={gp.isDefault} />
+            <ProgramCard
+              key={gp.program.id}
+              program={gp.program}
+              to={`/programs/${gp.program.id}`}
+              isDefault={gp.isDefault}
+            />
           ))}
         </div>
       )}
@@ -101,37 +97,5 @@ export default function ProgramsIndex() {
         onSaved={handleCreated}
       />
     </div>
-  )
-}
-
-function ProgramCard({ program, isDefault }: { program: Program; isDefault: boolean }) {
-  const stripe = program.coverColor ?? '#374151'
-  const memberCount = program._count?.members ?? 0
-  const workoutCount = program._count?.workouts ?? 0
-  return (
-    <Link
-      to={`/programs/${program.id}`}
-      className="group bg-gray-900 border border-gray-800 rounded-lg overflow-hidden hover:border-gray-700 transition-colors"
-    >
-      <div style={{ backgroundColor: stripe }} className="h-1.5 w-full" />
-      <div className="p-4">
-        <div className="flex items-start gap-2 flex-wrap">
-          <h3 className="font-semibold text-white truncate group-hover:text-indigo-300 transition-colors flex-1 min-w-0">
-            {program.name}
-          </h3>
-          {isDefault && <DefaultBadge className="shrink-0" />}
-          <VisibilityBadge visibility={program.visibility} className="shrink-0" />
-        </div>
-        {program.description && (
-          <p className="mt-1 text-xs text-gray-400 line-clamp-2">{program.description}</p>
-        )}
-        <p className="mt-3 text-xs text-gray-400">{formatDateRange(program.startDate, program.endDate)}</p>
-        <div className="mt-3 flex items-center gap-3 text-xs text-gray-400">
-          <span>{memberCount} {memberCount === 1 ? 'member' : 'members'}</span>
-          <span className="text-gray-700" aria-hidden="true">·</span>
-          <span>{workoutCount} {workoutCount === 1 ? 'workout' : 'workouts'}</span>
-        </div>
-      </div>
-    </Link>
   )
 }

--- a/apps/web/tests/admin-programs.spec.ts
+++ b/apps/web/tests/admin-programs.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Playwright E2E for the WODalytics admin program list + detail (#160 slice 2).
+ *
+ * Auth uses JWT cookie injection. The admin user is the first email in
+ * WODALYTICS_ADMIN_EMAILS — the API's `requireWodalyticsAdmin` middleware
+ * checks against the same env var, so seeding any user with a matching email
+ * passes the gate.
+ *
+ * Run via the worktree:
+ *   npm run test:worktree -- e2e tests/admin-programs.spec.ts
+ */
+
+import { test, expect } from '@playwright/test'
+import { randomUUID } from 'crypto'
+import { loginAs, prisma } from './lib/auth.js'
+
+interface AdminFixture {
+  adminUserId: string
+  programId: string
+  workoutId: string
+}
+
+function pickAdminEmail(): string {
+  const raw = process.env.WODALYTICS_ADMIN_EMAILS
+  if (!raw) throw new Error('WODALYTICS_ADMIN_EMAILS must be set in .env')
+  const parsed = raw.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean)
+  if (parsed.length === 0) throw new Error('WODALYTICS_ADMIN_EMAILS parsed to empty list')
+  return parsed[0]
+}
+
+async function seedAdminFixture(nameSuffix: string): Promise<AdminFixture> {
+  const adminEmail = pickAdminEmail()
+  // Upsert + never delete — the admin user is the same email across all
+  // parallel specs, so racing creates would collide on the unique-email
+  // constraint. Tolerating a long-lived admin row in the dev DB is fine.
+  const admin = await prisma.user.upsert({
+    where: { email: adminEmail },
+    update: {},
+    create: { email: adminEmail },
+  })
+  const adminUserId = admin.id
+
+  const program = await prisma.program.create({
+    data: {
+      name: `Admin E2E ${nameSuffix}`,
+      visibility: 'PUBLIC',
+      startDate: new Date('2026-04-01'),
+    },
+  })
+  const workout = await prisma.workout.create({
+    data: {
+      programId: program.id,
+      title: `Admin E2E Workout ${nameSuffix}`,
+      description: 'For Time: 21-15-9',
+      type: 'FOR_TIME',
+      status: 'PUBLISHED',
+      scheduledAt: new Date('2026-04-15T10:00:00Z'),
+    },
+  })
+
+  return { adminUserId, programId: program.id, workoutId: workout.id }
+}
+
+async function teardown(fx: AdminFixture, extraUserId?: string) {
+  await prisma.workout.delete({ where: { id: fx.workoutId } }).catch(() => {})
+  await prisma.program.delete({ where: { id: fx.programId } }).catch(() => {})
+  if (extraUserId) await prisma.user.delete({ where: { id: extraUserId } }).catch(() => {})
+  // Don't delete the admin user — it's the shared WODALYTICS_ADMIN_EMAILS
+  // user, reused across parallel specs and persistent in the dev DB.
+}
+
+test('admin sees the WODalytics Admin nav and can list + view an unaffiliated program', async ({ page, context }) => {
+  const fx = await seedAdminFixture(randomUUID().slice(0, 8))
+  try {
+    await loginAs(context, fx.adminUserId, 'OWNER')
+    await page.goto('/admin/programs')
+
+    // Sidebar nav header for admin.
+    await expect(page.getByText('WODalytics Admin')).toBeVisible()
+
+    // The seeded program shows up in the list.
+    const listLink = page.getByRole('link', { name: new RegExp(`Admin E2E `) }).first()
+    await expect(listLink).toBeVisible()
+
+    // Click into detail; verify program name + workouts section + the seeded workout.
+    await listLink.click()
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Admin E2E')
+    await expect(page.getByRole('heading', { name: 'Workouts' })).toBeVisible()
+    await expect(page.getByText(/Admin E2E Workout/)).toBeVisible()
+  } finally {
+    await teardown(fx)
+  }
+})
+
+test('non-admin user does not see the WODalytics Admin sidebar entry', async ({ page, context }) => {
+  const fx = await seedAdminFixture(randomUUID().slice(0, 8))
+  const ts = randomUUID().slice(0, 8)
+  const nonAdmin = await prisma.user.create({ data: { email: `admin-e2e-nonadmin-${ts}@test.com` } })
+  try {
+    await loginAs(context, nonAdmin.id, 'MEMBER')
+    await page.goto('/feed')
+
+    await expect(page.getByText('WODalytics Admin')).toHaveCount(0)
+
+    // Direct navigation to /admin/programs renders the page shell but the
+    // API call returns 403 — the heading still renders (no redirect) and
+    // no admin programs appear (the list comes from the 403'd API call).
+    await page.goto('/admin/programs')
+    await expect(page.getByRole('heading', { name: /Admin · Programs/ })).toBeVisible()
+    await expect(page.getByText(/Admin E2E /)).toHaveCount(0)
+  } finally {
+    await teardown(fx, nonAdmin.id)
+  }
+})


### PR DESCRIPTION
## Summary

Slice 2 of #160 — adds the WODalytics admin surface for browsing unaffiliated/public-catalog programs (e.g. the CrossFit Mainsite ingest) and their workouts. Read-only here; slice 3 layers editing on top of the **same** shared components.

- API: three gated `GET /api/admin/*` endpoints. Every route enforces `requireAuth + requireWodalyticsAdmin`. Affiliated (gym-linked) programs return 404 from this path, keeping the admin auth boundary clean.
- Web: `/admin/programs` list + `/admin/programs/:id` detail page, mounted via the `adminProgramScope` adapter and rendering the **shared** `ProgramCard` + `ProgramOverviewMeta` components also used by the gym-scoped pages.
- Sidebar gains a "WODalytics Admin" section keyed off `user.isWodalyticsAdmin` (visible to allowlisted emails only).
- `ProgramScope` contract introduced in `lib/programScope.ts` to formalize the no-duplicate-UI rule from #160. Slice 2 has one implementation (admin); slice 3 expands the contract with mutations and migrates the gym-scoped pages onto it as a side effect of building the shared editor.

Part of #160.

### Honoring the "shared UI" requirement

The parent issue called this out as non-negotiable. Concretely in this PR:

- `ProgramCard` is now a single component at `apps/web/src/components/ProgramCard.tsx`. Both `ProgramsIndex` (gym) and `AdminProgramsIndex` (admin) render it.
- `ProgramOverviewMeta` is the shared start-date / end-date / counts block, used by both `ProgramDetail` and `AdminProgramDetail`.
- The two badges (`VisibilityBadge`, `DefaultBadge`) continue to live in `pages/ProgramDetail.tsx` and are imported by the admin pages — same exports, same rendering.
- No `Admin*Editor.tsx` parallel components exist. Search the diff for `Admin` and you'll find page-level wrappers + the scope adapter only.

## Tests

**Unit** (`apps/web/src/pages/AdminProgramsIndex.test.tsx`):
- renders without crashing (heading visible)
- shows the empty state when no unaffiliated programs exist
- lists program cards when the API returns programs

**Unit** (`apps/web/src/pages/AdminProgramDetail.test.tsx`):
- renders without crashing (program heading visible)
- renders the workouts section header
- lists workouts when present
- shows empty-state copy when no workouts

**API integration** (`apps/api/tests/admin-programs.ts`):
- T1: `GET /api/admin/programs` no auth → 401
- T2: `GET /api/admin/programs` non-admin → 403
- T3: `GET /api/admin/programs` admin → 200, includes seeded unaffiliated program, excludes seeded gym-affiliated program
- T4: `GET /api/admin/programs/:id` no auth → 401
- T5: `GET /api/admin/programs/:id` non-admin → 403
- T6: `GET /api/admin/programs/:id` admin on unaffiliated program → 200 with `_count.workouts`
- T7: `GET /api/admin/programs/:id` admin on **affiliated** program → 404 (auth-boundary guard)
- T8: `GET /api/admin/programs/:id` admin on unknown id → 404
- T9: `GET /api/admin/programs/:id/workouts` no auth → 401
- T10: `GET /api/admin/programs/:id/workouts` non-admin → 403
- T11: `GET /api/admin/programs/:id/workouts` admin → 200, includes seeded workout, every row tagged with the program
- T12: `GET /api/admin/programs/:id/workouts` admin on affiliated program → 404

**Playwright E2E** (`apps/web/tests/admin-programs.spec.ts`):
- T1: admin sees the WODalytics Admin sidebar entry, can list and click into an unaffiliated program, sees the workouts section
- T2: non-admin user does not see the sidebar entry; direct navigation to `/admin/programs` renders the page heading but the list is empty (API 403'd)

**Roles tested:**
- Allowlisted (`WODALYTICS_ADMIN_EMAILS`) admin user — read access to all admin endpoints + sees admin nav.
- Non-allowlisted authenticated user (MEMBER role) — 403 on all admin endpoints; admin nav hidden.
- Unauthenticated — 401 on all admin endpoints.

**Not automated / manual verification needed:**
- [x] Visual: confirm the admin nav renders below the Staff section and matches the existing nav styling at `qa.wodalytics.com` once deployed.

## Test run

- `turbo lint`: clean
- `npm run test:unit --workspace=@wodalytics/web`: **174 passed, 0 failed**
- `npm run test:worktree -- api` (against live worktree dev stack): **all suites pass** (admin-programs: 20 / 20, others unaffected)
- `npm run test:worktree -- e2e`: **38 passed**, 1 pre-existing failure unrelated to this PR (`programs.spec.ts:277 — MEMBER joins a PUBLIC program from Browse and lands on its filtered Feed`). Verified the failure also reproduces 3/3 with `--repeat-each=3` on `origin/main`-derived code; this PR does not touch BrowsePrograms or the join flow.

## Out of scope (queued for slice 3)

- Editing surface (PATCH/POST/DELETE for programs and workouts).
- Migrating the gym-scoped pages onto `ProgramScope` (admin path uses it now; gym path will adopt it when editing forces the abstraction).
- "Adopt to gym" / promote-an-admin-program-into-a-gym flow (out of scope for #160 entirely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)