### PR TITLE
feat(mobile): collapsible coach notes viewer on WodDetailScreen

### DIFF
--- a/apps/mobile/__tests__/FeedScreen.test.tsx
+++ b/apps/mobile/__tests__/FeedScreen.test.tsx
@@ -38,7 +38,7 @@ import { useGym } from '../src/context/GymContext'
 import { useProgramFilter } from '../src/context/ProgramFilterContext'
 import { api } from '../src/lib/api'
 
-const ACTIVE_GYM = { id: 'gym-1', name: 'Test Gym', slug: 'test-gym', timezone: 'UTC', userRole: 'MEMBER' }
+const ACTIVE_GYM = { id: 'gym-1', name: 'Test Gym', slug: 'test-gym', timezone: 'UTC', role: 'MEMBER' }
 
 function makeNavigation() {
   return { navigate: jest.fn(), setOptions: jest.fn(), goBack: jest.fn() } as any

--- a/apps/mobile/__tests__/ProgramFilterContext.test.tsx
+++ b/apps/mobile/__tests__/ProgramFilterContext.test.tsx
@@ -87,7 +87,7 @@ describe('ProgramFilterContext', () => {
     jest.clearAllMocks()
     mockStore.clear()
     ;(useGym as jest.Mock).mockReturnValue({
-      activeGym: { id: 'gym-1', name: 'Test', slug: 't', timezone: 'UTC', userRole: 'MEMBER' },
+      activeGym: { id: 'gym-1', name: 'Test', slug: 't', timezone: 'UTC', role: 'MEMBER' },
       isLoading: false,
       selectGym: jest.fn(),
     })

--- a/apps/mobile/__tests__/WodDetailScreen.test.tsx
+++ b/apps/mobile/__tests__/WodDetailScreen.test.tsx
@@ -24,6 +24,10 @@ jest.mock('../src/context/AuthContext', () => ({
   useAuth: jest.fn(),
 }))
 
+jest.mock('../src/context/GymContext', () => ({
+  useGym: jest.fn(),
+}))
+
 jest.mock('../src/lib/api', () => ({
   api: {
     workouts: {
@@ -42,6 +46,7 @@ jest.mock('../src/lib/format', () => ({
 }))
 
 import { useAuth } from '../src/context/AuthContext'
+import { useGym } from '../src/context/GymContext'
 import { api } from '../src/lib/api'
 
 const WORKOUT = {
@@ -82,6 +87,13 @@ describe('WodDetailScreen', () => {
       isLoading: false,
       login: jest.fn(),
       logout: jest.fn(),
+    })
+    // Default to MEMBER for the existing tests — they don't care about role,
+    // and the coach-notes tests below override per-case via mockReturnValueOnce.
+    ;(useGym as jest.Mock).mockReturnValue({
+      activeGym: { id: 'gym-1', name: 'Test Gym', slug: 'test-gym', timezone: 'UTC', role: 'MEMBER' },
+      isLoading: false,
+      selectGym: jest.fn(),
     })
     ;(api.workouts.get as jest.Mock).mockResolvedValue(WORKOUT)
     ;(api.workouts.results as jest.Mock).mockResolvedValue([])
@@ -277,5 +289,79 @@ describe('WodDetailScreen', () => {
     const highlight = '#1e1b4b'
     expect(findAncestorWithBg(meText, highlight)).not.toBeNull()
     expect(findAncestorWithBg(await findByText('Alice'), highlight)).toBeNull()
+  })
+
+  // ── Coach notes (#187) ─────────────────────────────────────────────────────
+  // The collapsible "Coach notes" panel ships viewer-only on mobile (authoring
+  // is deferred until the mobile workout-edit screen lands — see #130). The
+  // default open/closed state is driven by the active gym role per #184:
+  // MEMBER → collapsed, COACH/PROGRAMMER/OWNER → expanded.
+  describe('coach notes', () => {
+    test('renders nothing when workout.coachNotes is null', async () => {
+      ;(api.workouts.get as jest.Mock).mockResolvedValue({ ...WORKOUT, coachNotes: null })
+
+      const { findByText, queryByText, queryByTestId } = render(
+        <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
+      )
+
+      // Wait for the screen to render fully before asserting absence — otherwise
+      // the queryBy could match against the loading state and produce a false
+      // negative.
+      await findByText('Fran')
+
+      expect(queryByText('COACH NOTES')).toBeNull()
+      expect(queryByTestId('coach-notes-toggle')).toBeNull()
+      expect(queryByTestId('coach-notes-body')).toBeNull()
+    })
+
+    test('MEMBER → header rendered, body hidden initially; press reveals body', async () => {
+      ;(useGym as jest.Mock).mockReturnValue({
+        activeGym: { id: 'gym-1', name: 'Test Gym', slug: 'test-gym', timezone: 'UTC', role: 'MEMBER' },
+        isLoading: false,
+        selectGym: jest.fn(),
+      })
+      ;(api.workouts.get as jest.Mock).mockResolvedValue({
+        ...WORKOUT,
+        coachNotes: 'Stim: 7-min sprint pace.',
+      })
+
+      const { findByTestId, queryByTestId, queryByText } = render(
+        <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
+      )
+
+      // Header is present, body is not.
+      const toggle = await findByTestId('coach-notes-toggle')
+      expect(queryByTestId('coach-notes-body')).toBeNull()
+      expect(queryByText('Stim: 7-min sprint pace.')).toBeNull()
+
+      // Pressing the header reveals the body.
+      fireEvent.press(toggle)
+      expect(await findByTestId('coach-notes-body')).toBeTruthy()
+      expect(queryByText('Stim: 7-min sprint pace.')).not.toBeNull()
+    })
+
+    test.each(['COACH', 'PROGRAMMER', 'OWNER'] as const)(
+      '%s → body rendered initially without a press',
+      async (role) => {
+        ;(useGym as jest.Mock).mockReturnValue({
+          activeGym: { id: 'gym-1', name: 'Test Gym', slug: 'test-gym', timezone: 'UTC', role },
+          isLoading: false,
+          selectGym: jest.fn(),
+        })
+        ;(api.workouts.get as jest.Mock).mockResolvedValue({
+          ...WORKOUT,
+          coachNotes: 'Cue hip drive on the second pull.',
+        })
+
+        const { findByTestId, findByText } = render(
+          <WodDetailScreen navigation={makeNavigation()} route={makeRoute()} />,
+        )
+
+        // Both header and body are present from first paint — no press needed.
+        await findByTestId('coach-notes-toggle')
+        await findByTestId('coach-notes-body')
+        await findByText('Cue hip drive on the second pull.')
+      },
+    )
   })
 })

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -59,6 +59,8 @@ export interface WorkoutMovementWithPrescription {
   seconds: number | null
 }
 
+export type Role = 'OWNER' | 'PROGRAMMER' | 'COACH' | 'MEMBER'
+
 export interface AuthUser {
   id: string
   email: string
@@ -71,7 +73,9 @@ export interface Gym {
   name: string
   slug: string
   timezone: string
-  userRole: string
+  // The caller's membership role within this gym. Mirrors what
+  // GET /api/me/gyms returns (see findGymMembershipsByUserId in the API).
+  role: Role
 }
 
 export interface Program {
@@ -96,6 +100,9 @@ export interface Workout {
   id: string
   title: string
   description: string
+  // Optional programmer-authored stimulus / teaching notes (#184). Nullable
+  // on read; mobile only displays it (no authoring surface yet — #130).
+  coachNotes?: string | null
   type: WorkoutType
   status: WorkoutStatus
   scheduledAt: string

--- a/apps/mobile/src/screens/WodDetailScreen.tsx
+++ b/apps/mobile/src/screens/WodDetailScreen.tsx
@@ -13,6 +13,7 @@ import type { RootStackParamList } from '../../App'
 import { api, type Workout, type LeaderboardEntry, type WorkoutLevel, type WorkoutGender } from '../lib/api'
 import { styleFor } from '../lib/workoutTypeStyles'
 import { useAuth } from '../context/AuthContext'
+import { useGym } from '../context/GymContext'
 import { formatResultValue } from '../lib/format'
 
 type Props = StackScreenProps<RootStackParamList, 'WodDetail'>
@@ -48,12 +49,18 @@ const GENDER_LABELS: Record<WorkoutGender, string> = {
 export default function WodDetailScreen({ route, navigation }: Props) {
   const { workoutId } = route.params
   const { user } = useAuth()
+  const { activeGym } = useGym()
   const [workout, setWorkout] = useState<Workout | null>(null)
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([])
   const [levelFilter, setLevelFilter] = useState<WorkoutLevel | null>(null)
   const [genderFilter, setGenderFilter] = useState<WorkoutGender | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  // Coach notes are reference material for staff during class but supplementary
+  // colour for members — so the toggle defaults open for COACH/PROGRAMMER/OWNER
+  // and closed for MEMBER. Same contract as web (#184). User can always toggle.
+  const isStaff = activeGym?.role === 'COACH' || activeGym?.role === 'PROGRAMMER' || activeGym?.role === 'OWNER'
+  const [showCoachNotes, setShowCoachNotes] = useState(isStaff)
 
   // Load workout details once
   useEffect(() => {
@@ -132,6 +139,29 @@ export default function WodDetailScreen({ route, navigation }: Props) {
         </View>
         <Text style={styles.title}>{workout.title}</Text>
       </View>
+
+      {/* Coach notes — collapsible. Default state per role (#184): expanded for
+          staff, collapsed for members. Hidden entirely when notes are absent. */}
+      {workout.coachNotes ? (
+        <View style={styles.section}>
+          <TouchableOpacity
+            style={styles.coachNotesHeader}
+            onPress={() => setShowCoachNotes((v) => !v)}
+            activeOpacity={0.7}
+            testID="coach-notes-toggle"
+            accessibilityRole="button"
+            accessibilityState={{ expanded: showCoachNotes }}
+          >
+            <Text style={styles.coachNotesLabel}>COACH NOTES</Text>
+            <Text style={styles.coachNotesChevron}>{showCoachNotes ? '−' : '+'}</Text>
+          </TouchableOpacity>
+          {showCoachNotes ? (
+            <Text style={styles.coachNotesBody} testID="coach-notes-body">
+              {workout.coachNotes}
+            </Text>
+          ) : null}
+        </View>
+      ) : null}
 
       {/* Description */}
       {workout.description ? (
@@ -302,6 +332,31 @@ const styles = StyleSheet.create({
     marginBottom: 10,
   },
   description: {
+    fontSize: 15,
+    color: '#d1d5db',
+    lineHeight: 22,
+  },
+  coachNotesHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  // Same visual as sectionLabel but without its own marginBottom (the row owns
+  // spacing so the chevron stays vertically centered).
+  coachNotesLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: '#4b5563',
+    letterSpacing: 0.8,
+  },
+  coachNotesChevron: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#6b7280',
+    paddingHorizontal: 6,
+  },
+  coachNotesBody: {
     fontSize: 15,
     color: '#d1d5db',
     lineHeight: 22,


### PR DESCRIPTION
Mobile slice of the coach-notes feature (parent #184). Adds a viewer-only "Coach notes" section to `WodDetailScreen` that mirrors the role-based default-expanded contract from the parent issue. Authoring on mobile is deferred until the workout-edit screen lands (tracked under #130).

## What changed

- `apps/mobile/src/screens/WodDetailScreen.tsx` — new collapsible "Coach notes" section above the workout description. `TouchableOpacity` header with a `+` / `−` chevron toggles a local `showCoachNotes` state. The initial value is derived from `useGym().activeGym?.role`:
  - `MEMBER` → collapsed
  - `COACH` / `PROGRAMMER` / `OWNER` → expanded
  - When `workout.coachNotes` is null/empty, nothing renders (no header, no body).
- `apps/mobile/src/lib/api.ts` — added `coachNotes?: string \| null` to the `Workout` interface (the API has been returning it since #185 / PR #191). Also corrected the `Gym` type's role field, which was typed as `userRole: string` but never matched what `GET /api/me/gyms` actually returns (`role: Role`); introduced a `Role` union to mirror the web's. Updated the two existing test fixtures (`FeedScreen`, `ProgramFilterContext`) that referenced the stale `userRole`.
- `apps/mobile/__tests__/WodDetailScreen.test.tsx` — added a `coach notes` describe block with three tests covering the role contract.

## Tests

**Unit** (`apps/mobile/__tests__/WodDetailScreen.test.tsx`):
- `coach notes › renders nothing when workout.coachNotes is null` — asserts that with `coachNotes: null` no header, no toggle, and no body are rendered.
- `coach notes › MEMBER → header rendered, body hidden initially; press reveals body` — asserts the toggle is present but the body is absent on first paint when role is `MEMBER`, then asserts pressing the toggle reveals the body and the note text.
- `coach notes › %s → body rendered initially without a press` — `test.each` over `['COACH', 'PROGRAMMER', 'OWNER']`; each role asserts the body and note text are visible from first paint with no interaction.
- All seven pre-existing `WodDetailScreen` tests still pass (added a default `useGym` mock in `beforeEach` returning a `MEMBER` gym so they remain valid against the new `useGym()` consumer).

**Suite totals:** 11 tests in `WodDetailScreen.test.tsx` (3 new + 8 pre-existing). 51 mobile tests pass overall across 7 of 8 suites; the 8th suite (`LogResultScreen.test.tsx`) errors at suite-level with `Cannot find module '@wodalytics/types'` — this is a pre-existing failure on `main`, unaffected by this PR (no LogResult code or its test was touched).

**API integration / Playwright E2E:** N/A. This PR only touches `apps/mobile/**`; the API + schema slice already shipped in PR #191 and the web slice is being implemented in parallel as #186.

**Typecheck:** `npx tsc --noEmit` from `apps/mobile/` is clean. (The mobile workspace has no `lint` script, so `turbo lint` skips it. The web workspace's `turbo lint` failure is pre-existing on `main` and unrelated — no `apps/web/**` files are touched here.)

**Not automated / manual verification needed:**
- [ ] Visual check on a device that the chevron + label layout reads naturally and the touch target is comfortable.
- [ ] Confirm role-default behavior end-to-end against the live API (Expo Go on a real device with a MEMBER and a COACH/OWNER account).

Closes #187
Part of #184