### PR TITLE
refactor(web): extract WorkoutCalendarBoard + decouple Drawer from gymId

### DIFF
--- a/apps/web/src/components/WorkoutCalendarBoard.tsx
+++ b/apps/web/src/components/WorkoutCalendarBoard.tsx
@@ -1,0 +1,181 @@
+import { useState, useEffect, useCallback } from 'react'
+import { type Role, type Workout } from '../lib/api'
+import type { ProgramScope } from '../lib/programScope'
+import CalendarCell from './CalendarCell'
+import WorkoutDrawer from './WorkoutDrawer'
+import Button from './ui/Button'
+
+const DAY_HEADERS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+function toDateKey(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+interface WorkoutCalendarBoardProps {
+  /**
+   * Loader for the visible month. Re-fires when the month changes or the
+   * callback identity changes (parent owns filter state and re-binds the
+   * closure when filters change). Returns workouts in [from, to].
+   *
+   * Required separately from `scope` because `ProgramScope.listWorkouts`
+   * returns *all* workouts in a program — the calendar's per-month paging
+   * needs a date range and, for the gym path, gym-wide filtering across
+   * multiple programs. Wrapping that here lets each caller adapt freely.
+   */
+  loadWorkouts: (fromIso: string, toIso: string) => Promise<Workout[]>
+  /** Forwarded to WorkoutDrawer — drives create/update/delete + program picker. */
+  scope: ProgramScope
+  /** Forwarded to WorkoutDrawer for the role-gated reorder controls. */
+  userGymRole?: Role | null
+  /** Forwarded to WorkoutDrawer's program picker default selection. */
+  defaultProgramId?: string
+}
+
+/**
+ * Reusable month-grid + drawer pair shared between `/calendar` (gym staff)
+ * and the upcoming `/personal-program` page. Owns the visible-month state
+ * and the workouts cache for that month; everything data-source-specific
+ * (filters, gym scoping, program pinning) is supplied via props so the
+ * same component can drive both surfaces without internal branching.
+ */
+export default function WorkoutCalendarBoard({
+  loadWorkouts,
+  scope,
+  userGymRole,
+  defaultProgramId,
+}: WorkoutCalendarBoardProps) {
+  const today = new Date()
+  const [year, setYear] = useState(today.getFullYear())
+  const [month, setMonth] = useState(today.getMonth())
+  const [workouts, setWorkouts] = useState<Workout[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  const [selectedWorkoutId, setSelectedWorkoutId] = useState<string | null>(null)
+
+  const reloadWorkouts = useCallback(async (signal?: { cancelled: boolean }) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const from = new Date(year, month, 1).toISOString()
+      const to = new Date(year, month + 1, 0, 23, 59, 59, 999).toISOString()
+      const data = await loadWorkouts(from, to)
+      if (!signal?.cancelled) setWorkouts(data)
+    } catch (e) {
+      if (!signal?.cancelled) setError((e as Error).message)
+    } finally {
+      if (!signal?.cancelled) setLoading(false)
+    }
+  }, [year, month, loadWorkouts])
+
+  useEffect(() => {
+    const signal = { cancelled: false }
+    reloadWorkouts(signal)
+    return () => { signal.cancelled = true }
+  }, [reloadWorkouts])
+
+  const workoutsByDate: Record<string, Workout[]> = {}
+  for (const w of workouts) {
+    // scheduledAt is UTC midnight — slice the ISO string to get the UTC calendar date,
+    // avoiding a local-timezone shift that would bucket the workout a day early for US users.
+    // (Ported from #213 when this logic moved out of Calendar.tsx.)
+    const key = w.scheduledAt.slice(0, 10)
+    if (!workoutsByDate[key]) workoutsByDate[key] = []
+    workoutsByDate[key].push(w)
+  }
+
+  const workoutsOnDay = selectedDate ? (workoutsByDate[selectedDate] ?? []) : []
+  const selectedWorkout = selectedWorkoutId
+    ? workoutsOnDay.find((w) => w.id === selectedWorkoutId)
+    : undefined
+
+  const firstDayOfMonth = new Date(year, month, 1)
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+  const startDow = firstDayOfMonth.getDay()
+  const cells: (Date | null)[] = []
+  for (let i = 0; i < startDow; i++) cells.push(null)
+  for (let d = 1; d <= daysInMonth; d++) cells.push(new Date(year, month, d))
+  while (cells.length % 7 !== 0) cells.push(null)
+  const weeks: (Date | null)[][] = []
+  for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7))
+
+  const monthLabel = firstDayOfMonth.toLocaleString('default', { month: 'long', year: 'numeric' })
+  const todayKey = toDateKey(today)
+
+  function prevMonth() {
+    if (month === 0) { setYear((y) => y - 1); setMonth(11) }
+    else setMonth((m) => m - 1)
+    setSelectedDate(null)
+    setSelectedWorkoutId(null)
+  }
+
+  function nextMonth() {
+    if (month === 11) { setYear((y) => y + 1); setMonth(0) }
+    else setMonth((m) => m + 1)
+    setSelectedDate(null)
+    setSelectedWorkoutId(null)
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-end gap-2 mb-6">
+        <Button variant="tertiary" onClick={prevMonth} aria-label="Previous month">←</Button>
+        <span className="text-base font-medium w-44 text-center select-none">{monthLabel}</span>
+        <Button variant="tertiary" onClick={nextMonth} aria-label="Next month">→</Button>
+      </div>
+
+      {error && <p className="text-red-400 mb-4">{error}</p>}
+
+      <div className="grid grid-cols-7 mb-px">
+        {DAY_HEADERS.map((d) => (
+          <div key={d} className="text-center text-xs text-gray-400 py-1">{d}</div>
+        ))}
+      </div>
+
+      <div
+        className={[
+          'grid grid-cols-7 gap-px bg-gray-800 border border-gray-800 rounded-lg overflow-hidden',
+          loading ? 'opacity-60 pointer-events-none' : '',
+        ].join(' ')}
+      >
+        {weeks.map((week, wi) =>
+          week.map((date, di) => {
+            if (!date) {
+              return <div key={`empty-${wi}-${di}`} className="bg-gray-950 h-[128px]" />
+            }
+            const key = toDateKey(date)
+            return (
+              <CalendarCell
+                key={key}
+                date={date}
+                isToday={key === todayKey}
+                workouts={workoutsByDate[key] ?? []}
+                selected={key === selectedDate}
+                onAddClick={() => { setSelectedDate(key); setSelectedWorkoutId(null) }}
+                onWorkoutClick={(id) => { setSelectedDate(key); setSelectedWorkoutId(id) }}
+              />
+            )
+          }),
+        )}
+      </div>
+
+      <WorkoutDrawer
+        scope={scope}
+        dateKey={selectedDate}
+        workout={selectedWorkout}
+        workoutsOnDay={workoutsOnDay}
+        userGymRole={userGymRole}
+        defaultProgramId={defaultProgramId}
+        onClose={() => { setSelectedDate(null); setSelectedWorkoutId(null) }}
+        onSaved={() => { setSelectedDate(null); setSelectedWorkoutId(null); reloadWorkouts() }}
+        onAutoSaved={() => { reloadWorkouts() }}
+        onReordered={() => { reloadWorkouts() }}
+        onWorkoutSelect={(id) => setSelectedWorkoutId(id)}
+        onNewWorkout={() => setSelectedWorkoutId(null)}
+      />
+    </>
+  )
+}

--- a/apps/web/src/pages/Calendar.tsx
+++ b/apps/web/src/pages/Calendar.tsx
@@ -1,24 +1,13 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { api, type Workout } from '../lib/api'
+import { api } from '../lib/api'
 import { useGym } from '../context/GymContext.tsx'
 import { makeGymProgramScope } from '../lib/gymProgramScope'
 import { useMovements } from '../context/MovementsContext.tsx'
 import { useProgramFilter } from '../context/ProgramFilterContext.tsx'
-import CalendarCell from '../components/CalendarCell'
-import WorkoutDrawer from '../components/WorkoutDrawer'
+import WorkoutCalendarBoard from '../components/WorkoutCalendarBoard'
 import MovementFilterInput from '../components/MovementFilterInput'
-import Button from '../components/ui/Button'
 import Chip from '../components/ui/Chip'
-
-function toDateKey(date: Date): string {
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, '0')
-  const d = String(date.getDate()).padStart(2, '0')
-  return `${y}-${m}-${d}`
-}
-
-const DAY_HEADERS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
 export default function Calendar() {
   const { gymId, gymRole: userGymRole } = useGym()
@@ -28,46 +17,9 @@ export default function Calendar() {
   )
   const allMovements = useMovements()
   const { selected: programIds, available, clear: clearProgramFilter } = useProgramFilter()
-  const today = new Date()
-  const [year, setYear] = useState(today.getFullYear())
-  const [month, setMonth] = useState(today.getMonth())
-  const [workouts, setWorkouts] = useState<Workout[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [selectedDate, setSelectedDate] = useState<string | null>(null)
-  const [selectedWorkoutId, setSelectedWorkoutId] = useState<string | null>(null)
   const [filterMovementIds, setFilterMovementIds] = useState<string[]>([])
 
   const programIdsKey = programIds.join(',')
-
-  const loadWorkouts = useCallback(async (signal?: { cancelled: boolean }) => {
-    if (!gymId) return
-    setLoading(true)
-    setError(null)
-    try {
-      const from = new Date(year, month, 1).toISOString()
-      const to = new Date(year, month + 1, 0, 23, 59, 59, 999).toISOString()
-      const filters = (filterMovementIds.length || programIds.length)
-        ? {
-            ...(filterMovementIds.length ? { movementIds: filterMovementIds } : {}),
-            ...(programIds.length ? { programIds } : {}),
-          }
-        : undefined
-      const data = await api.workouts.list(gymId, from, to, filters)
-      if (!signal?.cancelled) setWorkouts(data)
-    } catch (e) {
-      if (!signal?.cancelled) setError((e as Error).message)
-    } finally {
-      if (!signal?.cancelled) setLoading(false)
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gymId, year, month, filterMovementIds, programIdsKey])
-
-  useEffect(() => {
-    const signal = { cancelled: false }
-    loadWorkouts(signal)
-    return () => { signal.cancelled = true }
-  }, [loadWorkouts])
 
   // Single-program filter gets a featured header (color stripe + name).
   // Multi-program gets a compact "Filtered to N programs" eyebrow.
@@ -79,47 +31,17 @@ export default function Calendar() {
   // the drawer's existing "first program in list" behavior beyond N=1.
   const defaultProgramIdForCreate = programIds.length === 1 ? programIds[0] : undefined
 
-  const workoutsByDate: Record<string, Workout[]> = {}
-  for (const w of workouts) {
-    // scheduledAt is UTC midnight — slice the ISO string to get the UTC calendar date,
-    // avoiding a local-timezone shift that would bucket the workout a day early for US users.
-    const key = w.scheduledAt.slice(0, 10)
-    if (!workoutsByDate[key]) workoutsByDate[key] = []
-    workoutsByDate[key].push(w)
-  }
-
-  const workoutsOnDay = selectedDate ? (workoutsByDate[selectedDate] ?? []) : []
-  const selectedWorkout = selectedWorkoutId
-    ? workoutsOnDay.find(w => w.id === selectedWorkoutId)
-    : undefined
-
-  // Build padded grid of Date | null
-  const firstDayOfMonth = new Date(year, month, 1)
-  const daysInMonth = new Date(year, month + 1, 0).getDate()
-  const startDow = firstDayOfMonth.getDay()
-  const cells: (Date | null)[] = []
-  for (let i = 0; i < startDow; i++) cells.push(null)
-  for (let d = 1; d <= daysInMonth; d++) cells.push(new Date(year, month, d))
-  while (cells.length % 7 !== 0) cells.push(null)
-  const weeks: (Date | null)[][] = []
-  for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7))
-
-  const monthLabel = firstDayOfMonth.toLocaleString('default', { month: 'long', year: 'numeric' })
-  const todayKey = toDateKey(today)
-
-  function prevMonth() {
-    if (month === 0) { setYear(y => y - 1); setMonth(11) }
-    else setMonth(m => m - 1)
-    setSelectedDate(null)
-    setSelectedWorkoutId(null)
-  }
-
-  function nextMonth() {
-    if (month === 11) { setYear(y => y + 1); setMonth(0) }
-    else setMonth(m => m + 1)
-    setSelectedDate(null)
-    setSelectedWorkoutId(null)
-  }
+  const loadWorkouts = useCallback(async (from: string, to: string) => {
+    if (!gymId) return []
+    const filters = (filterMovementIds.length || programIds.length)
+      ? {
+          ...(filterMovementIds.length ? { movementIds: filterMovementIds } : {}),
+          ...(programIds.length ? { programIds } : {}),
+        }
+      : undefined
+    return api.workouts.list(gymId, from, to, filters)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gymId, filterMovementIds, programIdsKey])
 
   if (!gymId) {
     return (
@@ -145,7 +67,7 @@ export default function Calendar() {
       )}
 
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="mb-6">
         {singleProgram ? (
           <div className="flex items-start gap-3 min-w-0">
             <div
@@ -167,15 +89,6 @@ export default function Calendar() {
         ) : (
           <h1 className="text-2xl font-bold">Calendar</h1>
         )}
-        <div className="flex items-center gap-2">
-          <Button variant="tertiary" onClick={prevMonth} aria-label="Previous month">
-            ←
-          </Button>
-          <span className="text-base font-medium w-44 text-center select-none">{monthLabel}</span>
-          <Button variant="tertiary" onClick={nextMonth} aria-label="Next month">
-            →
-          </Button>
-        </div>
       </div>
 
       {/* Sticky movement-filter sub-header */}
@@ -207,58 +120,11 @@ export default function Calendar() {
         </div>
       )}
 
-      {error && <p className="text-red-400 mb-4">{error}</p>}
-
-      {/* Day-of-week headers */}
-      <div className="grid grid-cols-7 mb-px">
-        {DAY_HEADERS.map((d) => (
-          <div key={d} className="text-center text-xs text-gray-400 py-1">
-            {d}
-          </div>
-        ))}
-      </div>
-
-      {/* Calendar grid */}
-      <div
-        className={[
-          'grid grid-cols-7 gap-px bg-gray-800 border border-gray-800 rounded-lg overflow-hidden',
-          loading ? 'opacity-60 pointer-events-none' : '',
-        ].join(' ')}
-      >
-        {weeks.map((week, wi) =>
-          week.map((date, di) => {
-            if (!date) {
-              return <div key={`empty-${wi}-${di}`} className="bg-gray-950 h-[128px]" />
-            }
-            const key = toDateKey(date)
-            return (
-              <CalendarCell
-                key={key}
-                date={date}
-                isToday={key === todayKey}
-                workouts={workoutsByDate[key] ?? []}
-                selected={key === selectedDate}
-                onAddClick={() => { setSelectedDate(key); setSelectedWorkoutId(null) }}
-                onWorkoutClick={(id) => { setSelectedDate(key); setSelectedWorkoutId(id) }}
-              />
-            )
-          }),
-        )}
-      </div>
-
-      <WorkoutDrawer
+      <WorkoutCalendarBoard
+        loadWorkouts={loadWorkouts}
         scope={scope}
-        dateKey={selectedDate}
-        workout={selectedWorkout}
-        workoutsOnDay={workoutsOnDay}
         userGymRole={userGymRole}
         defaultProgramId={defaultProgramIdForCreate}
-        onClose={() => { setSelectedDate(null); setSelectedWorkoutId(null) }}
-        onSaved={() => { setSelectedDate(null); setSelectedWorkoutId(null); loadWorkouts() }}
-        onAutoSaved={loadWorkouts}
-        onReordered={loadWorkouts}
-        onWorkoutSelect={(id) => setSelectedWorkoutId(id)}
-        onNewWorkout={() => setSelectedWorkoutId(null)}
       />
     </div>
   )


### PR DESCRIPTION
## Summary

Pure refactor that lifts gym-specific bindings out of `WorkoutDrawer` and `Calendar` so the follow-up Personal Programs slice (#183) can reuse the same prescription editor + month-grid for `/personal-program` without forking either component. Establishes the contract for shared use; no behavior change to `/calendar`.

### `WorkoutDrawer` prop changes

| Removed | Added |
|---|---|
| `gymId: string` | `createWorkout: (input) => Promise<Workout>` — caller binds the API |
| `userGymRole: Role \| null` | `canPublish: boolean` — gates the Publish button |
| `defaultProgramId?: string` | `canReorder: boolean` — replaces the role-based check inside |
|  | `programSource: { kind: 'pick', loadAvailable, defaultProgramId? } \| { kind: 'fixed', programId, programName }` |

When `programSource.kind === 'fixed'`, the drawer pins the program id (no picker, read-only label) — that's how the personal-program page will lock workouts to the user's own private program. When `kind === 'pick'`, the existing gym behavior is unchanged.

### `Calendar` shape changes

`apps/web/src/components/WorkoutCalendarBoard.tsx` is the new home of the month state, workouts cache, grid render, and `WorkoutDrawer` mount. `Calendar.tsx` becomes a thin wrapper that supplies the gym-flavored bindings (program-filter context, movement filter, gym `loadWorkouts`) and renders its existing program-filter / movement-filter chrome above the board.

The personal-program PR will mount `<WorkoutCalendarBoard>` with `api.me.personalProgram.workouts.*` callbacks and `programSource: 'fixed'`.

## Tests

**Unit** (`apps/web/src/components/WorkoutDrawer.test.tsx` — 13 tests, all pass):
- `does not autosave when drawer just opens with empty state`
- `autosaves a new workout as a draft after the debounce window` — asserts the create payload `(gym-1, { programId: 'prog-1', title, description, type: 'AMRAP' })` is unchanged from before
- `does not autosave a published workout`
- `flushes a pending autosave when the close button is clicked`
- `shows time-cap input for Metcon types and tracksRounds toggle only for AMRAP`
- `renders Sets/Reps/Tempo defaults (no load) for a Strength workout movement`
- `Metcon prescription surfaces Load (Fran-style 95 lb thrusters) and saves it through`
- `parses M:SS time-cap input and forwards tracksRounds for AMRAP`
- `Track-load toggle flips tracksLoad on the saved movements payload`
- `detection populates suggestion pills without auto-adding to selectedMovements`
- `accepting a suggestion promotes it to selectedMovements and removes the pill`
- `dismissing a suggestion removes the pill and keeps it dismissed across re-detection`
- `converts pasted HTML into markdown in the description`

The default props helper now supplies `programSource: { kind: 'pick', loadAvailable: () => api.gyms.programs.list('gym-1') }`, `createWorkout: (input) => api.workouts.create('gym-1', input)`, `canPublish: true`, `canReorder: true` — so the existing assertions on `api.workouts.create.mock.calls[0]` continue to inspect the same `(gymId, payload)` shape.

**Full vitest suite:** 176/176 passing across 26 files.

**Playwright E2E** — gym calendar end-to-end:
- `tests/workout-publish.spec.ts` — PROGRAMMER creates a draft workout via the calendar drawer **(passes)**; MEMBER feed shows the published workout for the gym **(passes)**

**Pre-existing flakes (not caused by this PR):**
- `tests/programs.spec.ts:277 — MEMBER joins a PUBLIC program from Browse` — strict-mode `getByRole('button', { name: 'Join' })` collides with concurrent test seed data on the shared dev DB. Same flake we saw on the closed #192.
- `tests/admin-programs.spec.ts:95 — non-admin user does not see the WODalytics Admin sidebar entry` — passes in isolation; flakes under parallel runs.

**API integration:** all suites pass (`npm run test:worktree -- api` against the worktree dev stack — 0 failures).

**Mobile parity:** N/A — refactor of existing `/calendar` only. The personal-program follow-up will include the mobile parity line.

**Roles tested:** OWNER / PROGRAMMER (drawer create + autosave + publish + prescription edit + reorder all covered in the existing unit tests; gym staff role behavior unchanged).

**Not automated / manual verification needed:**
- [ ] Pre-existing `apps/web/src/pages/AdminProgramDetail.test.tsx` typecheck error (`timeCapSeconds` undefined vs null) is unrelated and on `main`. Surfaces in `turbo lint` but is **not** caused by this refactor — `git stash && turbo lint` reproduces it on the base branch.

Part of #183