### PR TITLE
feat(db): Program.ownerUserId for Personal Programs (migration only)

### DIFF
--- a/packages/db/prisma/migrations/20260502191111_personal_program_owner/migration.sql
+++ b/packages/db/prisma/migrations/20260502191111_personal_program_owner/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Program" ADD COLUMN     "ownerUserId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Program_ownerUserId_key" ON "Program"("ownerUserId");
+
+-- AddForeignKey
+ALTER TABLE "Program" ADD CONSTRAINT "Program_ownerUserId_fkey" FOREIGN KEY ("ownerUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -190,6 +190,10 @@ model User {
   refreshTokens         RefreshToken[]
   gyms                  UserGym[]
   programs              UserProgram[]
+  // The user's private "Personal Program" — auto-upserted on first use,
+  // never linked to a Gym, never visible to other users. Nullable until the
+  // user touches the feature for the first time.
+  personalProgram       Program?               @relation("UserPersonalProgram")
   results               Result[]
   emergencyContacts     EmergencyContact[]
   membershipRequests    GymMembershipRequest[] @relation("UserRequests")
@@ -254,9 +258,15 @@ model Program {
   endDate     DateTime?
   coverColor  String?
   visibility  ProgramVisibility @default(PRIVATE)
+  // When set, this program is the owner's private "Personal Program" — never
+  // linked to a Gym, never publicly browsable. The unique constraint enforces
+  // one personal program per user, so the upsert in `findOrCreatePersonalProgram`
+  // can race-safely use `ownerUserId` as its where-key.
+  ownerUserId String?           @unique
   createdAt   DateTime          @default(now())
   updatedAt   DateTime          @updatedAt
 
+  owner    User?           @relation("UserPersonalProgram", fields: [ownerUserId], references: [id], onDelete: Cascade)
   gyms     GymProgram[]
   members  UserProgram[]
   workouts Workout[]


### PR DESCRIPTION
## Summary

Adds the schema for the new **Personal Programs** feature (#183) — a private, auto-upserted `Program` per user that never links to a gym and never surfaces to other users. This PR ships the migration alone so the API + UI slices can land afterwards against an already-deployed schema (per CLAUDE.md → *Isolate migration PRs*).

Schema change:

\`\`\`prisma
model Program {
  ...
  ownerUserId String? @unique
  owner       User?   @relation("UserPersonalProgram", fields: [ownerUserId], references: [id], onDelete: Cascade)
}

model User {
  ...
  personalProgram Program? @relation("UserPersonalProgram")
}
\`\`\`

The `@unique` on a nullable column is the standard Postgres "partial unique index" — null values are unconstrained, so existing rows (which have no owner) coexist freely. One personal program per user is enforced at the DB layer, which lets the follow-up upsert helper use `where: { ownerUserId }` race-safely.

The migration is **additive**:
- new nullable column `Program.ownerUserId`
- new unique index `Program_ownerUserId_key`
- new FK `Program_ownerUserId_fkey` with `ON DELETE CASCADE`

Old code does not read or write the new column. New code (in the follow-up PR) will. Both can coexist on the same DB schema, satisfying the staged-rollout pattern.

## Tests

**Migration apply:**
- `npx prisma migrate deploy` against local dev DB applied cleanly (22 → 23 migrations).
- `npx prisma generate` regenerated the client without warnings.
- `turbo build` typechecked api / db / web / mobile / types successfully.

**Not automated / manual verification needed:**
- [ ] QA deploy applies `migrate deploy` and Railway reports green.

No runtime code reads or writes `ownerUserId` in this PR, so there's nothing to integration-test until the follow-up.

Part of #183