### PR TITLE
feat: Personal Programs — private per-user workouts (API + web)

### DIFF
--- a/apps/api/src/db/programDbManager.ts
+++ b/apps/api/src/db/programDbManager.ts
@@ -1,4 +1,4 @@
-import { prisma, type ProgramVisibility } from '@wodalytics/db'
+import { prisma, ProgramRole, Prisma, type ProgramVisibility } from '@wodalytics/db'
 
 interface UpdateProgramData {
   name?: string
@@ -84,6 +84,63 @@ export async function findUnaffiliatedPublicProgramsForUser(userId: string) {
     orderBy: { createdAt: 'desc' },
     include: { _count: { select: { members: true, workouts: true } } },
   })
+}
+
+// ─── Personal Program (#183) ──────────────────────────────────────────────────
+
+const personalProgramInclude = {
+  _count: { select: { workouts: true } },
+} as const
+
+export type PersonalProgramRow = Prisma.ProgramGetPayload<{
+  include: typeof personalProgramInclude
+}>
+
+/**
+ * Returns the caller's personal program, creating it on first call. Idempotent:
+ * subsequent calls return the existing row. The unique constraint on
+ * `Program.ownerUserId` makes the create race-safe — concurrent first-time
+ * callers collapse to a single row, the loser gets P2002 and we re-fetch.
+ *
+ * Personal programs are PRIVATE, never linked to a Gym, and the owner is
+ * auto-subscribed as PROGRAMMER so the existing workout middleware grants
+ * read+write on workouts under the program (see middleware/workout.ts).
+ */
+export async function findOrCreatePersonalProgramForUser(userId: string): Promise<PersonalProgramRow> {
+  const existing = await prisma.program.findUnique({
+    where: { ownerUserId: userId },
+    include: personalProgramInclude,
+  })
+  if (existing) return existing
+
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const program = await tx.program.create({
+        data: {
+          name: 'Personal Program',
+          ownerUserId: userId,
+          startDate: new Date(),
+          visibility: 'PRIVATE',
+        },
+      })
+      await tx.userProgram.create({
+        data: { userId, programId: program.id, role: ProgramRole.PROGRAMMER },
+      })
+      return tx.program.findUniqueOrThrow({
+        where: { id: program.id },
+        include: personalProgramInclude,
+      })
+    })
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+      const racedRow = await prisma.program.findUnique({
+        where: { ownerUserId: userId },
+        include: personalProgramInclude,
+      })
+      if (racedRow) return racedRow
+    }
+    throw err
+  }
 }
 
 export type ProgramGymAccessResult = 'ok' | 'not-found' | 'forbidden'

--- a/apps/api/src/db/workoutDbManager.ts
+++ b/apps/api/src/db/workoutDbManager.ts
@@ -196,6 +196,30 @@ export async function findWorkoutsByGymAndDateRange(
   }))
 }
 
+/**
+ * Lists every workout in a single program, scheduled-asc. Used by the
+ * personal-program endpoint (#183) — there's no gym scoping, no date range,
+ * and no published-only filter because the caller is always the owner of
+ * a private one-user program.
+ */
+export async function findWorkoutsByProgramId(programId: string, viewerUserId: string) {
+  const workouts = await prisma.workout.findMany({
+    where: { programId },
+    orderBy: [{ scheduledAt: 'asc' }, { dayOrder: 'asc' }, { createdAt: 'asc' }],
+    include: {
+      program: programSelect,
+      namedWorkout: namedWorkoutSelect,
+      _count: { select: { results: true } },
+      results: { where: { userId: viewerUserId }, select: { id: true } },
+      ...workoutMovementsInclude,
+    },
+  })
+  return workouts.map(({ results, ...rest }) => ({
+    ...rest,
+    myResultId: results[0]?.id ?? null,
+  }))
+}
+
 export async function findWorkoutById(id: string) {
   return prisma.workout.findUnique({
     where: { id },

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,7 @@ import { prisma } from '@wodalytics/db'
 import { authRouter } from './routes/auth.js'
 import gymsRouter from './routes/gyms'
 import programsRouter from './routes/programs'
+import personalProgramRouter from './routes/personalProgram'
 import workoutsRouter from './routes/workouts'
 import resultsRouter from './routes/results'
 import namedWorkoutsRouter from './routes/namedWorkouts'
@@ -56,6 +57,7 @@ app.get('/api/health', async (_req, res) => {
 
 app.use('/api', gymsRouter)
 app.use('/api', programsRouter)
+app.use('/api', personalProgramRouter)
 app.use('/api', workoutsRouter)
 app.use('/api', resultsRouter)
 app.use('/api', namedWorkoutsRouter)

--- a/apps/api/src/routes/personalProgram.ts
+++ b/apps/api/src/routes/personalProgram.ts
@@ -1,0 +1,77 @@
+import { Router } from 'express'
+import type { Request, Response } from 'express'
+import { CreateWorkoutSchema } from '@wodalytics/types'
+import { requireAuth } from '../middleware/auth.js'
+import { findOrCreatePersonalProgramForUser } from '../db/programDbManager.js'
+import {
+  createWorkoutForProgram as createWorkoutForProgramDb,
+  findWorkoutsByProgramId,
+} from '../db/workoutDbManager.js'
+
+const router = Router()
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+// GET  /api/me/personal-program — returns the caller's personal program,
+//        creating it on first call. Idempotent.
+router.get('/me/personal-program', requireAuth, getMyPersonalProgram)
+
+// GET  /api/me/personal-program/workouts — list every workout in the personal program.
+//        No date range / publish-state filter — it's a single-user private program.
+router.get('/me/personal-program/workouts', requireAuth, listMyPersonalProgramWorkouts)
+
+// POST /api/me/personal-program/workouts — create a workout in the personal program.
+//        Upserts the program if missing so the user doesn't need to call GET first.
+//        `programId` in the body is ignored (we always pin to the personal program).
+router.post('/me/personal-program/workouts', requireAuth, createMyPersonalProgramWorkout)
+
+export default router
+
+// ─── Handler functions ────────────────────────────────────────────────────────
+
+async function getMyPersonalProgram(req: Request, res: Response) {
+  const userId = req.user!.id
+  const program = await findOrCreatePersonalProgramForUser(userId)
+  res.json(program)
+}
+
+async function listMyPersonalProgramWorkouts(req: Request, res: Response) {
+  const userId = req.user!.id
+  const program = await findOrCreatePersonalProgramForUser(userId)
+  const workouts = await findWorkoutsByProgramId(program.id, userId)
+  res.json(workouts)
+}
+
+async function createMyPersonalProgramWorkout(req: Request, res: Response) {
+  // Strip programId from the body before validating — personal-program workouts
+  // always pin to the caller's own program. Otherwise a spoofed programId could
+  // escape into another program.
+  const body = (req.body && typeof req.body === 'object') ? { ...req.body } : {}
+  delete (body as Record<string, unknown>).programId
+  const parsed = CreateWorkoutSchema.safeParse(body)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const field = issue?.path[0] ?? 'request'
+    const message = issue?.message ?? 'Invalid request'
+    return res.status(400).json({ error: `${field}: ${message}` })
+  }
+
+  const userId = req.user!.id
+  const program = await findOrCreatePersonalProgramForUser(userId)
+
+  const { title, description, type, scheduledAt, dayOrder, movementIds, movements, timeCapSeconds, tracksRounds } = parsed.data
+  const workout = await createWorkoutForProgramDb({
+    programId: program.id,
+    title,
+    description,
+    type,
+    scheduledAt: new Date(scheduledAt),
+    dayOrder: dayOrder ?? 0,
+    movementIds,
+    movements,
+    timeCapSeconds,
+    tracksRounds,
+  })
+  res.status(201).json(workout)
+}
+

--- a/apps/api/tests/personalProgram.ts
+++ b/apps/api/tests/personalProgram.ts
@@ -1,0 +1,249 @@
+/**
+ * Integration tests for the Personal Programs endpoints (#183).
+ *
+ * Requires: API running on localhost:3000 (or API_URL), DB accessible via DATABASE_URL.
+ * Run from apps/api/: npx tsx tests/personalProgram.ts
+ */
+
+import { prisma } from '@wodalytics/db'
+import { signTokenPair } from '../src/lib/jwt.js'
+
+const BASE = process.env.API_URL ?? 'http://localhost:3000/api'
+let pass = 0
+let fail = 0
+
+function check(label: string, expected: unknown, actual: unknown) {
+  if (String(expected) === String(actual)) {
+    console.log(`  ✓ ${label}`)
+    pass++
+  } else {
+    console.log(`  ✗ ${label}  [expected=${expected} actual=${actual}]`)
+    fail++
+  }
+}
+
+async function api(method: string, path: string, token?: string, body?: unknown) {
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  const text = await res.text()
+  let json: unknown
+  try { json = JSON.parse(text) } catch { json = text }
+  return { status: res.status, body: json as Record<string, unknown> }
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const TS = Date.now()
+let userAId = ''
+let userBId = ''
+let userATok = ''
+let userBTok = ''
+let movementId = ''
+const createdProgramIds: string[] = []
+const createdWorkoutIds: string[] = []
+
+async function setup() {
+  console.log('\n=== Setup ===')
+  const [a, b] = await Promise.all([
+    prisma.user.create({ data: { email: `pp-a-${TS}@test.com` } }),
+    prisma.user.create({ data: { email: `pp-b-${TS}@test.com` } }),
+  ])
+  userAId = a.id
+  userBId = b.id
+  userATok = signTokenPair(userAId, 'MEMBER').accessToken
+  userBTok = signTokenPair(userBId, 'MEMBER').accessToken
+
+  const movement = await prisma.movement.create({
+    data: { name: `pp-mov-${TS}`, status: 'ACTIVE' },
+  })
+  movementId = movement.id
+
+  console.log(`  userA=${userAId} userB=${userBId} movement=${movementId}`)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+async function testAuthGuards() {
+  console.log('\n=== Auth guards ===')
+  const r1 = await api('GET', '/me/personal-program')
+  check('GET /me/personal-program no token → 401', 401, r1.status)
+
+  const r2 = await api('GET', '/me/personal-program/workouts')
+  check('GET workouts no token → 401', 401, r2.status)
+
+  const r3 = await api('POST', '/me/personal-program/workouts', undefined, {
+    title: 'x', description: 'x', type: 'WARMUP', scheduledAt: new Date().toISOString(),
+  })
+  check('POST workouts no token → 401', 401, r3.status)
+}
+
+async function testUpsert() {
+  console.log('\n=== Upsert + idempotency ===')
+  const first = await api('GET', '/me/personal-program', userATok)
+  check('first GET → 200', 200, first.status)
+  check('returned ownerUserId matches caller', userAId, first.body.ownerUserId)
+  check('visibility is PRIVATE', 'PRIVATE', first.body.visibility)
+  check('name is "Personal Program"', 'Personal Program', first.body.name)
+  const programId = first.body.id as string
+  createdProgramIds.push(programId)
+
+  // Auto-subscription: caller is now a UserProgram PROGRAMMER on this program.
+  const sub = await prisma.userProgram.findUnique({
+    where: { userId_programId: { userId: userAId, programId } },
+  })
+  check('userProgram row exists', true, !!sub)
+  check('userProgram role is PROGRAMMER', 'PROGRAMMER', sub?.role)
+
+  // Second GET returns the same row (idempotent).
+  const second = await api('GET', '/me/personal-program', userATok)
+  check('second GET → 200', 200, second.status)
+  check('second GET returns same id', programId, second.body.id)
+
+  // No GymProgram rows ever created.
+  const gp = await prisma.gymProgram.count({ where: { programId } })
+  check('zero GymProgram links', 0, gp)
+}
+
+async function testWorkoutCreate() {
+  console.log('\n=== Create workout ===')
+  const r = await api('POST', '/me/personal-program/workouts', userATok, {
+    title: 'Z2 row',
+    description: '20 min easy row',
+    type: 'ROWING',
+    scheduledAt: new Date().toISOString(),
+    movementIds: [movementId],
+  })
+  check('POST workouts → 201', 201, r.status)
+  const workoutId = r.body.id as string
+  createdWorkoutIds.push(workoutId)
+  check('workout has personal program id', true, typeof r.body.programId === 'string' && r.body.programId.length > 0)
+  check('workout title persisted', 'Z2 row', r.body.title)
+
+  // Spoofed programId in body is ignored — workout still pins to the personal program.
+  const spoofed = await api('POST', '/me/personal-program/workouts', userATok, {
+    programId: 'nonexistent-program-id',
+    title: 'spoof attempt',
+    description: 'should still land in personal program',
+    type: 'WARMUP',
+    scheduledAt: new Date().toISOString(),
+  })
+  check('spoofed programId still 201', 201, spoofed.status)
+  check('spoofed programId was overridden', r.body.programId, spoofed.body.programId)
+  if (typeof spoofed.body.id === 'string') createdWorkoutIds.push(spoofed.body.id)
+
+  // Validation: 400 on missing title.
+  const bad = await api('POST', '/me/personal-program/workouts', userATok, {
+    description: 'no title', type: 'WARMUP', scheduledAt: new Date().toISOString(),
+  })
+  check('missing title → 400', 400, bad.status)
+}
+
+async function testWorkoutList() {
+  console.log('\n=== List workouts ===')
+  const r = await api('GET', '/me/personal-program/workouts', userATok)
+  check('GET workouts → 200', 200, r.status)
+  const arr = r.body as unknown as Array<{ id: string }>
+  check('list contains created workouts', true, arr.length >= 2)
+  check('list ids include first created workout', true, arr.some((w) => w.id === createdWorkoutIds[0]))
+}
+
+async function testIsolation() {
+  console.log('\n=== Isolation between users ===')
+  // User B gets their own personal program — different id.
+  const b = await api('GET', '/me/personal-program', userBTok)
+  check('user B GET → 200', 200, b.status)
+  const bProgramId = b.body.id as string
+  createdProgramIds.push(bProgramId)
+  check('user B has different programId from user A', true, bProgramId !== createdProgramIds[0])
+
+  // User B's workout list is empty.
+  const list = await api('GET', '/me/personal-program/workouts', userBTok)
+  check('user B sees empty workout list', 0, (list.body as unknown as unknown[]).length)
+
+  // User B cannot read user A's workout via /api/workouts/:id.
+  const aWorkoutId = createdWorkoutIds[0]
+  const denied = await api('GET', `/workouts/${aWorkoutId}`, userBTok)
+  check('user B GET /workouts/<A-workout> → 403', 403, denied.status)
+
+  // User A can read it (workout middleware permits unaffiliated-program subscribers).
+  const allowed = await api('GET', `/workouts/${aWorkoutId}`, userATok)
+  check('user A GET /workouts/<A-workout> → 200', 200, allowed.status)
+}
+
+async function testEdit() {
+  console.log('\n=== Edit + delete via existing /workouts/:id route ===')
+  const wid = createdWorkoutIds[0]
+  const patch = await api('PATCH', `/workouts/${wid}`, userATok, { title: 'Z2 row (edited)' })
+  check('user A PATCH → 200', 200, patch.status)
+  check('title updated', 'Z2 row (edited)', patch.body.title)
+
+  // User B cannot patch user A's personal-program workout.
+  const denied = await api('PATCH', `/workouts/${wid}`, userBTok, { title: 'hijack' })
+  check('user B PATCH → 403', 403, denied.status)
+
+  const del = await api('DELETE', `/workouts/${wid}`, userATok)
+  check('user A DELETE → 204', 204, del.status)
+  // Remove from cleanup list since it's gone.
+  createdWorkoutIds.splice(createdWorkoutIds.indexOf(wid), 1)
+}
+
+async function testNotPubliclyDiscoverable() {
+  console.log('\n=== Not publicly discoverable ===')
+  // /api/programs/public-catalog filters by visibility=PUBLIC — personal
+  // programs are PRIVATE so they must not appear.
+  const r = await api('GET', '/programs/public-catalog', userBTok)
+  check('GET public-catalog → 200', 200, r.status)
+  const list = r.body as unknown as Array<{ ownerUserId: string | null }>
+  const leaked = list.some((p) => p.ownerUserId !== null && p.ownerUserId !== undefined)
+  check('no personal programs surface in public-catalog', false, leaked)
+}
+
+async function runTests() {
+  await testAuthGuards()
+  await testUpsert()
+  await testWorkoutCreate()
+  await testWorkoutList()
+  await testIsolation()
+  await testEdit()
+  await testNotPubliclyDiscoverable()
+}
+
+// ─── Teardown ─────────────────────────────────────────────────────────────────
+
+async function teardown() {
+  console.log('\n=== Teardown ===')
+  for (const wid of createdWorkoutIds) {
+    await prisma.workout.delete({ where: { id: wid } }).catch(() => {})
+  }
+  for (const pid of createdProgramIds) {
+    await prisma.workout.deleteMany({ where: { programId: pid } }).catch(() => {})
+    await prisma.userProgram.deleteMany({ where: { programId: pid } }).catch(() => {})
+    await prisma.program.delete({ where: { id: pid } }).catch(() => {})
+  }
+  await prisma.movement.delete({ where: { id: movementId } }).catch(() => {})
+  await prisma.user.deleteMany({ where: { id: { in: [userAId, userBId] } } }).catch(() => {})
+  console.log('  cleaned up')
+}
+
+async function main() {
+  try {
+    await setup()
+    await runTests()
+  } finally {
+    await teardown()
+    await prisma.$disconnect()
+  }
+  console.log(`\n=== Results: ${pass} passed, ${fail} failed ===\n`)
+  if (fail > 0) process.exit(1)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -27,6 +27,7 @@ import Feed from './pages/Feed.tsx'
 import WodDetail from './pages/WodDetail.tsx'
 import WodResultDetail from './pages/WodResultDetail.tsx'
 import History from './pages/History.tsx'
+import PersonalProgram from './pages/PersonalProgram.tsx'
 
 export function PageErrorFallback({ error, resetErrorBoundary }: { error: unknown; resetErrorBoundary: () => void }) {
   const navigate = useNavigate()
@@ -70,6 +71,7 @@ function AppLayout() {
               <Route path="/workouts/:id" element={<WodDetail />} />
               <Route path="/workouts/:id/results/:resultId" element={<WodResultDetail />} />
               <Route path="/history" element={<History />} />
+              <Route path="/personal-program" element={<PersonalProgram />} />
               <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/calendar" element={<Calendar />} />
               <Route path="/programs" element={<ProgramsIndex />} />

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -5,8 +5,9 @@ import ProgramFilterPicker from './ProgramFilterPicker.tsx'
 
 // Browse Gyms moved into the TopBar gym picker — no standalone sidebar entry.
 const memberLinks = [
-  { to: '/feed',    label: 'Feed'    },
-  { to: '/history', label: 'History' },
+  { to: '/feed',             label: 'Feed'             },
+  { to: '/history',          label: 'History'          },
+  { to: '/personal-program', label: 'Personal Program' },
 ]
 
 // Members consolidated into /gym-settings#members (slice D1) — no standalone link.

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -271,6 +271,14 @@ export interface Program {
   _count?: { members: number; workouts: number }
 }
 
+// User's private "Personal Program" (#183) — same Prisma model as Program but
+// with `ownerUserId` set, no GymProgram links, and PRIVATE visibility. The
+// `_count.workouts` field is always populated since the page header reads it.
+export interface PersonalProgram extends Omit<Program, '_count'> {
+  ownerUserId: string
+  _count: { workouts: number }
+}
+
 export type ProgramRole = 'MEMBER' | 'PROGRAMMER'
 
 export interface ProgramMember {
@@ -495,6 +503,39 @@ export const api = {
      */
     programs: (gymId: string, token?: string) =>
       req<GymProgram[]>(`/api/me/programs?gymId=${encodeURIComponent(gymId)}`, { token }),
+
+    personalProgram: {
+      // Returns the caller's private "Personal Program" (#183), creating it on
+      // first call. Idempotent — repeat calls return the existing row.
+      get: (token?: string) =>
+        req<PersonalProgram>('/api/me/personal-program', { token }),
+
+      workouts: {
+        list: (token?: string) =>
+          req<Workout[]>('/api/me/personal-program/workouts', { token }),
+        // Body uses the same shape as `api.workouts.create` minus `programId`,
+        // which is always the caller's personal program server-side.
+        create: (
+          data: {
+            title: string
+            description: string
+            type: WorkoutType
+            scheduledAt: string
+            movementIds?: string[]
+            movements?: WorkoutMovementInput[]
+            namedWorkoutId?: string
+            timeCapSeconds?: number | null
+            tracksRounds?: boolean
+          },
+          token?: string,
+        ) =>
+          req<Workout>('/api/me/personal-program/workouts', {
+            method: 'POST',
+            body: JSON.stringify(data),
+            token,
+          }),
+      },
+    },
   },
 
   gyms: {

--- a/apps/web/src/pages/PersonalProgram.test.tsx
+++ b/apps/web/src/pages/PersonalProgram.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import PersonalProgram from './PersonalProgram'
+import type { PersonalProgram as PersonalProgramType, Workout } from '../lib/api'
+
+const baseProgram: PersonalProgramType = {
+  id: 'pp1',
+  name: 'Personal Program',
+  description: null,
+  startDate: '2026-05-01T00:00:00.000Z',
+  endDate: null,
+  coverColor: null,
+  visibility: 'PRIVATE',
+  ownerUserId: 'u1',
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-01T00:00:00.000Z',
+  _count: { workouts: 0 },
+}
+
+const seededWorkout: Workout = {
+  id: 'w1',
+  title: 'Easy Z2 row',
+  description: '20 minutes at conversational pace',
+  type: 'ROWING',
+  status: 'DRAFT',
+  scheduledAt: '2026-05-02T00:00:00.000Z',
+  dayOrder: 0,
+  workoutMovements: [],
+  programId: 'pp1',
+  program: { id: 'pp1', name: 'Personal Program' },
+  namedWorkoutId: null,
+  namedWorkout: null,
+  timeCapSeconds: null,
+  tracksRounds: false,
+  _count: { results: 0 },
+  createdAt: '2026-05-02T00:00:00.000Z',
+  updatedAt: '2026-05-02T00:00:00.000Z',
+}
+
+vi.mock('../lib/api', () => ({
+  api: {
+    me: {
+      personalProgram: {
+        get: vi.fn(),
+        workouts: {
+          list: vi.fn(),
+          create: vi.fn(),
+        },
+      },
+    },
+  },
+}))
+
+import { api } from '../lib/api'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(api.me.personalProgram.get).mockResolvedValue(baseProgram)
+  vi.mocked(api.me.personalProgram.workouts.list).mockResolvedValue([])
+})
+
+function renderPage() {
+  return render(<MemoryRouter><PersonalProgram /></MemoryRouter>)
+}
+
+describe('PersonalProgram page', () => {
+  it('renders the heading and empty state when no workouts exist', async () => {
+    renderPage()
+    expect(await screen.findByRole('heading', { name: 'Personal Program' })).toBeInTheDocument()
+    expect(await screen.findByText(/No personal workouts yet/)).toBeInTheDocument()
+  })
+
+  it('lists existing personal workouts with title and date', async () => {
+    vi.mocked(api.me.personalProgram.workouts.list).mockResolvedValue([seededWorkout])
+    vi.mocked(api.me.personalProgram.get).mockResolvedValue({ ...baseProgram, _count: { workouts: 1 } })
+    renderPage()
+    expect(await screen.findByText('Easy Z2 row')).toBeInTheDocument()
+    expect(screen.getByText('1 workout')).toBeInTheDocument()
+  })
+
+  it('opens the create form when "New workout" is clicked and submits valid input', async () => {
+    vi.mocked(api.me.personalProgram.workouts.create).mockResolvedValue({
+      ...seededWorkout,
+      id: 'w2',
+      title: 'Murph (light)',
+    })
+    renderPage()
+    await screen.findByRole('heading', { name: 'Personal Program' })
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /New workout/ }))
+
+    await user.type(screen.getByLabelText('Title'), 'Murph (light)')
+    await user.type(screen.getByLabelText('Description'), '1 mile run, 50 pull-ups, 100 push-ups, 150 squats, 1 mile run')
+    await user.click(screen.getByRole('button', { name: /Create workout/ }))
+
+    await waitFor(() => expect(api.me.personalProgram.workouts.create).toHaveBeenCalled())
+    const payload = vi.mocked(api.me.personalProgram.workouts.create).mock.calls[0][0]
+    expect(payload.title).toBe('Murph (light)')
+    expect(payload.description).toContain('mile run')
+    // After successful create, the new workout appears in the list.
+    expect(await screen.findByText('Murph (light)')).toBeInTheDocument()
+  })
+
+  it('blocks create when title or description is empty', async () => {
+    renderPage()
+    await screen.findByRole('heading', { name: 'Personal Program' })
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /New workout/ }))
+    // Leave fields blank — HTML5 `required` prevents submit, so api isn't called.
+    await user.click(screen.getByRole('button', { name: /Create workout/ }))
+    expect(api.me.personalProgram.workouts.create).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/pages/PersonalProgram.tsx
+++ b/apps/web/src/pages/PersonalProgram.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api, type PersonalProgram, type Workout, type WorkoutType } from '../lib/api'
+import { WORKOUT_CATEGORIES, WORKOUT_TYPE_STYLES, typesInCategory } from '../lib/workoutTypeStyles'
+import Button from '../components/ui/Button'
+import EmptyState from '../components/ui/EmptyState'
+import Skeleton from '../components/ui/Skeleton'
+
+function todayLocalIsoDate(): string {
+  const now = new Date()
+  const y = now.getFullYear()
+  const m = String(now.getMonth() + 1).padStart(2, '0')
+  const d = String(now.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+function formatDateBadge(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+export default function PersonalProgramPage() {
+  const navigate = useNavigate()
+  const [program, setProgram] = useState<PersonalProgram | null>(null)
+  const [workouts, setWorkouts] = useState<Workout[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [showForm, setShowForm] = useState(false)
+
+  // Create-form state
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [type, setType] = useState<WorkoutType>('METCON')
+  const [scheduledDate, setScheduledDate] = useState<string>(todayLocalIsoDate)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    Promise.all([
+      api.me.personalProgram.get(),
+      api.me.personalProgram.workouts.list(),
+    ])
+      .then(([p, w]) => {
+        if (!cancelled) {
+          setProgram(p)
+          setWorkouts(w)
+        }
+      })
+      .catch((e: unknown) => { if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  function resetForm() {
+    setTitle('')
+    setDescription('')
+    setType('METCON')
+    setScheduledDate(todayLocalIsoDate())
+    setFormError(null)
+  }
+
+  async function handleCreate(e: FormEvent) {
+    e.preventDefault()
+    if (creating) return
+    if (!title.trim() || !description.trim()) {
+      setFormError('Title and description are required')
+      return
+    }
+    setCreating(true)
+    setFormError(null)
+    try {
+      // Local midnight → ISO string. Personal-program workouts have no
+      // gym timezone, so the user's local clock is the source of truth.
+      const scheduledAt = new Date(`${scheduledDate}T00:00:00`).toISOString()
+      const created = await api.me.personalProgram.workouts.create({
+        title: title.trim(),
+        description: description.trim(),
+        type,
+        scheduledAt,
+      })
+      setWorkouts((prev) => [...prev, created].sort((a, b) => a.scheduledAt.localeCompare(b.scheduledAt)))
+      resetForm()
+      setShowForm(false)
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to create workout')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <header className="flex flex-wrap items-baseline justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold">Personal Program</h1>
+          <p className="text-sm text-gray-400 mt-1">
+            Your private workouts — only you can see or edit these.
+          </p>
+        </div>
+        {program && (
+          <span
+            className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded-full bg-gray-800 text-gray-300"
+            aria-label={`${program._count.workouts} workouts`}
+          >
+            {program._count.workouts} workout{program._count.workouts === 1 ? '' : 's'}
+          </span>
+        )}
+      </header>
+
+      {error && (
+        <div className="bg-rose-950/40 border border-rose-900 text-rose-300 text-sm px-3 py-2 rounded">
+          {error}
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        {!showForm ? (
+          <Button variant="primary" onClick={() => setShowForm(true)}>
+            New workout
+          </Button>
+        ) : (
+          <Button variant="tertiary" onClick={() => { setShowForm(false); resetForm() }}>
+            Cancel
+          </Button>
+        )}
+      </div>
+
+      {showForm && (
+        <form
+          onSubmit={handleCreate}
+          aria-label="New personal workout"
+          className="bg-gray-900 border border-gray-800 rounded-lg p-4 space-y-3"
+        >
+          <div className="space-y-1">
+            <label htmlFor="pp-title" className="text-xs text-gray-400">Title</label>
+            <input
+              id="pp-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Easy Z2 row"
+              className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+              maxLength={120}
+              required
+            />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="pp-description" className="text-xs text-gray-400">Description</label>
+            <textarea
+              id="pp-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Sets, reps, notes…"
+              className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm h-28 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+              required
+            />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <label htmlFor="pp-type" className="text-xs text-gray-400">Type</label>
+              <select
+                id="pp-type"
+                value={type}
+                onChange={(e) => setType(e.target.value as WorkoutType)}
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+              >
+                {WORKOUT_CATEGORIES.map((cat) => (
+                  <optgroup key={cat} label={cat}>
+                    {typesInCategory(cat).map((t) => (
+                      <option key={t} value={t}>{WORKOUT_TYPE_STYLES[t].label}</option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="pp-date" className="text-xs text-gray-400">Date</label>
+              <input
+                id="pp-date"
+                type="date"
+                value={scheduledDate}
+                onChange={(e) => setScheduledDate(e.target.value)}
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                required
+              />
+            </div>
+          </div>
+
+          {formError && <p className="text-rose-400 text-sm">{formError}</p>}
+
+          <div className="flex justify-end gap-2">
+            <Button type="submit" variant="primary" disabled={creating}>
+              {creating ? 'Creating…' : 'Create workout'}
+            </Button>
+          </div>
+        </form>
+      )}
+
+      {loading ? (
+        <div className="space-y-2">
+          <Skeleton variant="feed-row" count={3} />
+        </div>
+      ) : workouts.length === 0 ? (
+        <EmptyState
+          title="No personal workouts yet"
+          body="Add accessory work, extra cardio, or anything else you want to track outside of your gym's programming."
+        />
+      ) : (
+        <ul className="space-y-2">
+          {workouts.map((w) => {
+            const style = WORKOUT_TYPE_STYLES[w.type]
+            return (
+              <li key={w.id}>
+                <button
+                  type="button"
+                  onClick={() => navigate(`/workouts/${w.id}`)}
+                  className="w-full text-left bg-gray-900 hover:bg-gray-800 border border-gray-800 rounded-lg p-3 flex items-start gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
+                >
+                  <span
+                    className={`shrink-0 inline-flex items-center justify-center text-[10px] font-semibold rounded px-1.5 py-1 min-w-[2.5rem] ${style.bg} ${style.tint}`}
+                    aria-hidden="true"
+                  >
+                    {style.abbr}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-medium truncate">{w.title}</span>
+                      <time className="text-xs text-gray-400 shrink-0">{formatDateBadge(w.scheduledAt)}</time>
+                    </div>
+                    {w.description && (
+                      <p className="text-sm text-gray-400 mt-0.5 line-clamp-2">{w.description}</p>
+                    )}
+                  </div>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Adds the user-facing slice of the **Personal Programs** feature (#183) on top of the schema migration in #189 — a private, auto-upserted `Program` per user where they can author workouts that are never visible to anyone else.

> **Depends on #189** (migration). When the migration PR merges first, the feature diff in this PR collapses to just the API + web changes.

### API
- **`findOrCreatePersonalProgramForUser(userId)`** in `programDbManager` — race-safe upsert leaning on the unique `Program.ownerUserId` constraint, with a P2002 → re-fetch fallback for concurrent first-time callers. Auto-subscribes the caller as `UserProgram.role=PROGRAMMER`.
- New routes (`apps/api/src/routes/personalProgram.ts`):
  - `GET  /api/me/personal-program` — upsert + return
  - `GET  /api/me/personal-program/workouts` — list, sorted by `scheduledAt`
  - `POST /api/me/personal-program/workouts` — create. Strips `programId` from the body before validating so a spoofed id can't escape into another program.
- Workout edit / delete reuse `PATCH/DELETE /api/workouts/:id`. The existing `requireWorkoutWriteAccess` middleware already gates write-access on unaffiliated programs by `UserProgram.role=PROGRAMMER`, so personal-program workouts are authorized through the same path catalog programs use — **no new middleware**.

### Web
- **`/personal-program`** page — workout list (badge / title / date / description) plus an inline create form (title / description / type / date). Each row links to the existing `/workouts/:id` detail page.
- Sidebar adds a **Personal Program** entry in `memberLinks` (any signed-in user, not staff-gated).
- `api.me.personalProgram.{get, workouts.{list,create}}` mirrors the server.
- `PersonalProgram` type extends `Program` with `ownerUserId` and a narrowed `_count: { workouts }` (no members count for one-user programs).

### Why this design

`Program` already supports unaffiliated rows (no `GymProgram` links — used today by the CrossFit Mainsite catalog), and the workout middleware already grants write access to `UserProgram.PROGRAMMER` on unaffiliated programs. Personal programs slot into that existing path with a single new explicit signal — `ownerUserId` — so we don't fork the auth model.

## Tests

**Unit** (`apps/web/src/pages/PersonalProgram.test.tsx`):
- renders the heading and shows the EmptyState when no workouts exist
- lists existing personal workouts with title and date when the API returns rows
- opens the create form, submits valid input, surfaces the new workout in the list
- HTML5 `required` blocks submit when title or description is empty

**API integration** (`apps/api/tests/personalProgram.ts`):
- Auth guards: `GET /me/personal-program`, `GET workouts`, `POST workouts` all 401 without a token
- Upsert + idempotency: first GET creates → 200, returns `ownerUserId` matching caller, `visibility=PRIVATE`, `name="Personal Program"`; auto-subscription row exists with `role=PROGRAMMER`; second GET returns the same id; zero `GymProgram` links ever created
- Create workout: `POST workouts` → 201 with the personal program's id; spoofed `programId` in body is silently overridden; missing title → 400
- List: `GET workouts` returns the created workouts
- Isolation between users: user B's GET creates a *different* program; user B's workout list is empty; user B cannot read user A's workouts via `/api/workouts/:id` (403); user A can (200)
- Edit + delete via existing `/workouts/:id`: user A PATCH → 200 (title updates), user B PATCH → 403, user A DELETE → 204
- Not publicly discoverable: `/api/programs/public-catalog` does not surface any program with a non-null `ownerUserId`

**Playwright E2E:**
- Existing personal-program flow is covered end-to-end by the API integration test (every endpoint), and component-level by the unit test (rendering, form submit). No new E2E spec — adding one would duplicate the cross-stack assertions already covered.
- Pre-existing flake on master: `tests/programs.spec.ts:277 — MEMBER joins a PUBLIC program from Browse` failed in this run too. Strict-mode `getByRole('button', { name: 'Join' })` likely collides with concurrent seed data on the shared dev DB. Not caused by this PR — none of the changed files touch `/browse-programs` or `findUnaffiliatedPublicProgramsForUser`.

**Roles tested:** any authenticated user (Personal Programs are not gym-role-gated). User isolation is the primary access concern and is covered above (user B blocked from user A's workouts at both `GET /me/personal-program/workouts` and `PATCH /api/workouts/:id`).

**Mobile parity:** desk-suitable + phone-suitable hybrid — viewing/jotting an extra workout is phone-suitable, but authoring a complex workout with prescriptions is desk-suitable. Mobile sibling tracked under #183. Filing a follow-up sub-issue is part of closing #183 in this slice; the web shape (route `/personal-program`, request/response of `GET/POST /api/me/personal-program/workouts`) is the contract mobile will mirror.

**Not automated / manual verification needed:**
- [ ] Visual polish — the form is intentionally minimal; advanced prescription editing (movements, sets/reps/load) lives in the existing `WorkoutDrawer` and is not yet reachable from this page. A follow-up can wire the drawer in once it's pulled out of the gym/calendar coupling.

Closes #183