### PR TITLE
feat(api): coachNotes field on Workout — schema, Zod, routes, tests

### DIFF
--- a/apps/api/src/db/workoutDbManager.ts
+++ b/apps/api/src/db/workoutDbManager.ts
@@ -24,6 +24,7 @@ interface CreateWorkoutData {
   programId?: string
   title: string
   description: string
+  coachNotes?: string | null
   type: WorkoutType
   scheduledAt: Date
   dayOrder?: number
@@ -41,6 +42,7 @@ interface CreateWorkoutData {
 interface UpdateWorkoutData {
   title?: string
   description?: string
+  coachNotes?: string | null
   type?: WorkoutType
   scheduledAt?: Date
   dayOrder?: number

--- a/apps/api/src/routes/workouts.ts
+++ b/apps/api/src/routes/workouts.ts
@@ -115,7 +115,7 @@ async function createWorkoutForProgram(req: Request, res: Response) {
     return res.status(400).json({ error: `${field}: ${message}` })
   }
 
-  const { programId, title, description, type, scheduledAt, dayOrder, movementIds, movements, timeCapSeconds, tracksRounds } = parsed.data
+  const { programId, title, description, coachNotes, type, scheduledAt, dayOrder, movementIds, movements, timeCapSeconds, tracksRounds } = parsed.data
   const gymId = req.params.gymId as string
   const scheduledAtDate = new Date(scheduledAt)
   const resolvedDayOrder = dayOrder ?? await countWorkoutsOnSameDay(gymId, scheduledAtDate)
@@ -123,6 +123,7 @@ async function createWorkoutForProgram(req: Request, res: Response) {
     programId,
     title,
     description,
+    coachNotes: coachNotes === '' ? null : coachNotes,
     type,
     scheduledAt: scheduledAtDate,
     dayOrder: resolvedDayOrder,
@@ -169,10 +170,11 @@ async function patchWorkout(req: Request, res: Response) {
     return res.status(400).json({ error: `${field}: ${message}` })
   }
 
-  const { title, description, type, scheduledAt, dayOrder, movementIds, movements, namedWorkoutId, timeCapSeconds, tracksRounds } = parsed.data
+  const { title, description, coachNotes, type, scheduledAt, dayOrder, movementIds, movements, namedWorkoutId, timeCapSeconds, tracksRounds } = parsed.data
   const workout = await updateWorkout(id, {
     title,
     description,
+    coachNotes: coachNotes === '' ? null : coachNotes,
     type,
     scheduledAt: scheduledAt ? new Date(scheduledAt) : undefined,
     dayOrder,

--- a/apps/api/tests/workouts.ts
+++ b/apps/api/tests/workouts.ts
@@ -351,6 +351,79 @@ async function runTests() {
   // membership now uses POST /programs/:id/members. Coverage moved to
   // apps/api/tests/programs.ts under the slice-3 + slice-4 sections.)
 
+  // ── coachNotes (#185) ──────────────────────────────────────────────────────
+  console.log('\n=== coachNotes ===')
+
+  let coachNotesWorkoutId = ''
+
+  {
+    // Create with coachNotes set
+    const r = await api('POST', `/gyms/${gymId}/workouts`, programmerToken, {
+      programId,
+      title: 'Coach Notes Workout',
+      description: 'desc',
+      coachNotes: 'Stim: 7-min sprint, sub ring rows for pull-ups.',
+      type: 'FOR_TIME',
+      scheduledAt: '2026-04-15T10:00:00Z',
+    })
+    check('POST workout with coachNotes → 201', 201, r.status)
+    check('POST workout → coachNotes persisted', 'Stim: 7-min sprint, sub ring rows for pull-ups.', r.body.coachNotes)
+    coachNotesWorkoutId = r.body.id as string
+  }
+
+  {
+    // Create without coachNotes → null
+    const r = await api('POST', `/gyms/${gymId}/workouts`, programmerToken, {
+      programId,
+      title: 'No Coach Notes Workout',
+      description: 'desc',
+      type: 'FOR_TIME',
+      scheduledAt: '2026-04-16T10:00:00Z',
+    })
+    check('POST workout without coachNotes → 201', 201, r.status)
+    check('POST workout without coachNotes → coachNotes is null', null, r.body.coachNotes)
+    if (r.body.id) await prisma.workout.delete({ where: { id: r.body.id as string } })
+  }
+
+  {
+    // GET surfaces coachNotes for any authorized reader (member)
+    const r = await api('GET', `/workouts/${coachNotesWorkoutId}`, memberToken)
+    check('GET /workouts/:id as MEMBER → coachNotes visible', 'Stim: 7-min sprint, sub ring rows for pull-ups.', r.body.coachNotes)
+  }
+
+  {
+    // PATCH with new coachNotes
+    const r = await api('PATCH', `/workouts/${coachNotesWorkoutId}`, programmerToken, { coachNotes: 'Updated: focus on hip drive.' })
+    check('PATCH coachNotes → 200', 200, r.status)
+    check('PATCH coachNotes → value updated', 'Updated: focus on hip drive.', r.body.coachNotes)
+
+    const reread = await api('GET', `/workouts/${coachNotesWorkoutId}`, programmerToken)
+    check('PATCH coachNotes → re-GET reflects update', 'Updated: focus on hip drive.', reread.body.coachNotes)
+  }
+
+  {
+    // PATCH with empty string clears to null
+    const r = await api('PATCH', `/workouts/${coachNotesWorkoutId}`, programmerToken, { coachNotes: '' })
+    check('PATCH coachNotes="" → 200', 200, r.status)
+    check('PATCH coachNotes="" → value cleared to null', null, r.body.coachNotes)
+  }
+
+  {
+    // PATCH with explicit null also clears
+    await api('PATCH', `/workouts/${coachNotesWorkoutId}`, programmerToken, { coachNotes: 'temp' })
+    const r = await api('PATCH', `/workouts/${coachNotesWorkoutId}`, programmerToken, { coachNotes: null })
+    check('PATCH coachNotes=null → 200', 200, r.status)
+    check('PATCH coachNotes=null → value cleared', null, r.body.coachNotes)
+  }
+
+  {
+    // PATCH with wrong type → 400
+    const r = await api('PATCH', `/workouts/${coachNotesWorkoutId}`, programmerToken, { coachNotes: 12345 })
+    check('PATCH coachNotes with wrong type → 400', 400, r.status)
+  }
+
+  if (coachNotesWorkoutId) await prisma.workout.delete({ where: { id: coachNotesWorkoutId } })
+
   // ── Workout auth: gym-linked program (#118) ────────────────────────────────
   // Regression coverage for the bug where workout write access ran the caller's
   // UserProgram.role through the gym-role allowlist. The fix derives write

--- a/packages/db/prisma/migrations/20260503001749_add_workout_coach_notes/migration.sql
+++ b/packages/db/prisma/migrations/20260503001749_add_workout_coach_notes/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Workout" ADD COLUMN     "coachNotes" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -355,6 +355,11 @@ model Workout {
   programId        String?
   title            String
   description      String
+  // Programmer-authored stimulus / teaching notes shown on the workout
+  // detail view. UI defaults to expanded for staff (COACH/PROGRAMMER/OWNER)
+  // and collapsed for MEMBER. Empty string is normalized to null at the API
+  // boundary so the field can be cleared via the same PATCH.
+  coachNotes       String?
   type             WorkoutType
   status           WorkoutStatus @default(DRAFT)
   scheduledAt      DateTime

--- a/packages/types/src/workout.ts
+++ b/packages/types/src/workout.ts
@@ -50,6 +50,9 @@ export const CreateWorkoutSchema = z
     programId: z.string().optional(),
     title: z.string().min(1, 'Title is required'),
     description: z.string().min(1, 'Description is required'),
+    // Optional stimulus / teaching notes (markdown). Empty string is
+    // normalized to null on write.
+    coachNotes: z.string().optional(),
     type: WorkoutTypeSchema,
     scheduledAt: z.string().datetime(),
     dayOrder: z.number().int().min(0).optional(),
@@ -74,6 +77,8 @@ export const UpdateWorkoutSchema = z
   .object({
     title: z.string().min(1).optional(),
     description: z.string().min(1).optional(),
+    // Empty string is treated as a clear (→ null) on the server.
+    coachNotes: z.string().nullable().optional(),
     type: WorkoutTypeSchema.optional(),
     scheduledAt: z.string().datetime().optional(),
     dayOrder: z.number().int().min(0).optional(),


### PR DESCRIPTION
Closes #185. Part of #184.

Smallest, additive, backwards-compatible PR for the coach notes feature. Lands ahead of the web (#186) and mobile (#187) sub-issues so both can consume the new field.

## Summary

- **Schema** — adds `coachNotes String?` (nullable TEXT) to `Workout`. New migration: `20260503001749_add_workout_coach_notes`.
- **Zod** — `CreateWorkoutSchema` accepts `coachNotes` as optional; `UpdateWorkoutSchema` accepts it as nullable + optional.
- **Routes** (`apps/api/src/routes/workouts.ts`) — `createWorkoutForProgram` and `patchWorkout` both destructure `coachNotes` and pass it through. The route layer normalizes empty string `""` → `null` so the field can be cleared via the same PATCH (no separate delete verb).
- **DB manager** — `CreateWorkoutData` / `UpdateWorkoutData` interfaces gain `coachNotes?: string | null`; the existing `...rest` pass-through wires it into `prisma.workout.create` / `update` with no per-field plumbing.
- **Read paths** unchanged — every GET query for Workout already uses `include` (not an explicit `select` of fields), so `coachNotes` rides along on `GET /api/workouts/:id` and `GET /api/gyms/:gymId/workouts` automatically.

Visibility is intentionally not gated at the API layer — every reader who can see the workout sees the `coachNotes`. The role-based default-collapsed/expanded behavior is a UI concern handled by #186 and #187.

## Tests

**API integration** (`apps/api/tests/workouts.ts`, new `=== coachNotes ===` block — 13 cases):
- POST with `coachNotes` → 201, value persisted on the response.
- POST without `coachNotes` → 201, value is `null`.
- GET `/workouts/:id` as MEMBER → `coachNotes` is included in the response (no API-level role gating).
- PATCH with `coachNotes: "..."` → 200, value updated; re-GET confirms persistence.
- PATCH with `coachNotes: ""` → 200, value cleared to `null`.
- PATCH with `coachNotes: null` → 200, value cleared to `null`.
- PATCH with `coachNotes: 12345` (wrong type) → 400.
- Auth guards on the underlying create/update routes are already covered by the existing `=== Program-scoped write access ===` and `=== Workout auth: gym-linked program (#118) ===` blocks; this field rides on the same routes so no new guard tests are needed.

**Roles tested:** PROGRAMMER (writes), MEMBER (reads).

**Run results against the worktree dev stack** (`API:3537`, `web:6862`):
- `npm run test:worktree -- api` — **371 passed, 0 failed** across all 8 API integration files (including the 65 in `workouts.ts` after the new 13).
- `npx turbo lint` (typecheck) — clean across all workspaces.
- E2E was not run for this PR — it's an API-only change with no new web behavior to drive.

**Mobile parity:** API only — no UI surface added in this PR. Web sub-issue is #186; mobile sub-issue is #187.

**Not automated / manual verification needed:**
- [x] None — all behavior is covered by integration tests.