### PR TITLE
fix(web): strength result detail shows all sets, not just heaviest

### DIFF
--- a/apps/web/src/pages/WodResultDetail.test.tsx
+++ b/apps/web/src/pages/WodResultDetail.test.tsx
@@ -151,4 +151,150 @@ describe('WodResultDetail', () => {
     renderPage('workout-1', 'missing-result-id')
     expect(await screen.findByText(/Result not found/i)).toBeInTheDocument()
   })
+
+  it('renders the full per-movement set breakdown for a strength result', async () => {
+    const strengthWorkout = {
+      ...makeWorkout({
+        title: 'Back Squat 5×5',
+        type: 'STRENGTH' as const,
+        description: '5x5 Back Squat',
+      }),
+      workoutMovements: [
+        {
+          movement: { id: 'm-back-squat', name: 'Back Squat', parentId: null },
+          displayOrder: 0,
+          sets: 5,
+          reps: '5',
+          load: null,
+          loadUnit: 'LB' as const,
+          tracksLoad: true,
+          tempo: null,
+          distance: null,
+          distanceUnit: null,
+          calories: null,
+          seconds: null,
+        },
+      ],
+    }
+    const strengthResult = {
+      ...makeResult({ id: 'r-str', userId: 'somebody-else', name: 'Jane Doe' }),
+      value: {
+        movementResults: [
+          {
+            workoutMovementId: 'm-back-squat',
+            loadUnit: 'LB',
+            sets: [
+              { reps: '5', load: 225 },
+              { reps: '5', load: 235 },
+              { reps: '5', load: 245 },
+              { reps: '3', load: 255 },
+              { reps: '1', load: 275 },
+            ],
+          },
+        ],
+      },
+    }
+    vi.mocked(api.workouts.get).mockResolvedValue(strengthWorkout)
+    vi.mocked(api.results.leaderboard).mockResolvedValue([strengthResult] as never)
+
+    renderPage('workout-1', 'r-str')
+
+    // Movement section header is shown (also appears in the workout movement
+    // chip list above, so allow the duplicate).
+    const squatLabels = await screen.findAllByText('Back Squat')
+    expect(squatLabels.length).toBeGreaterThanOrEqual(1)
+    // Every set is enumerated, not just the heaviest
+    expect(screen.getByText('Set 1')).toBeInTheDocument()
+    expect(screen.getByText('Set 5')).toBeInTheDocument()
+    // Each set's reps × load is rendered (the lighter sets would be hidden if
+    // the page kept using the leaderboard summary helper).
+    expect(screen.getByText('5 × 225 lb')).toBeInTheDocument()
+    expect(screen.getByText('5 × 235 lb')).toBeInTheDocument()
+    expect(screen.getByText('5 × 245 lb')).toBeInTheDocument()
+    expect(screen.getByText('3 × 255 lb')).toBeInTheDocument()
+    expect(screen.getByText('1 × 275 lb')).toBeInTheDocument()
+    // Headline summary still surfaces the heaviest set
+    expect(screen.getByText('1 x 275 lb')).toBeInTheDocument()
+  })
+
+  it('renders sets across multiple movements with the right names and per-movement units', async () => {
+    const workout = {
+      ...makeWorkout({
+        title: 'Squat + Press',
+        type: 'STRENGTH' as const,
+        description: 'Heavy squat then press',
+      }),
+      workoutMovements: [
+        {
+          movement: { id: 'm-squat', name: 'Back Squat', parentId: null },
+          displayOrder: 0,
+          sets: 3,
+          reps: '3',
+          load: null,
+          loadUnit: 'LB' as const,
+          tracksLoad: true,
+          tempo: null,
+          distance: null,
+          distanceUnit: null,
+          calories: null,
+          seconds: null,
+        },
+        {
+          movement: { id: 'm-press', name: 'Strict Press', parentId: null },
+          displayOrder: 1,
+          sets: 3,
+          reps: '5',
+          load: null,
+          loadUnit: 'KG' as const,
+          tracksLoad: true,
+          tempo: null,
+          distance: null,
+          distanceUnit: null,
+          calories: null,
+          seconds: null,
+        },
+      ],
+    }
+    const result = {
+      ...makeResult({ id: 'r-multi', userId: 'somebody-else', name: 'Jane Doe', notes: 'Felt grindy on the third squat set.' }),
+      value: {
+        movementResults: [
+          {
+            workoutMovementId: 'm-squat',
+            loadUnit: 'LB',
+            sets: [
+              { reps: '3', load: 285 },
+              { reps: '3', load: 295 },
+              { reps: '3', load: 305 },
+            ],
+          },
+          {
+            workoutMovementId: 'm-press',
+            loadUnit: 'KG',
+            sets: [
+              { reps: '5', load: 60 },
+              { reps: '5', load: 62.5 },
+            ],
+          },
+        ],
+      },
+    }
+    vi.mocked(api.workouts.get).mockResolvedValue(workout)
+    vi.mocked(api.results.leaderboard).mockResolvedValue([result] as never)
+
+    renderPage('workout-1', 'r-multi')
+
+    // Both movement names appear as section headers in the result block
+    const squat = await screen.findAllByText('Back Squat')
+    expect(squat.length).toBeGreaterThan(0)
+    const press = await screen.findAllByText('Strict Press')
+    expect(press.length).toBeGreaterThan(0)
+
+    // Per-movement load unit is honored
+    expect(screen.getByText('3 × 305 lb')).toBeInTheDocument()
+    expect(screen.getByText('5 × 62.5 kg')).toBeInTheDocument()
+
+    // Notes are still rendered alongside the breakdown
+    expect(screen.getByText(/Felt grindy/)).toBeInTheDocument()
+  })
 })

--- a/apps/web/src/pages/WodResultDetail.tsx
+++ b/apps/web/src/pages/WodResultDetail.tsx
@@ -32,6 +32,49 @@ function formatResultValue(result: WorkoutResult): string {
   return formatValue(result.value)
 }
 
+interface SetEntry {
+  reps?: string
+  load?: number
+  tempo?: string
+  distance?: number
+  calories?: number
+  seconds?: number
+}
+
+interface MovementResultEntry {
+  workoutMovementId?: string
+  loadUnit?: string
+  distanceUnit?: string
+  sets?: SetEntry[]
+}
+
+function formatSeconds(totalSec: number): string {
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+// Compose one set into a "5 × 225 lb · tempo 3.1.1.0" line. Empty fields are
+// dropped so the row only shows what the member actually logged.
+function describeSet(set: SetEntry, loadUnit?: string, distanceUnit?: string): string {
+  const parts: string[] = []
+  const repsLabel = set.reps ?? (set.load !== undefined ? '?' : null)
+  if (set.load !== undefined) {
+    const unit = loadUnit ? ` ${loadUnit.toLowerCase()}` : ''
+    parts.push(`${repsLabel ?? '?'} × ${set.load}${unit}`)
+  } else if (set.reps) {
+    parts.push(`${set.reps} reps`)
+  }
+  if (set.distance !== undefined) {
+    const unit = distanceUnit ? ` ${distanceUnit.toLowerCase()}` : ''
+    parts.push(`${set.distance}${unit}`)
+  }
+  if (set.calories !== undefined) parts.push(`${set.calories} cal`)
+  if (set.seconds !== undefined) parts.push(formatSeconds(set.seconds))
+  if (set.tempo) parts.push(`tempo ${set.tempo}`)
+  return parts.join(' · ') || '—'
+}
+
 export default function WodResultDetail() {
   const { id, resultId } = useParams<{ id: string; resultId: string }>()
   const navigate = useNavigate()
@@ -82,6 +125,12 @@ export default function WodResultDetail() {
   const isMe = result.userId === user?.id
   const ownerName = result.user.name ?? 'Unknown athlete'
   const titleText = isMe ? 'Your Result' : `${ownerName}'s Result`
+
+  const movementResults = ((result.value as { movementResults?: MovementResultEntry[] } | null)?.movementResults ?? [])
+    .filter((mr) => (mr.sets?.length ?? 0) > 0)
+  const movementNameById = new Map(
+    workout.workoutMovements.map((wm) => [wm.movement.id, wm.movement.name]),
+  )
 
   const scheduledDate = new Date(workout.scheduledAt).toLocaleDateString('en-US', {
     weekday: 'long',
@@ -147,13 +196,36 @@ export default function WodResultDetail() {
       )}
 
       {/* Result block */}
-      <div className="px-4 py-3 rounded-lg bg-gray-900 border border-gray-700 space-y-2">
+      <div className="px-4 py-3 rounded-lg bg-gray-900 border border-gray-700 space-y-3">
         <div className="flex items-center gap-3 flex-wrap">
           <span className="text-xs font-semibold text-gray-400 uppercase tracking-wide">Result</span>
           <span className="text-base font-medium text-white font-mono">{formatResultValue(result)}</span>
           <span className="text-xs text-gray-400">{LEVEL_LABELS[result.level]}</span>
           <span className="text-xs text-gray-500">{WORKOUT_GENDER_LABELS[result.workoutGender]}</span>
         </div>
+        {movementResults.length > 0 && (
+          <div className="space-y-3 pt-1">
+            {movementResults.map((mr, mIdx) => {
+              const name = (mr.workoutMovementId && movementNameById.get(mr.workoutMovementId)) || 'Movement'
+              return (
+                <div key={mr.workoutMovementId ?? mIdx}>
+                  <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wide mb-1.5">{name}</p>
+                  <ol className="space-y-1">
+                    {(mr.sets ?? []).map((set, sIdx) => (
+                      <li
+                        key={sIdx}
+                        className="flex items-baseline gap-3 text-sm text-gray-200"
+                      >
+                        <span className="text-xs text-gray-400 font-mono w-12 shrink-0">Set {sIdx + 1}</span>
+                        <span className="font-mono">{describeSet(set, mr.loadUnit, mr.distanceUnit)}</span>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              )
+            })}
+          </div>
+        )}
         {result.notes ? (
           <div>
             <p className="text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-1">Notes</p>


### PR DESCRIPTION
## Summary

Clicking a strength result from the WOD leaderboard now shows the full per-movement set breakdown — every reps × load row the member logged — instead of collapsing the result down to the heaviest single set.

The bug surfaced because `WodResultDetail` was rendering result values through the same `formatResultValue()` helper that the leaderboard rows use. That helper deliberately surfaces the heaviest set as the headline (it's the figure leaderboards rank by), but the read-only detail page is supposed to show the whole picture. Members editing their own result already saw the full breakdown via `LogResultDrawer`, which is why the bug felt like "only happens when viewing someone else's result" — the alternate authoring path masked it for the viewer's own data.

The fix renders `value.movementResults` inline below the summary line: one section per movement (name pulled from `workout.workoutMovements`), with each set as `Set N — reps × load unit · …`. The existing notes block is unchanged.

Closes #182

## Tests

**Unit** (`apps/web/src/pages/WodResultDetail.test.tsx`):
- `shows 'Your Result' when the result belongs to the current user` — title gating (existing).
- `shows '<name>'s Result' when viewing another athlete` — title gating for non-owner (existing).
- `renders the workout description, formatted result, level, and notes` — FOR_TIME render path (existing).
- `falls back to a friendly empty notes message when the result has no notes` — empty-notes copy (existing).
- `shows an error when the result cannot be located on the leaderboard` — error path (existing).
- **NEW** `renders the full per-movement set breakdown for a strength result` — seeds a single-movement strength result with 5 sets (225 → 275 lb) and asserts every set row renders, not just the heaviest. Also asserts the headline summary still surfaces "1 × 275 lb".
- **NEW** `renders sets across multiple movements with the right names and per-movement units` — seeds a Back Squat (LB) + Strict Press (KG) result, asserts both movement names render, that per-movement load units are honored (`3 × 305 lb`, `5 × 62.5 kg`), and that notes still render alongside the breakdown.

**Type check / unit suite:**
- `npx turbo lint --force` — clean.
- `npx vitest run` (apps/web) — 24 files, 166 tests passed.

**API integration** (`apps/api/tests/*`):
- `npm run test:worktree -- api` — 52 passed, 0 failed against the worktree dev stack.
- No API surface changed; this PR is web-only. The existing leaderboard endpoint already returns the full `value.movementResults` payload, so no API or schema changes were needed.

**Playwright E2E** (`apps/web/tests/*`):
- `npm run test:worktree -- e2e` — 36 passed, 1 failed.
- The single failure is `programs.spec.ts:277` "MEMBER joins a PUBLIC program from Browse and lands on its filtered Feed" — a strict-mode locator ambiguity on `getByRole('button', { name: 'Join' })` because the seeded PUBLIC program currently appears in two `<section>` blocks ("From your gym / Public programs" + "Public programs / Open programs"). Reproduces deterministically; unrelated to this PR (no programs code touched). Worth filing as its own issue.

**Not automated / manual verification needed:**
- [x] Visual check: a strength result with multiple movements renders cleanly within the result block on a narrow viewport.

**Mobile parity:** N/A on mobile — `apps/mobile/src/screens/WodDetailScreen.tsx` does not currently make leaderboard rows clickable, so there is no broken detail flow on mobile to fix in this PR. The mobile "result detail / view another athlete's result" surface is part of the active mobile-parity backlog (#130).

🤖 Generated with [Claude Code](https://claude.com/claude-code)