### PR TITLE
feat(dev): deterministic worktree shutdown via dev:worktree:stop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,8 @@ WODalytics/
 
 ```bash
 turbo dev             # start all apps concurrently (default ports: 3000 / 5173)
-npm run dev:worktree  # worktree-aware dev — picks free ports, prints URLs, writes .dev-ports.local
+npm run dev:worktree         # worktree-aware dev — picks free ports, prints URLs, writes .dev-ports.local + .dev-pids.local
+npm run dev:worktree:stop    # tear down THIS worktree's dev stack (PID + port-targeted; never affects siblings)
 npm run dev:jobs -- <name>            # run a single API background job locally
 npm run test:worktree -- api          # API integration tests against the worktree's dev stack
 npm run test:worktree -- e2e [args]   # Playwright E2E against the worktree's dev stack
@@ -117,7 +118,7 @@ When working in a `git worktree` (e.g. `.claude/worktrees/<branch>`), the defaul
    ```bash
    npm run dev:worktree
    ```
-   Picks random free API + web ports, writes `.dev-ports.local`, spawns `dev:api` and `dev:web` with the right env, and self-heals if a parallel worktree collides on the same port. Full behavior, port ranges, and troubleshooting live in the script header — see `scripts/dev-worktree.mjs`. Ctrl-C tears both servers down cleanly.
+   Picks random free API + web ports, writes `.dev-ports.local` + `.dev-pids.local`, spawns `dev:api` and `dev:web` with the right env, and self-heals if a parallel worktree collides on the same port. Full behavior, port ranges, and troubleshooting live in the script header — see `scripts/dev-worktree.mjs`. Ctrl-C tears both servers down cleanly in an interactive terminal; from a background / scripted context use the stop command (next section).
 
 2. **Run tests against that stack:**
    ```bash
@@ -142,9 +143,25 @@ Before reporting test success in a PR (especially for a slice or feature work), 
 1. From the worktree, run `npm run dev:worktree` in the background and wait for both servers to bind.
 2. Run **both** `npm run test:worktree -- api` and `npm run test:worktree -- e2e` against that stack.
 3. Report the actual numbers (passed / failed / total) plus any flaky tests.
-4. Tear the dev stack down (`kill` the bg PIDs) before opening the PR.
+4. Tear the dev stack down with `npm run dev:worktree:stop` before opening the PR.
 
 Skipping the live test runs and falling back to "static checks only" — like the slice-1 / slice-2 PRs had to — is a regression that this workflow exists to prevent. If the worktree dev stack genuinely won't start (port conflict the helper can't resolve, DB unreachable), say so explicitly in the PR rather than papering over with "reviewer to verify".
+
+### Stopping the dev stack — the only sanctioned way
+
+> **Hard rule: never use `pkill node`, `killall node`, or any other broad process kill to clean up after `npm run dev:worktree`.** Those kill sibling worktrees too, which is the foot-gun this section exists to prevent.
+
+From a background / scripted context (which is most Claude sessions), shut the stack down with:
+
+```bash
+npm run dev:worktree:stop
+```
+
+It reads `.dev-pids.local` and `.dev-ports.local` and kills only this worktree's orchestrator and any process still listening on this worktree's API/web ports. Idempotent — safe to run when nothing is running. Sibling worktrees in other directories are untouched.
+
+From an interactive terminal, Ctrl-C in the foreground process is equivalent and also cleans up the state files.
+
+If you're unsure whether a stack is still running, check `.dev-pids.local` (presence + a live PID = running) before launching another. The orchestrator refuses to start a second instance over an existing live one.
 
 ### Env vars honored
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:web": "cd apps/web && npm run dev",
     "dev:mobile": "cd apps/mobile && npm run dev",
     "dev:worktree": "node scripts/dev-worktree.mjs",
+    "dev:worktree:stop": "node scripts/stop-worktree.mjs",
     "test:worktree": "node scripts/test-worktree.mjs",
     "find-free-ports": "node scripts/find-free-ports.mjs",
     "build": "turbo build",

--- a/scripts/dev-worktree.mjs
+++ b/scripts/dev-worktree.mjs
@@ -10,12 +10,17 @@
  *    them to .dev-ports.local at the worktree root. Random port within
  *    API [3001, 5000) and web [5174, 7000); defaults 3000 / 5173 are reserved
  *    for non-worktree `turbo dev`.
- * 2. Spawns `npm run dev:api` with API_PORT set, and `npm run dev:web` with
+ * 2. Records the orchestrator's PID in .dev-pids.local. The companion
+ *    `npm run dev:worktree:stop` reads this file to terminate **only this
+ *    worktree's stack**, never sibling worktrees. If a stale .dev-pids.local
+ *    exists at startup with a still-alive PID, this script refuses to start
+ *    and tells the operator to run the stop script first.
+ * 3. Spawns `npm run dev:api` with API_PORT set, and `npm run dev:web` with
  *    WEB_PORT set. Vite's proxy reads API_PORT to forward `/api/*` to the
  *    correct backend port.
- * 3. Forwards stdout / stderr from both children with a [api] / [web] prefix
+ * 4. Forwards stdout / stderr from both children with a [api] / [web] prefix
  *    so the engineer can see both streams in one terminal.
- * 4. **Self-healing on collision.** If a child crashes within the first
+ * 5. **Self-healing on collision.** If a child crashes within the first
  *    COLLISION_WINDOW_MS with an EADDRINUSE-shaped error (Node's native
  *    string OR Vite's "Port N is (already) in use" wording), it means the
  *    randomly-picked port collided with a sibling worktree starting at the
@@ -23,31 +28,81 @@
  *    `find-free-ports --repick=<role>`), updates .dev-ports.local, and
  *    respawns that child. Capped at MAX_PORT_RETRIES per role with a clear
  *    `[dev:worktree] <role> hit EADDRINUSE on N — retrying on M` log line.
- * 5. Non-collision exits (or exhausted retries) take the surviving sibling
+ * 6. Non-collision exits (or exhausted retries) take the surviving sibling
  *    down so the orchestrator never outlives a half-broken pair.
- * 6. On Ctrl-C, sends SIGTERM to both children and waits for them to exit
- *    cleanly before quitting.
+ * 7. On Ctrl-C (interactive) or SIGTERM (from the stop script), sends SIGTERM
+ *    to both children, waits for them to exit cleanly, deletes
+ *    .dev-pids.local, and quits.
+ *
+ * Two ways to stop a running stack:
+ * - **Interactive shell:** Ctrl-C in the terminal that started it.
+ * - **Background / scripted (Claude sessions):** `npm run dev:worktree:stop`
+ *   from the same worktree root. **Never** use `pkill node` / `killall node`
+ *   — that kills sibling worktrees too and is the foot-gun this script
+ *   exists to prevent.
  *
  * After a successful run, downstream tooling (npm run test:worktree, the
  * test:e2e command) reads .dev-ports.local to know where the live stack is.
  *
  * Troubleshooting:
+ * - "Stack is already running (PID N)" on startup — a previous run didn't
+ *   clean up its PID file. Run `npm run dev:worktree:stop` to terminate it,
+ *   or, if you know that PID is dead, delete .dev-pids.local manually.
  * - "API URL printed but `curl` 404s" — proxy target wasn't set; confirm
  *   API_PORT made it into the web child's env (printed `[web]` lines log
  *   the resolved proxy target on Vite startup).
  * - "Both children keep crashing on the same port" — the retry cap was hit;
- *   shut everything down with Ctrl-C, check `lsof -i :<port>` for a stale
- *   process, then restart.
+ *   run `npm run dev:worktree:stop`, then `lsof -i :<port>` to find any
+ *   stale external listener, then restart.
  * - "I want a fixed port" — skip this script and use `npm run dev:api` /
  *   `npm run dev:web` directly with explicit `API_PORT=` / `WEB_PORT=` env.
  */
 import { spawn, spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
-import { readFileSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const root = resolve(here, '..')
+const pidsFile = resolve(root, '.dev-pids.local')
+
+// Stale-PID guard: if a previous run left .dev-pids.local behind and that PID
+// is still alive, refuse to start. Otherwise, ignore the stale file.
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+if (existsSync(pidsFile)) {
+  let stale = null
+  try {
+    stale = JSON.parse(readFileSync(pidsFile, 'utf8'))
+  } catch {
+    // unreadable / corrupt — treat as stale
+  }
+  if (stale && typeof stale.orchestratorPid === 'number' && isProcessAlive(stale.orchestratorPid)) {
+    console.error(`[dev:worktree] A dev stack is already running in this worktree (PID ${stale.orchestratorPid}).`)
+    console.error('[dev:worktree] Run \`npm run dev:worktree:stop\` to terminate it before starting a new one.')
+    process.exit(1)
+  }
+}
+
+// Write our own PID before doing anything else, so the stop script has a
+// target even if startup fails partway through.
+writeFileSync(pidsFile, JSON.stringify({ orchestratorPid: process.pid }, null, 2) + '\n')
+
+function cleanupPidsFile() {
+  try { unlinkSync(pidsFile) } catch {}
+}
+// 'exit' fires for any normal termination (process.exit, end of event loop,
+// or after our SIGINT/SIGTERM handlers run process.exit). It does NOT fire
+// on SIGKILL — but the stop script's job in that case is to clean up the
+// file itself, so we're covered.
+process.on('exit', cleanupPidsFile)
 
 // Children sometimes log EADDRINUSE long after they've actually been running
 // (e.g. an HMR reload that hits a port that just closed). Only treat it as a

--- a/scripts/stop-worktree.mjs
+++ b/scripts/stop-worktree.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Deterministic shutdown for `npm run dev:worktree`.
+ *
+ * Why this exists: a Claude session (or any background scripted workflow)
+ * needs to tear down its own dev stack at the end of a task without killing
+ * sibling worktrees. `pkill node` / `killall node` are foot-guns — they kill
+ * every Node process on the box, including parallel worktrees that are still
+ * working. This script is the **only** sanctioned way to stop a stack from
+ * outside the orchestrator's interactive terminal.
+ *
+ * Algorithm:
+ * 1. Read .dev-pids.local. If it has a live orchestrator PID, send SIGINT.
+ *    The orchestrator's existing handler forwards SIGTERM to its children
+ *    and exits cleanly. Wait up to TERM_GRACE_MS for it to die.
+ * 2. If the orchestrator didn't exit in time, send SIGKILL.
+ * 3. Belt-and-suspenders: read .dev-ports.local and `lsof -ti :<port>` for
+ *    the API and web ports. SIGKILL anything still listening — these are
+ *    detached / orphaned children whose orchestrator already died.
+ * 4. Delete .dev-pids.local and .dev-ports.local. The worktree is now in
+ *    a clean state — `npm run dev:worktree` can be run again immediately.
+ *
+ * Idempotent: if neither file exists, exits 0 with a "nothing to clean up"
+ * message. Safe to run repeatedly.
+ *
+ * Important: kills are scoped to **this worktree's** PID + ports. Sibling
+ * worktrees in other directories have their own .dev-pids.local /
+ * .dev-ports.local and are not touched.
+ */
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { readFileSync, existsSync, unlinkSync } from 'node:fs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const root = resolve(here, '..')
+const pidsFile = resolve(root, '.dev-pids.local')
+const portsFile = resolve(root, '.dev-ports.local')
+
+// How long to wait for the orchestrator to gracefully shut down its children
+// after SIGINT before escalating to SIGKILL. The orchestrator itself tends to
+// take ~100ms; the children (nodemon, vite) can take 1-2s to wind down.
+const TERM_GRACE_MS = 4000
+const POLL_INTERVAL_MS = 100
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+async function waitForExit(pid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return true
+    await sleep(POLL_INTERVAL_MS)
+  }
+  return !isProcessAlive(pid)
+}
+
+function pidsListeningOnPort(port) {
+  // -t = terse (PIDs only, one per line). -i :<port> = sockets bound to that
+  // TCP/UDP port. -sTCP:LISTEN restricts to listeners (the dev servers we
+  // care about) and skips short-lived client connections.
+  const result = spawnSync('lsof', ['-tiTCP:' + port, '-sTCP:LISTEN'], { encoding: 'utf8' })
+  if (result.status !== 0) return [] // lsof exits 1 when nothing matches; treat as empty
+  return result.stdout
+    .split('\n')
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => Number.isFinite(n) && n > 0)
+}
+
+let touchedAnything = false
+
+// Step 1: SIGINT the orchestrator.
+let orchestratorPid = null
+if (existsSync(pidsFile)) {
+  try {
+    const data = JSON.parse(readFileSync(pidsFile, 'utf8'))
+    if (typeof data.orchestratorPid === 'number') orchestratorPid = data.orchestratorPid
+  } catch {
+    // corrupt — treat as no PID
+  }
+}
+
+if (orchestratorPid && isProcessAlive(orchestratorPid)) {
+  touchedAnything = true
+  console.log(`[dev:worktree:stop] Sending SIGINT to orchestrator PID ${orchestratorPid}`)
+  try {
+    process.kill(orchestratorPid, 'SIGINT')
+  } catch (err) {
+    console.error(`[dev:worktree:stop] SIGINT failed: ${err.message}`)
+  }
+  const exited = await waitForExit(orchestratorPid, TERM_GRACE_MS)
+  if (!exited) {
+    console.log(`[dev:worktree:stop] Orchestrator did not exit within ${TERM_GRACE_MS}ms — escalating to SIGKILL`)
+    try { process.kill(orchestratorPid, 'SIGKILL') } catch {}
+    await waitForExit(orchestratorPid, 1000)
+  }
+}
+
+// Step 2: belt-and-suspenders — kill anything still on this worktree's ports.
+if (existsSync(portsFile)) {
+  let ports = null
+  try {
+    ports = JSON.parse(readFileSync(portsFile, 'utf8'))
+  } catch {
+    // corrupt — skip
+  }
+  if (ports) {
+    for (const [role, port] of [['api', ports.apiPort], ['web', ports.webPort]]) {
+      if (typeof port !== 'number') continue
+      const stragglers = pidsListeningOnPort(port)
+      if (stragglers.length === 0) continue
+      touchedAnything = true
+      console.log(`[dev:worktree:stop] ${role} port ${port} still has listeners ${stragglers.join(', ')} — SIGKILL`)
+      for (const pid of stragglers) {
+        try { process.kill(pid, 'SIGKILL') } catch {}
+      }
+    }
+  }
+}
+
+// Step 3: clean state files.
+for (const f of [pidsFile, portsFile]) {
+  if (existsSync(f)) {
+    touchedAnything = true
+    try { unlinkSync(f) } catch (err) {
+      console.error(`[dev:worktree:stop] Failed to delete ${f}: ${err.message}`)
+    }
+  }
+}
+
+if (!touchedAnything) {
+  console.log('[dev:worktree:stop] Nothing to clean up — no .dev-pids.local or .dev-ports.local found, no listeners on tracked ports.')
+} else {
+  console.log('[dev:worktree:stop] Done. Worktree is clean.')
+}


### PR DESCRIPTION
## Why

Background Claude sessions have been falling back to \`pkill node\` / \`killall node\` to clean up after \`npm run dev:worktree\` because there was no scoped shutdown command. That kills sibling worktrees too — exactly the parallel-session foot-gun the worktree workflow exists to prevent.

This adds a deterministic, scoped cleanup path: PID + port targeted, never touches other worktrees.

## What changes

### \`scripts/dev-worktree.mjs\`

- On startup, writes \`.dev-pids.local\` (`{ orchestratorPid: <pid> }`) at the worktree root.
- Stale-PID guard: if \`.dev-pids.local\` exists with an alive PID, refuses to start and tells the operator to run \`dev:worktree:stop\` first.
- Cleans the file up on a \`process.exit\` handler.
- Header (canonical-reference per the earlier doc-consolidation PR) describes both shutdown paths and the new guard.

### \`scripts/stop-worktree.mjs\` (new)

1. Reads \`.dev-pids.local\`. If the orchestrator PID is alive, sends SIGINT.
2. Waits up to 4s for the orchestrator (and its children, via the orchestrator's own SIGTERM-forwarding handler) to exit. Escalates to SIGKILL if the grace period elapses.
3. Belt-and-suspenders: reads \`.dev-ports.local\` and \`lsof -tiTCP:<port> -sTCP:LISTEN\`s anything still listening on this worktree's API/web ports. SIGKILLs each. This catches the case where the orchestrator was killed but a child survived.
4. Deletes \`.dev-pids.local\` and \`.dev-ports.local\`. The worktree is back to a clean state.

Idempotent — running with nothing to clean prints \"Nothing to clean up\" and exits 0.

### \`package.json\`

Adds \`dev:worktree:stop\` script. \`dev:worktree\` is unchanged in shape.

### \`CLAUDE.md\`

- Top-level commands list now includes \`dev:worktree:stop\`.
- New *Stopping the dev stack — the only sanctioned way* subsection with a **hard rule**: never use \`pkill node\` / \`killall node\`.
- *What Claude must do before saying \"all tests pass\"* — step 4 was \"kill the bg PIDs\" (vague, exactly the kind of instruction that produced the foot-gun); now it says \`npm run dev:worktree:stop\`.

## Tests

**Manual verification** (no automated test surface for shell orchestration scripts):

1. **PID file written on start.** Started orchestrator with absolute path; \`.dev-pids.local\` contained \`{ \"orchestratorPid\": 25569 }\` matching \`ps -p 25569\`.
2. **Stop kills + cleans up.** Ran \`dev:worktree:stop\` against the running stack. Output:
   \`\`\`
   [dev:worktree:stop] Sending SIGINT to orchestrator PID 25569
   [dev:worktree:stop] Orchestrator did not exit within 4000ms — escalating to SIGKILL
   [dev:worktree:stop] web port 5325 still has listeners 25692 — SIGKILL
   [dev:worktree:stop] Done. Worktree is clean.
   \`\`\`
   The escalation triggered because the API child was crash-looping (no \`.env\` in this checkout) and nodemon's \"waiting for changes\" mode doesn't respond to SIGTERM. The fallback handled it cleanly. Confirmed: orchestrator dead, both ports free, both state files deleted.
3. **Idempotent.** Second \`dev:worktree:stop\` invocation: \`Nothing to clean up — no .dev-pids.local or .dev-ports.local found, no listeners on tracked ports.\`
4. **Stale-PID guard.** Started orchestrator, then immediately tried to start a second from the same worktree. Second exited 1 with: \`A dev stack is already running in this worktree (PID 28120). Run \\`npm run dev:worktree:stop\\` to terminate it before starting a new one.\`

**Mobile parity:** N/A — this is dev-tooling for the local Node stack, not a user-facing surface.

## Follow-up worth noting (not in this PR)

The orchestrator's SIGINT path doesn't always lead to a clean exit when one of the children is in nodemon's \"waiting for file changes\" mode after a crash — nodemon catches SIGTERM but stays alive. The stop script handles this via the SIGKILL fallback so the user-visible behavior is correct, but the orchestrator could be improved to explicitly \`process.exit()\` after a grace period in its shutdown handler. Worth a small follow-up but not gating this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)