### PR TITLE
feat(admin): editing surface — programs + workouts via shared editors (slice 3 of #160)

### DIFF
--- a/apps/api/src/db/programDbManager.ts
+++ b/apps/api/src/db/programDbManager.ts
@@ -65,30 +65,82 @@ export async function ensureProgramIsPublic(programId: string) {
 }
 
 /**
- * Lists every program with no `GymProgram` link, regardless of caller
- * subscription. Used by the WODalytics admin surface (#160) to enumerate
- * programs that need curation. Differs from `findUnaffiliatedPublicProgramsForUser`
- * which excludes the caller's own subscriptions for the public-catalog browse
- * use case — admins need the full list.
+ * Public-catalog filter for the admin surface: programs with no gym link
+ * AND no `ownerUserId` (i.e. not a Personal Program — those belong to a
+ * specific user and are private by design). The two conditions together
+ * isolate true "WODalytics-curated" programs like the CrossFit Mainsite
+ * ingest from both gym-scoped programs and per-user Personal Programs.
+ */
+const ADMIN_CATALOG_WHERE = {
+  gyms: { none: {} },
+  ownerUserId: null,
+} as const
+
+/**
+ * Lists every public-catalog program (gym-less + non-Personal), regardless
+ * of caller subscription. Used by the WODalytics admin surface (#160) to
+ * enumerate programs that need curation. Differs from
+ * `findUnaffiliatedPublicProgramsForUser` which excludes the caller's own
+ * subscriptions for the public-catalog browse use case — admins need the
+ * full list.
  */
 export async function findAllUnaffiliatedPrograms() {
   return prisma.program.findMany({
-    where: { gyms: { none: {} } },
+    where: ADMIN_CATALOG_WHERE,
     orderBy: { createdAt: 'desc' },
     include: { _count: { select: { members: true, workouts: true } } },
   })
 }
 
 /**
- * Look up a single unaffiliated program by id with the same `_count` shape
- * the list endpoint returns. Returns null when the program either does not
- * exist or has any `GymProgram` link — that second case keeps the admin
- * surface from straying onto gym-affiliated programs (a separate auth
- * boundary). Callers should treat null as 404.
+ * Look up a single public-catalog program by id with the same `_count`
+ * shape the list endpoint returns. Returns null when the program does not
+ * exist, has a gym link, or is a Personal Program — those cases would
+ * stray the admin surface onto material that has its own auth boundary.
+ * Callers should treat null as 404.
  */
 export async function findUnaffiliatedProgramByIdWithCounts(id: string) {
   return prisma.program.findFirst({
-    where: { id, gyms: { none: {} } },
+    where: { id, ...ADMIN_CATALOG_WHERE },
+    include: { _count: { select: { members: true, workouts: true } } },
+  })
+}
+
+/**
+ * Same predicate as `findUnaffiliatedProgramByIdWithCounts` but without the
+ * `_count` payload — for mutation handlers that just need the existence +
+ * access check before delegating to a generic update / delete.
+ */
+export async function findUnaffiliatedProgramById(id: string) {
+  return prisma.program.findFirst({
+    where: { id, ...ADMIN_CATALOG_WHERE },
+  })
+}
+
+interface CreateUnaffiliatedProgramData {
+  name: string
+  description?: string | null
+  startDate: Date
+  endDate?: Date | null
+  coverColor?: string | null
+  visibility?: ProgramVisibility
+}
+
+/**
+ * Creates a new public-catalog program (no gym link, no owner). Visibility
+ * defaults to PUBLIC — the whole point of admin curation is discoverability
+ * across gyms.
+ */
+export async function createUnaffiliatedProgram(data: CreateUnaffiliatedProgramData) {
+  return prisma.program.create({
+    data: {
+      name: data.name,
+      description: data.description ?? null,
+      startDate: data.startDate,
+      endDate: data.endDate ?? null,
+      coverColor: data.coverColor ?? null,
+      visibility: data.visibility ?? 'PUBLIC',
+    },
     include: { _count: { select: { members: true, workouts: true } } },
   })
 }

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,37 +1,75 @@
 /**
  * WODalytics admin surface (#160). Curates unaffiliated/public-catalog
  * programs (e.g. the CrossFit Mainsite ingest) without granting access to any
- * gym-scoped data. Slice 2 is read-only — list, detail, workouts. Slice 3
- * adds mutations behind the same `requireWodalyticsAdmin` gate.
+ * gym-scoped data. Slice 2 added read-only endpoints; slice 3 (this file's
+ * mutating handlers) lets admins author programs and workouts directly.
  *
  * Every route is gated by `requireAuth + requireWodalyticsAdmin`. Empty /
  * unset `WODALYTICS_ADMIN_EMAILS` → 403 (deny by default).
+ *
+ * **Auth boundary:** every mutation re-checks that its target program is in
+ * the public catalog (`gyms: { none: {} }, ownerUserId: null`). Without that
+ * check an admin could PATCH a gym-scoped or Personal Program through the
+ * admin path, which would muddle two separate auth surfaces. The check
+ * lives in `findUnaffiliatedProgramById` / `findUnaffiliatedProgramByIdWithCounts`
+ * — both return null for anything that isn't admin-curatable.
  */
 import { Router } from 'express'
 import type { Request, Response } from 'express'
 import { requireAuth, requireWodalyticsAdmin } from '../middleware/auth.js'
 import {
+  CreateProgramSchema,
+  UpdateProgramSchema,
+  CreateWorkoutSchema,
+  UpdateWorkoutSchema,
+} from '@wodalytics/types'
+import {
   findAllUnaffiliatedPrograms,
+  findUnaffiliatedProgramById,
   findUnaffiliatedProgramByIdWithCounts,
+  createUnaffiliatedProgram,
+  updateProgramById,
+  deleteProgramById,
 } from '../db/programDbManager.js'
-import { findWorkoutsByProgramId } from '../db/workoutDbManager.js'
+import {
+  createWorkoutForProgram,
+  findWorkoutById,
+  findWorkoutsByProgramId,
+  updateWorkout,
+  deleteWorkout,
+} from '../db/workoutDbManager.js'
 
 const router = Router()
 
+const adminGuards = [requireAuth, requireWodalyticsAdmin] as const
+
 // ─── Routes ───────────────────────────────────────────────────────────────────
 
-router.get('/admin/programs', requireAuth, requireWodalyticsAdmin, listAdminPrograms)
-router.get('/admin/programs/:id', requireAuth, requireWodalyticsAdmin, getAdminProgramById)
-router.get(
-  '/admin/programs/:id/workouts',
-  requireAuth,
-  requireWodalyticsAdmin,
-  listAdminProgramWorkouts,
-)
+// Read (slice 2)
+router.get('/admin/programs', ...adminGuards, listAdminPrograms)
+router.get('/admin/programs/:id', ...adminGuards, getAdminProgramById)
+router.get('/admin/programs/:id/workouts', ...adminGuards, listAdminProgramWorkouts)
+
+// Mutations (slice 3)
+router.post('/admin/programs', ...adminGuards, createAdminProgram)
+router.patch('/admin/programs/:id', ...adminGuards, updateAdminProgram)
+router.delete('/admin/programs/:id', ...adminGuards, deleteAdminProgram)
+router.post('/admin/programs/:id/workouts', ...adminGuards, createAdminWorkout)
+router.patch('/admin/workouts/:id', ...adminGuards, updateAdminWorkout)
+router.delete('/admin/workouts/:id', ...adminGuards, deleteAdminWorkout)
 
 export default router
 
-// ─── Handler functions ────────────────────────────────────────────────────────
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function badRequestFromZod(err: { issues: { path: (string | number)[]; message: string }[] }, res: Response) {
+  const issue = err.issues[0]
+  const field = issue?.path[0] ?? 'request'
+  const message = issue?.message ?? 'Invalid request'
+  res.status(400).json({ error: `${field}: ${message}` })
+}
+
+// ─── Read handlers (slice 2 — unchanged) ──────────────────────────────────────
 
 async function listAdminPrograms(_req: Request, res: Response) {
   const programs = await findAllUnaffiliatedPrograms()
@@ -50,9 +88,6 @@ async function getAdminProgramById(req: Request, res: Response) {
 
 async function listAdminProgramWorkouts(req: Request, res: Response) {
   const id = req.params.id as string
-  // Re-check the program is unaffiliated. Without this an admin could read
-  // a gym-scoped program's workouts via the admin path, which would muddle
-  // the auth boundary.
   const program = await findUnaffiliatedProgramByIdWithCounts(id)
   if (!program) {
     res.status(404).json({ error: 'Program not found' })
@@ -60,4 +95,134 @@ async function listAdminProgramWorkouts(req: Request, res: Response) {
   }
   const workouts = await findWorkoutsByProgramId(id)
   res.json(workouts)
+}
+
+// ─── Program mutations ────────────────────────────────────────────────────────
+
+async function createAdminProgram(req: Request, res: Response) {
+  const parsed = CreateProgramSchema.safeParse(req.body)
+  if (!parsed.success) return badRequestFromZod(parsed.error, res)
+  const data = parsed.data
+  const program = await createUnaffiliatedProgram({
+    name: data.name,
+    description: data.description ?? null,
+    startDate: new Date(data.startDate),
+    endDate: data.endDate ? new Date(data.endDate) : null,
+    coverColor: data.coverColor ?? null,
+    visibility: data.visibility,
+  })
+  res.status(201).json(program)
+}
+
+async function updateAdminProgram(req: Request, res: Response) {
+  const id = req.params.id as string
+  const existing = await findUnaffiliatedProgramById(id)
+  if (!existing) {
+    res.status(404).json({ error: 'Program not found' })
+    return
+  }
+  const parsed = UpdateProgramSchema.safeParse(req.body)
+  if (!parsed.success) return badRequestFromZod(parsed.error, res)
+  const d = parsed.data
+  const updated = await updateProgramById(id, {
+    name: d.name,
+    description: d.description,
+    startDate: d.startDate ? new Date(d.startDate) : undefined,
+    endDate: d.endDate === null ? null : d.endDate ? new Date(d.endDate) : undefined,
+    coverColor: d.coverColor,
+    visibility: d.visibility,
+  })
+  res.json(updated)
+}
+
+async function deleteAdminProgram(req: Request, res: Response) {
+  const id = req.params.id as string
+  const existing = await findUnaffiliatedProgramById(id)
+  if (!existing) {
+    res.status(404).json({ error: 'Program not found' })
+    return
+  }
+  await deleteProgramById(id)
+  res.status(204).send()
+}
+
+// ─── Workout mutations ────────────────────────────────────────────────────────
+
+async function createAdminWorkout(req: Request, res: Response) {
+  const programId = req.params.id as string
+  const program = await findUnaffiliatedProgramById(programId)
+  if (!program) {
+    res.status(404).json({ error: 'Program not found' })
+    return
+  }
+  const parsed = CreateWorkoutSchema.safeParse(req.body)
+  if (!parsed.success) return badRequestFromZod(parsed.error, res)
+  const d = parsed.data
+  // URL programId is authoritative — body's optional programId is ignored to
+  // keep the URL as the single source of truth for which program a workout
+  // belongs to. Status defaults to PUBLISHED for admin-authored content (the
+  // catalog has no draft/staging concept; it's curated and live).
+  const workout = await createWorkoutForProgram({
+    programId,
+    title: d.title,
+    description: d.description,
+    coachNotes: d.coachNotes === '' ? null : d.coachNotes,
+    type: d.type,
+    scheduledAt: new Date(d.scheduledAt),
+    dayOrder: d.dayOrder,
+    movementIds: d.movementIds,
+    movements: d.movements,
+    namedWorkoutId: d.namedWorkoutId,
+    timeCapSeconds: d.timeCapSeconds,
+    tracksRounds: d.tracksRounds,
+    status: 'PUBLISHED',
+  })
+  res.status(201).json(workout)
+}
+
+async function updateAdminWorkout(req: Request, res: Response) {
+  const workoutId = req.params.id as string
+  const existing = await findWorkoutById(workoutId)
+  if (!existing) {
+    res.status(404).json({ error: 'Workout not found' })
+    return
+  }
+  // Verify the workout's program is in the admin catalog. Without this an
+  // admin could PATCH a gym-scoped workout via the admin path.
+  if (!existing.programId || !(await findUnaffiliatedProgramById(existing.programId))) {
+    res.status(404).json({ error: 'Workout not found' })
+    return
+  }
+  const parsed = UpdateWorkoutSchema.safeParse(req.body)
+  if (!parsed.success) return badRequestFromZod(parsed.error, res)
+  const d = parsed.data
+  const updated = await updateWorkout(workoutId, {
+    title: d.title,
+    description: d.description,
+    coachNotes: d.coachNotes === '' ? null : d.coachNotes,
+    type: d.type,
+    scheduledAt: d.scheduledAt ? new Date(d.scheduledAt) : undefined,
+    dayOrder: d.dayOrder,
+    movementIds: d.movementIds,
+    movements: d.movements,
+    namedWorkoutId: d.namedWorkoutId,
+    timeCapSeconds: d.timeCapSeconds,
+    tracksRounds: d.tracksRounds,
+  })
+  res.json(updated)
+}
+
+async function deleteAdminWorkout(req: Request, res: Response) {
+  const workoutId = req.params.id as string
+  const existing = await findWorkoutById(workoutId)
+  if (!existing) {
+    res.status(404).json({ error: 'Workout not found' })
+    return
+  }
+  if (!existing.programId || !(await findUnaffiliatedProgramById(existing.programId))) {
+    res.status(404).json({ error: 'Workout not found' })
+    return
+  }
+  await deleteWorkout(workoutId)
+  res.status(204).send()
 }

--- a/apps/api/tests/admin-programs-mutations.ts
+++ b/apps/api/tests/admin-programs-mutations.ts
@@ -1,0 +1,349 @@
+/**
+ * Integration tests for the WODalytics admin mutating endpoints (slice 3 of #160).
+ *
+ * Covers:
+ *   - POST   /api/admin/programs                  — create
+ *   - PATCH  /api/admin/programs/:id              — update
+ *   - DELETE /api/admin/programs/:id              — delete
+ *   - POST   /api/admin/programs/:id/workouts     — create workout
+ *   - PATCH  /api/admin/workouts/:id              — update workout
+ *   - DELETE /api/admin/workouts/:id              — delete workout
+ *
+ * Auth gates (401 / 403) on every mutation. Affiliated-program guards: every
+ * mutation that targets an existing program (PATCH/DELETE program, POST
+ * workout) must 404 when the program is gym-affiliated, AND when the
+ * program is a Personal Program (ownerUserId != null) — both routed
+ * through the shared `findUnaffiliatedProgramById` predicate.
+ *
+ * Requires: API running, WODALYTICS_ADMIN_EMAILS in .env. Run:
+ *   cd apps/api && npx tsx tests/admin-programs-mutations.ts
+ */
+
+import { prisma } from '@wodalytics/db'
+import { signTokenPair } from '../src/lib/jwt.js'
+import { parseAdminEmails } from '../src/middleware/auth.js'
+
+const BASE = process.env.API_URL ?? 'http://localhost:3000/api'
+let pass = 0
+let fail = 0
+
+function check(label: string, expected: unknown, actual: unknown) {
+  if (String(expected) === String(actual)) {
+    console.log(`  ✓ ${label}`)
+    pass++
+  } else {
+    console.log(`  ✗ ${label}  [expected=${expected} actual=${actual}]`)
+    fail++
+  }
+}
+
+async function api(method: string, path: string, token?: string, body?: unknown) {
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  const text = await res.text()
+  let json: unknown
+  try {
+    json = JSON.parse(text)
+  } catch {
+    json = text
+  }
+  return { status: res.status, body: json as Record<string, unknown> | unknown[] }
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const TS = Date.now()
+let adminUserId = ''
+let nonAdminUserId = ''
+let personalUserId = ''
+let adminToken = ''
+let nonAdminToken = ''
+let publicProgramId = ''
+let affiliatedProgramId = ''
+let personalProgramId = ''
+let publicWorkoutId = ''
+let affiliatedWorkoutId = ''
+let affiliatedGymId = ''
+
+async function setup() {
+  console.log('\n=== Setup ===')
+
+  const allowed = [...parseAdminEmails(process.env.WODALYTICS_ADMIN_EMAILS)]
+  if (allowed.length === 0) throw new Error('WODALYTICS_ADMIN_EMAILS must be set in .env')
+  const adminEmail = allowed[0]
+
+  const admin = await prisma.user.upsert({
+    where: { email: adminEmail },
+    update: {},
+    create: { email: adminEmail },
+  })
+  adminUserId = admin.id
+
+  const nonAdmin = await prisma.user.create({ data: { email: `admin-mut-nonadmin-${TS}@test.com` } })
+  nonAdminUserId = nonAdmin.id
+
+  const personal = await prisma.user.create({ data: { email: `admin-mut-personal-${TS}@test.com` } })
+  personalUserId = personal.id
+
+  adminToken = signTokenPair(adminUserId, 'OWNER').accessToken
+  nonAdminToken = signTokenPair(nonAdminUserId, 'MEMBER').accessToken
+
+  // Public-catalog program (admin should mutate)
+  const pub = await prisma.program.create({
+    data: {
+      name: `Admin-Mut-Public-${TS}`,
+      visibility: 'PUBLIC',
+      startDate: new Date('2026-04-01'),
+    },
+  })
+  publicProgramId = pub.id
+
+  const pubWorkout = await prisma.workout.create({
+    data: {
+      programId: pub.id,
+      title: `Public-W-${TS}`,
+      description: 'desc',
+      type: 'FOR_TIME',
+      status: 'PUBLISHED',
+      scheduledAt: new Date('2026-04-15T10:00:00Z'),
+    },
+  })
+  publicWorkoutId = pubWorkout.id
+
+  // Gym-affiliated program (admin must NOT mutate)
+  const gym = await prisma.gym.create({
+    data: { name: `Admin-Mut-Gym-${TS}`, slug: `admin-mut-gym-${TS}`, timezone: 'UTC' },
+  })
+  affiliatedGymId = gym.id
+  const affiliated = await prisma.program.create({
+    data: {
+      name: `Admin-Mut-Affiliated-${TS}`,
+      visibility: 'PUBLIC',
+      startDate: new Date('2026-04-01'),
+      gyms: { create: { gymId: gym.id } },
+    },
+  })
+  affiliatedProgramId = affiliated.id
+
+  const affWorkout = await prisma.workout.create({
+    data: {
+      programId: affiliated.id,
+      title: `Affiliated-W-${TS}`,
+      description: 'desc',
+      type: 'FOR_TIME',
+      status: 'PUBLISHED',
+      scheduledAt: new Date('2026-04-15T10:00:00Z'),
+    },
+  })
+  affiliatedWorkoutId = affWorkout.id
+
+  // Personal Program (ownerUserId != null) — admin must NOT mutate
+  const pers = await prisma.program.create({
+    data: {
+      name: `Admin-Mut-Personal-${TS}`,
+      visibility: 'PRIVATE',
+      startDate: new Date('2026-04-01'),
+      ownerUserId: personal.id,
+    },
+  })
+  personalProgramId = pers.id
+
+  console.log(`  admin=${adminUserId}`)
+  console.log(`  public=${publicProgramId} affiliated=${affiliatedProgramId} personal=${personalProgramId}`)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+async function runTests() {
+  // ── POST /api/admin/programs ────────────────────────────────────────────────
+  console.log('\n=== POST /api/admin/programs ===')
+  let createdProgramId = ''
+  {
+    const r = await api('POST', '/admin/programs', undefined, { name: 'x', startDate: '2026-04-01' })
+    check('T1: no auth → 401', 401, r.status)
+  }
+  {
+    const r = await api('POST', '/admin/programs', nonAdminToken, { name: 'x', startDate: '2026-04-01' })
+    check('T2: non-admin → 403', 403, r.status)
+  }
+  {
+    const r = await api('POST', '/admin/programs', adminToken, { name: '', startDate: '2026-04-01' })
+    check('T3: admin invalid (empty name) → 400', 400, r.status)
+  }
+  {
+    const r = await api('POST', '/admin/programs', adminToken, {
+      name: `Admin-Mut-Created-${TS}`,
+      description: 'created via admin',
+      startDate: '2026-05-01',
+    })
+    check('T4: admin → 201', 201, r.status)
+    const body = r.body as { id: string; visibility: string; name: string }
+    check('T4: defaults visibility to PUBLIC', 'PUBLIC', body.visibility)
+    check('T4: name persisted', `Admin-Mut-Created-${TS}`, body.name)
+    createdProgramId = body.id
+  }
+
+  // ── PATCH /api/admin/programs/:id ───────────────────────────────────────────
+  console.log('\n=== PATCH /api/admin/programs/:id ===')
+  {
+    const r = await api('PATCH', `/admin/programs/${publicProgramId}`, undefined, { name: 'y' })
+    check('T5: no auth → 401', 401, r.status)
+  }
+  {
+    const r = await api('PATCH', `/admin/programs/${publicProgramId}`, nonAdminToken, { name: 'y' })
+    check('T6: non-admin → 403', 403, r.status)
+  }
+  {
+    const r = await api('PATCH', `/admin/programs/${publicProgramId}`, adminToken, {
+      name: `Admin-Mut-Renamed-${TS}`,
+    })
+    check('T7: admin rename → 200', 200, r.status)
+    check('T7: name updated', `Admin-Mut-Renamed-${TS}`, (r.body as { name: string }).name)
+  }
+  {
+    const r = await api('PATCH', `/admin/programs/${affiliatedProgramId}`, adminToken, { name: 'shouldfail' })
+    check('T8: admin PATCH affiliated → 404', 404, r.status)
+  }
+  {
+    const r = await api('PATCH', `/admin/programs/${personalProgramId}`, adminToken, { name: 'shouldfail' })
+    check('T9: admin PATCH personal → 404', 404, r.status)
+  }
+
+  // ── DELETE /api/admin/programs/:id ──────────────────────────────────────────
+  console.log('\n=== DELETE /api/admin/programs/:id ===')
+  {
+    const r = await api('DELETE', `/admin/programs/${createdProgramId}`)
+    check('T10: no auth → 401', 401, r.status)
+  }
+  {
+    const r = await api('DELETE', `/admin/programs/${createdProgramId}`, nonAdminToken)
+    check('T11: non-admin → 403', 403, r.status)
+  }
+  {
+    const r = await api('DELETE', `/admin/programs/${affiliatedProgramId}`, adminToken)
+    check('T12: admin DELETE affiliated → 404', 404, r.status)
+  }
+  {
+    const r = await api('DELETE', `/admin/programs/${personalProgramId}`, adminToken)
+    check('T13: admin DELETE personal → 404', 404, r.status)
+  }
+  {
+    const r = await api('DELETE', `/admin/programs/${createdProgramId}`, adminToken)
+    check('T14: admin DELETE → 204', 204, r.status)
+  }
+  {
+    const r = await api('GET', `/admin/programs/${createdProgramId}`, adminToken)
+    check('T15: deleted program returns 404', 404, r.status)
+  }
+
+  // ── POST /api/admin/programs/:id/workouts ───────────────────────────────────
+  console.log('\n=== POST /api/admin/programs/:id/workouts ===')
+  let createdWorkoutId = ''
+  {
+    const r = await api('POST', `/admin/programs/${publicProgramId}/workouts`, nonAdminToken, {
+      title: 'x', description: 'x', type: 'AMRAP', scheduledAt: '2026-05-01T10:00:00.000Z',
+    })
+    check('T16: non-admin → 403', 403, r.status)
+  }
+  {
+    const r = await api('POST', `/admin/programs/${affiliatedProgramId}/workouts`, adminToken, {
+      title: 'x', description: 'x', type: 'AMRAP', scheduledAt: '2026-05-01T10:00:00.000Z',
+    })
+    check('T17: admin POST workout on affiliated → 404', 404, r.status)
+  }
+  {
+    const r = await api('POST', `/admin/programs/${personalProgramId}/workouts`, adminToken, {
+      title: 'x', description: 'x', type: 'AMRAP', scheduledAt: '2026-05-01T10:00:00.000Z',
+    })
+    check('T18: admin POST workout on personal → 404', 404, r.status)
+  }
+  {
+    const r = await api('POST', `/admin/programs/${publicProgramId}/workouts`, adminToken, {
+      title: `Admin-Mut-Workout-${TS}`,
+      description: 'created via admin',
+      type: 'FOR_TIME',
+      scheduledAt: '2026-05-15T10:00:00.000Z',
+    })
+    check('T19: admin → 201', 201, r.status)
+    const body = r.body as { id: string; status: string; programId: string }
+    check('T19: programId from URL wins', publicProgramId, body.programId)
+    check('T19: auto-PUBLISHED', 'PUBLISHED', body.status)
+    createdWorkoutId = body.id
+  }
+
+  // ── PATCH /api/admin/workouts/:id ───────────────────────────────────────────
+  console.log('\n=== PATCH /api/admin/workouts/:id ===')
+  {
+    const r = await api('PATCH', `/admin/workouts/${createdWorkoutId}`, nonAdminToken, { title: 'y' })
+    check('T20: non-admin → 403', 403, r.status)
+  }
+  {
+    const r = await api('PATCH', `/admin/workouts/${affiliatedWorkoutId}`, adminToken, { title: 'shouldfail' })
+    check('T21: admin PATCH affiliated workout → 404', 404, r.status)
+  }
+  {
+    const r = await api('PATCH', `/admin/workouts/${createdWorkoutId}`, adminToken, {
+      title: `Admin-Mut-Workout-Renamed-${TS}`,
+    })
+    check('T22: admin rename → 200', 200, r.status)
+    check('T22: title updated', `Admin-Mut-Workout-Renamed-${TS}`, (r.body as { title: string }).title)
+  }
+
+  // ── DELETE /api/admin/workouts/:id ──────────────────────────────────────────
+  console.log('\n=== DELETE /api/admin/workouts/:id ===')
+  {
+    const r = await api('DELETE', `/admin/workouts/${createdWorkoutId}`, nonAdminToken)
+    check('T23: non-admin → 403', 403, r.status)
+  }
+  {
+    const r = await api('DELETE', `/admin/workouts/${affiliatedWorkoutId}`, adminToken)
+    check('T24: admin DELETE affiliated workout → 404', 404, r.status)
+  }
+  {
+    const r = await api('DELETE', `/admin/workouts/${createdWorkoutId}`, adminToken)
+    check('T25: admin DELETE → 204', 204, r.status)
+  }
+}
+
+// ─── Teardown ─────────────────────────────────────────────────────────────────
+
+async function teardown() {
+  console.log('\n=== Teardown ===')
+  await prisma.workout.deleteMany({ where: { id: { in: [publicWorkoutId, affiliatedWorkoutId] } } }).catch(() => {})
+  await prisma.workout.deleteMany({ where: { programId: { in: [publicProgramId, affiliatedProgramId, personalProgramId] } } }).catch(() => {})
+  await prisma.gymProgram.deleteMany({ where: { programId: affiliatedProgramId } }).catch(() => {})
+  await prisma.program.delete({ where: { id: publicProgramId } }).catch(() => {})
+  await prisma.program.delete({ where: { id: affiliatedProgramId } }).catch(() => {})
+  await prisma.program.delete({ where: { id: personalProgramId } }).catch(() => {})
+  await prisma.gym.delete({ where: { id: affiliatedGymId } }).catch(() => {})
+  await prisma.user.delete({ where: { id: nonAdminUserId } }).catch(() => {})
+  await prisma.user.delete({ where: { id: personalUserId } }).catch(() => {})
+  // Don't delete the admin user — shared across parallel test files.
+  void adminUserId
+  console.log('  cleaned up')
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  try {
+    await setup()
+    await runTests()
+  } finally {
+    await teardown()
+    await prisma.$disconnect()
+  }
+  console.log(`\n=== Results: ${pass} passed, ${fail} failed ===\n`)
+  if (fail > 0) process.exit(1)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/apps/web/src/components/ProgramFormDrawer.tsx
+++ b/apps/web/src/components/ProgramFormDrawer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { api, type Program, type ProgramVisibility } from '../lib/api'
+import type { Program, ProgramVisibility } from '../lib/api'
+import type { ProgramScope } from '../lib/programScope'
 import Button from './ui/Button'
 
 const COVER_COLORS = [
@@ -14,12 +15,10 @@ const COVER_COLORS = [
 ]
 
 interface ProgramFormDrawerProps {
-  gymId: string
+  scope: ProgramScope
   program?: Program  // edit mode when provided
-  /** Whether the program is currently the gym's default. Edit mode only. */
+  /** Whether the program is currently the gym's default. Gym-only edit mode. */
   isDefault?: boolean
-  /** OWNER-only on the parent — gates the gym-default toggle inside the drawer. */
-  canSetDefault?: boolean
   open: boolean
   onClose: () => void
   onSaved: (program: Program) => void
@@ -31,14 +30,14 @@ function toDateInputValue(iso: string | null | undefined): string {
 }
 
 export default function ProgramFormDrawer({
-  gymId,
+  scope,
   program,
   isDefault: initialIsDefault = false,
-  canSetDefault = false,
   open,
   onClose,
   onSaved,
 }: ProgramFormDrawerProps) {
+  const canSetDefault = scope.capabilities.canSetDefault
   const isEdit = !!program
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
@@ -89,10 +88,10 @@ export default function ProgramFormDrawer({
         // default in the same save, and we send the clearDefault before the
         // PATCH only when both flips are happening.
         const becomingPrivate = visibility === 'PRIVATE' && program.visibility !== 'PRIVATE'
-        if (initialIsDefault && !isDefault && becomingPrivate) {
-          await api.gyms.programs.clearDefault(gymId, program.id)
+        if (initialIsDefault && !isDefault && becomingPrivate && scope.clearProgramDefault) {
+          await scope.clearProgramDefault(program.id)
         }
-        const updated = await api.programs.update(program.id, {
+        const updated = await scope.updateProgram(program.id, {
           name: name.trim(),
           description: description.trim() || null,
           startDate,
@@ -101,12 +100,12 @@ export default function ProgramFormDrawer({
           visibility,
         })
         if (canSetDefault && initialIsDefault !== isDefault && !becomingPrivate) {
-          if (isDefault) await api.gyms.programs.setDefault(gymId, program.id)
-          else await api.gyms.programs.clearDefault(gymId, program.id)
+          if (isDefault) await scope.setProgramAsDefault?.(program.id)
+          else await scope.clearProgramDefault?.(program.id)
         }
         onSaved(updated)
       } else {
-        const { program: created } = await api.gyms.programs.create(gymId, {
+        const created = await scope.createProgram({
           name: name.trim(),
           description: description.trim() || undefined,
           startDate,
@@ -116,7 +115,7 @@ export default function ProgramFormDrawer({
         })
         // Allow OWNERs to mark as default at create-time too.
         if (canSetDefault && isDefault && visibility === 'PUBLIC') {
-          await api.gyms.programs.setDefault(gymId, created.id)
+          await scope.setProgramAsDefault?.(created.id)
         }
         onSaved(created)
       }

--- a/apps/web/src/components/WorkoutDrawer.test.tsx
+++ b/apps/web/src/components/WorkoutDrawer.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import WorkoutDrawer from './WorkoutDrawer'
+import { makeGymProgramScope } from '../lib/gymProgramScope'
 
 vi.mock('../lib/api', () => ({
   api: {
@@ -33,9 +34,15 @@ import { api } from '../lib/api'
 
 const noop = () => {}
 
+// The gym scope routes its CRUD methods through `api.gyms.programs.*` and
+// `api.workouts.*`, so the existing `api.*` mocks are still authoritative
+// — this test file's `expect(api.workouts.create).toHaveBeenCalled()`
+// assertions remain valid after the slice-3 ProgramScope refactor.
+const gymScope = makeGymProgramScope({ gymId: 'gym-1', gymRole: 'OWNER' })
+
 function defaultProps(overrides: Partial<Parameters<typeof WorkoutDrawer>[0]> = {}) {
   return {
-    gymId: 'gym-1',
+    scope: gymScope,
     dateKey: '2026-04-21',
     workout: undefined,
     workoutsOnDay: [],
@@ -53,6 +60,9 @@ function seedApi() {
   vi.mocked(api.namedWorkouts.list).mockResolvedValue([])
   vi.mocked(api.movements.list).mockResolvedValue([])
   vi.mocked(api.movements.detect).mockResolvedValue([])
+  // Gym scope's `list()` calls api.gyms.programs.list and maps each row's
+  // `.program` into a Program — the test's mock still uses the GymProgram
+  // shape so the mapping has something to project from.
   vi.mocked(api.gyms.programs.list).mockResolvedValue([
     { programId: 'prog-1', program: { id: 'prog-1', name: 'General' } } as never,
   ])

--- a/apps/web/src/components/WorkoutDrawer.tsx
+++ b/apps/web/src/components/WorkoutDrawer.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useRef } from 'react'
 import TurndownService from 'turndown'
 // @ts-expect-error — turndown-plugin-gfm ships no types
 import { gfm } from 'turndown-plugin-gfm'
-import { api, TYPE_ABBR, type DistanceUnit, type GymProgram, type LoadUnit, type Movement, type NamedWorkout, type Role, type Workout, type WorkoutStatus, type WorkoutType } from '../lib/api'
+import { api, TYPE_ABBR, type DistanceUnit, type LoadUnit, type Movement, type NamedWorkout, type Program, type Role, type Workout, type WorkoutStatus, type WorkoutType } from '../lib/api'
+import type { ProgramScope } from '../lib/programScope'
 import { WORKOUT_CATEGORIES, WORKOUT_TYPE_STYLES, typesInCategory } from '../lib/workoutTypeStyles'
 import { useMovements } from '../context/MovementsContext.tsx'
 
@@ -140,23 +141,31 @@ const AUTOSAVE_MIN_TITLE = 3
 const AUTOSAVE_MIN_DESCRIPTION = 5
 
 interface WorkoutDrawerProps {
-  gymId: string
+  /**
+   * Routes program/workout list + create/update/delete through the active
+   * scope (gym vs admin). Gym callers build it from `useGym()` via
+   * `makeGymProgramScope`; admin callers pass `adminProgramScope`. The
+   * drawer only sees the interface, not the gym/admin specifics.
+   */
+  scope: ProgramScope
   dateKey: string | null
   workout?: Workout
-  workoutsOnDay: Workout[]
+  workoutsOnDay?: Workout[]
   userGymRole?: Role | null
   /**
    * Pre-selects this program in the picker when the drawer opens in create
    * mode. Used by Calendar's `?programId` filter so a workout created from a
-   * filtered view is auto-tagged to that program.
+   * filtered view is auto-tagged to that program. For admin, the parent
+   * page (`AdminProgramDetail`) passes the current program id so the picker
+   * is locked to the program being edited.
    */
   defaultProgramId?: string
   onClose: () => void
   onSaved: () => void
   onAutoSaved?: () => void
   onReordered?: () => void
-  onWorkoutSelect: (id: string) => void
-  onNewWorkout: () => void
+  onWorkoutSelect?: (id: string) => void
+  onNewWorkout?: () => void
 }
 
 function buildSnapshot(args: {
@@ -185,11 +194,16 @@ function buildSnapshot(args: {
   })
 }
 
-export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, userGymRole, defaultProgramId, onClose, onSaved, onAutoSaved, onReordered, onWorkoutSelect, onNewWorkout }: WorkoutDrawerProps) {
+export default function WorkoutDrawer({ scope, dateKey, workout, workoutsOnDay = [], userGymRole, defaultProgramId, onClose, onSaved, onAutoSaved, onReordered, onWorkoutSelect, onNewWorkout }: WorkoutDrawerProps) {
   const isOpen = dateKey !== null
+  // The day-context affordances (workoutsOnDay nav, dayOrder reorder, draft
+  // autosave + publish-from-draft toggle) only make sense in the gym
+  // calendar surface. Admin curates one workout at a time inside a program
+  // and auto-publishes on create.
+  const isGymScope = scope.kind === 'gym'
 
   const allMovements = useMovements()
-  const [programs, setPrograms] = useState<GymProgram[]>([])
+  const [programs, setPrograms] = useState<Program[]>([])
   const [programsLoading, setProgramsLoading] = useState(false)
   const [programId, setProgramId] = useState('')
   const [title, setTitle] = useState('')
@@ -239,14 +253,14 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
       .catch(() => {}) // non-fatal
     if (isEdit) return
     setProgramsLoading(true)
-    api.gyms.programs.list(gymId)
+    scope.list()
       .then((list) => {
         setPrograms(list)
-        setProgramId((prev) => prev || defaultProgramId || list[0]?.programId || '')
+        setProgramId((prev) => prev || defaultProgramId || list[0]?.id || '')
       })
       .catch(() => setError('Failed to load programs'))
       .finally(() => setProgramsLoading(false))
-  }, [isOpen, isEdit, gymId, defaultProgramId])
+  }, [isOpen, isEdit, scope, defaultProgramId])
 
   useEffect(() => {
     if (!isOpen) return
@@ -347,7 +361,7 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
       setAutosaving(true)
       try {
         if (localWorkoutId) {
-          await api.workouts.update(localWorkoutId, {
+          await scope.updateWorkout(localWorkoutId, {
             title: title.trim(),
             description,
             type,
@@ -359,8 +373,7 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
           lastAutosaveSnapshotRef.current = snapshotAtSave
         } else {
           const scheduledAt = new Date(dateKey! + 'T12:00:00').toISOString()
-          const created = await api.workouts.create(gymId, {
-            programId,
+          const created = await scope.createWorkout(programId, {
             title: title.trim(),
             description,
             type,
@@ -528,10 +541,10 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
       const tracksRoundsForType = type === 'AMRAP' ? tracksRounds : false
       const timeCapForCreate = timeCapSeconds !== null ? { timeCapSeconds } : {}
       if (localWorkoutId) {
-        await api.workouts.update(localWorkoutId, { title: title.trim(), description, type, movements, namedWorkoutId, timeCapSeconds, tracksRounds: tracksRoundsForType })
+        await scope.updateWorkout(localWorkoutId, { title: title.trim(), description, type, movements, namedWorkoutId, timeCapSeconds, tracksRounds: tracksRoundsForType })
       } else {
         const scheduledAt = new Date(dateKey! + 'T12:00:00').toISOString()
-        await api.workouts.create(gymId, { programId, title: title.trim(), description, type, scheduledAt, movements, namedWorkoutId: namedWorkoutId ?? undefined, ...timeCapForCreate, tracksRounds: tracksRoundsForType })
+        await scope.createWorkout(programId, { title: title.trim(), description, type, scheduledAt, movements, namedWorkoutId: namedWorkoutId ?? undefined, ...timeCapForCreate, tracksRounds: tracksRoundsForType })
       }
       onSaved()
       setSaving(false)
@@ -554,13 +567,16 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
       const timeCapForCreate = timeCapSeconds !== null ? { timeCapSeconds } : {}
       let id = localWorkoutId
       if (id) {
-        await api.workouts.update(id, { title: title.trim(), description, type, movements, namedWorkoutId, timeCapSeconds, tracksRounds: tracksRoundsForType })
+        await scope.updateWorkout(id, { title: title.trim(), description, type, movements, namedWorkoutId, timeCapSeconds, tracksRounds: tracksRoundsForType })
       } else {
         const scheduledAt = new Date(dateKey! + 'T12:00:00').toISOString()
-        const created = await api.workouts.create(gymId, { programId, title: title.trim(), description, type, scheduledAt, movements, namedWorkoutId: namedWorkoutId ?? undefined, ...timeCapForCreate, tracksRounds: tracksRoundsForType })
+        const created = await scope.createWorkout(programId, { title: title.trim(), description, type, scheduledAt, movements, namedWorkoutId: namedWorkoutId ?? undefined, ...timeCapForCreate, tracksRounds: tracksRoundsForType })
         id = created.id
       }
-      await api.workouts.publish(id!)
+      // Publish is gym-only — admin workouts are auto-PUBLISHED on create.
+      // Hidden in the UI when scope.kind !== 'gym', so this branch is
+      // unreachable in admin mode; the guard is belt-and-suspenders.
+      if (isGymScope) await api.workouts.publish(id!)
       onSaved()
       setSaving(false)
     } catch (e) {
@@ -574,7 +590,7 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     setDeleting(true)
     setError(null)
     try {
-      await api.workouts.delete(localWorkoutId)
+      await scope.deleteWorkout(localWorkoutId)
       onSaved()
     } catch (e) {
       setError((e as Error).message)
@@ -594,8 +610,8 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
     setError(null)
     try {
       await Promise.all([
-        api.workouts.update(current.id, { dayOrder: target.dayOrder }),
-        api.workouts.update(target.id, { dayOrder: current.dayOrder }),
+        scope.updateWorkout(current.id, { dayOrder: target.dayOrder }),
+        scope.updateWorkout(target.id, { dayOrder: current.dayOrder }),
       ])
       onReordered?.()
     } catch (e) {
@@ -617,7 +633,7 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
 
   const programName =
     workout?.program?.name ??
-    programs.find((gp) => gp.programId === programId)?.program.name ??
+    programs.find((p) => p.id === programId)?.name ??
     '—'
 
   const autosaveLabel = isPublished
@@ -724,7 +740,7 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
                 ) : (
                   <button
                     key={w.id}
-                    onClick={() => onWorkoutSelect(w.id)}
+                    onClick={() => onWorkoutSelect?.(w.id)}
                     className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left text-gray-300 hover:bg-gray-800/60 hover:text-white transition-colors"
                   >
                     {rowContent}
@@ -764,8 +780,8 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
                 {!programsLoading && programs.length === 0 && (
                   <option value="">No programs found — create one in Settings</option>
                 )}
-                {programs.map((gp) => (
-                  <option key={gp.programId} value={gp.programId}>{gp.program.name}</option>
+                {programs.map((p) => (
+                  <option key={p.id} value={p.id}>{p.name}</option>
                 ))}
               </select>
             )}
@@ -1096,6 +1112,21 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
 
           {!showPublishConfirm && !showDeleteConfirm && (
             <>
+              {/*
+                * Admin path has no draft/staging concept (catalog content is
+                * always live), so the footer collapses to a single Save
+                * button that publishes immediately. Gym keeps the original
+                * Draft/Publish split flow.
+                */}
+              {!isGymScope ? (
+                <button
+                  onClick={handlePublish}
+                  disabled={saving}
+                  className="w-full bg-indigo-700 hover:bg-indigo-600 text-white text-sm py-2 rounded transition-colors disabled:opacity-50"
+                >
+                  {saving ? 'Saving...' : 'Save'}
+                </button>
+              ) : (
               <div className="flex gap-2">
                 <button
                   onClick={handleSaveDraft}
@@ -1114,6 +1145,7 @@ export default function WorkoutDrawer({ gymId, dateKey, workout, workoutsOnDay, 
                   </button>
                 )}
               </div>
+              )}
               {isEdit && (
                 <button
                   onClick={() => setShowDeleteConfirm(true)}

--- a/apps/web/src/lib/adminProgramScope.ts
+++ b/apps/web/src/lib/adminProgramScope.ts
@@ -21,4 +21,12 @@ export const adminProgramScope: ProgramScope = {
   list: () => api.admin.programs.list(),
   get: (id) => api.admin.programs.get(id),
   listWorkouts: (programId) => api.admin.programs.listWorkouts(programId),
+
+  createProgram: (data) => api.admin.programs.create(data),
+  updateProgram: (id, data) => api.admin.programs.update(id, data),
+  deleteProgram: (id) => api.admin.programs.delete(id),
+
+  createWorkout: (programId, data) => api.admin.programs.createWorkout(programId, data),
+  updateWorkout: (workoutId, data) => api.admin.workouts.update(workoutId, data),
+  deleteWorkout: (workoutId) => api.admin.workouts.delete(workoutId),
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -845,6 +845,56 @@ export const api = {
         req<Program>(`/api/admin/programs/${id}`, { token }),
       listWorkouts: (id: string, token?: string) =>
         req<Workout[]>(`/api/admin/programs/${id}/workouts`, { token }),
+      create: (
+        data: { name: string; description?: string; startDate: string; endDate?: string; coverColor?: string | null; visibility?: ProgramVisibility },
+        token?: string,
+      ) =>
+        req<Program>(`/api/admin/programs`, { method: 'POST', body: JSON.stringify(data), token }),
+      update: (
+        id: string,
+        data: { name?: string; description?: string | null; startDate?: string; endDate?: string | null; coverColor?: string | null; visibility?: ProgramVisibility },
+        token?: string,
+      ) =>
+        req<Program>(`/api/admin/programs/${id}`, { method: 'PATCH', body: JSON.stringify(data), token }),
+      delete: (id: string, token?: string) =>
+        req<void>(`/api/admin/programs/${id}`, { method: 'DELETE', token }),
+      createWorkout: (
+        programId: string,
+        data: {
+          title: string
+          description: string
+          type: WorkoutType
+          scheduledAt: string
+          movementIds?: string[]
+          movements?: WorkoutMovementInput[]
+          namedWorkoutId?: string
+          timeCapSeconds?: number | null
+          tracksRounds?: boolean
+        },
+        token?: string,
+      ) =>
+        req<Workout>(`/api/admin/programs/${programId}/workouts`, { method: 'POST', body: JSON.stringify(data), token }),
+    },
+    workouts: {
+      update: (
+        id: string,
+        data: {
+          title?: string
+          description?: string
+          type?: WorkoutType
+          scheduledAt?: string
+          dayOrder?: number
+          movementIds?: string[]
+          movements?: WorkoutMovementInput[]
+          namedWorkoutId?: string | null
+          timeCapSeconds?: number | null
+          tracksRounds?: boolean
+        },
+        token?: string,
+      ) =>
+        req<Workout>(`/api/admin/workouts/${id}`, { method: 'PATCH', body: JSON.stringify(data), token }),
+      delete: (id: string, token?: string) =>
+        req<void>(`/api/admin/workouts/${id}`, { method: 'DELETE', token }),
     },
   },
 }

--- a/apps/web/src/lib/gymProgramScope.ts
+++ b/apps/web/src/lib/gymProgramScope.ts
@@ -1,0 +1,56 @@
+/**
+ * `ProgramScope` implementation for the gym-scoped pages (#160). Wraps the
+ * existing gym-aware REST client so the same `ProgramFormDrawer` and
+ * `WorkoutDrawer` components serve both gym staff and WODalytics admins.
+ *
+ * Capabilities are derived from the caller's gym role. Gym-default toggle
+ * and members visibility are gym-only concepts; they're absent from the
+ * admin scope. The actual gym-default toggle still lives in
+ * `ProgramFormDrawer`'s gym-only render branch — this scope only carries
+ * the capability flags so the component knows what to show.
+ */
+import { api, type Role } from './api'
+import type { ProgramScope } from './programScope'
+
+interface GymScopeOpts {
+  gymId: string
+  gymRole: Role | null
+}
+
+export function makeGymProgramScope({ gymId, gymRole }: GymScopeOpts): ProgramScope {
+  const isStaff = gymRole === 'OWNER' || gymRole === 'PROGRAMMER'
+  const canSeeMembers = isStaff || gymRole === 'COACH'
+  return {
+    kind: 'gym',
+    capabilities: {
+      canWrite: isStaff,
+      canDelete: gymRole === 'OWNER',
+      canSeeMembers,
+      canSetDefault: gymRole === 'OWNER',
+    },
+
+    list: () => api.gyms.programs.list(gymId).then((rows) => rows.map((r) => r.program)),
+    get: (id) => api.programs.get(id).then((row) => row.program),
+    // Gym-scoped programs surface their workouts through the gym-day-range
+    // endpoint, not a per-program list — so this method is a no-op here.
+    // Slice 4 (when the gym path adopts shared workout-list components)
+    // will resolve this; for slice 3, only the admin path calls
+    // listWorkouts, so the gym implementation can stay unimplemented.
+    listWorkouts: () => Promise.resolve([]),
+
+    createProgram: async (data) => {
+      const { program } = await api.gyms.programs.create(gymId, data)
+      return program
+    },
+    updateProgram: (id, data) => api.programs.update(id, data),
+    deleteProgram: (id) => api.programs.delete(id),
+
+    createWorkout: (programId, data) =>
+      api.workouts.create(gymId, { ...data, programId }),
+    updateWorkout: (workoutId, data) => api.workouts.update(workoutId, data),
+    deleteWorkout: (workoutId) => api.workouts.delete(workoutId),
+
+    setProgramAsDefault: (programId) => api.gyms.programs.setDefault(gymId, programId),
+    clearProgramDefault: (programId) => api.gyms.programs.clearDefault(gymId, programId),
+  }
+}

--- a/apps/web/src/lib/programScope.ts
+++ b/apps/web/src/lib/programScope.ts
@@ -8,14 +8,14 @@
  * scope implementations — the components only see the scope interface, not
  * gym vs admin specifics.
  *
- * Slice 2 (this slice) establishes the read-only surface — list, get,
- * listWorkouts — and only the admin path uses it. The gym-scoped pages
- * still call the `api.gyms.*` / `api.programs.*` clients directly. Slice 3
- * grows the contract with mutations (`updateProgram`, `createWorkout`,
- * `updateWorkout`, `deleteWorkout`, ...) and migrates the gym-scoped pages
- * onto it as a side-effect of building the shared editor.
+ * Slice 2 established the read-only surface (list / get / listWorkouts).
+ * Slice 3 (this file's expanded contract) adds mutations: programs and
+ * workouts CRUD. Both editor components — `ProgramFormDrawer` and
+ * `WorkoutDrawer` — consume this interface; their two consumer routes
+ * pass a `gymProgramScope` (built from the active gym + role) or the
+ * singleton `adminProgramScope`.
  */
-import type { Program, Workout } from './api'
+import type { Program, ProgramVisibility, Workout, WorkoutMovementInput, WorkoutType } from './api'
 
 export type ProgramScopeKind = 'gym' | 'admin'
 
@@ -26,6 +26,54 @@ export interface ProgramScopeCapabilities {
   canSetDefault: boolean
 }
 
+// Shapes mirror the existing api.ts client signatures so the scope is a
+// drop-in over them — keeps the editor components free of conversion logic.
+export interface CreateProgramScopeData {
+  name: string
+  description?: string
+  startDate: string
+  endDate?: string
+  // No nullable form on create — to leave a field unset, omit it. The
+  // admin client's `create` accepts `string | null` but normalizes null to
+  // undefined; this tighter type keeps consumers honest.
+  coverColor?: string
+  visibility?: ProgramVisibility
+}
+
+export interface UpdateProgramScopeData {
+  name?: string
+  description?: string | null
+  startDate?: string
+  endDate?: string | null
+  coverColor?: string | null
+  visibility?: ProgramVisibility
+}
+
+export interface CreateWorkoutScopeData {
+  title: string
+  description: string
+  type: WorkoutType
+  scheduledAt: string
+  movementIds?: string[]
+  movements?: WorkoutMovementInput[]
+  namedWorkoutId?: string
+  timeCapSeconds?: number | null
+  tracksRounds?: boolean
+}
+
+export interface UpdateWorkoutScopeData {
+  title?: string
+  description?: string
+  type?: WorkoutType
+  scheduledAt?: string
+  dayOrder?: number
+  movementIds?: string[]
+  movements?: WorkoutMovementInput[]
+  namedWorkoutId?: string | null
+  timeCapSeconds?: number | null
+  tracksRounds?: boolean
+}
+
 export interface ProgramScope {
   kind: ProgramScopeKind
   /**
@@ -34,7 +82,25 @@ export interface ProgramScope {
    * every mutating call.
    */
   capabilities: ProgramScopeCapabilities
+
+  // Read (slice 2)
   list(): Promise<Program[]>
   get(id: string): Promise<Program>
   listWorkouts(programId: string): Promise<Workout[]>
+
+  // Program mutations (slice 3)
+  createProgram(data: CreateProgramScopeData): Promise<Program>
+  updateProgram(id: string, data: UpdateProgramScopeData): Promise<Program>
+  deleteProgram(id: string): Promise<void>
+
+  // Workout mutations (slice 3)
+  createWorkout(programId: string, data: CreateWorkoutScopeData): Promise<Workout>
+  updateWorkout(workoutId: string, data: UpdateWorkoutScopeData): Promise<Workout>
+  deleteWorkout(workoutId: string): Promise<void>
+
+  // Gym-only affordances. Optional on the contract so the admin scope can
+  // omit them entirely; consumers must check both `capabilities.canSetDefault`
+  // AND method presence before calling.
+  setProgramAsDefault?(programId: string): Promise<void>
+  clearProgramDefault?(programId: string): Promise<void>
 }

--- a/apps/web/src/pages/AdminProgramDetail.test.tsx
+++ b/apps/web/src/pages/AdminProgramDetail.test.tsx
@@ -7,9 +7,31 @@ import type { Program, Workout } from '../lib/api'
 vi.mock('../lib/api', () => ({
   api: {
     admin: {
-      programs: { list: vi.fn(), get: vi.fn(), listWorkouts: vi.fn() },
+      programs: {
+        list: vi.fn(),
+        get: vi.fn(),
+        listWorkouts: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        createWorkout: vi.fn(),
+      },
+      workouts: { update: vi.fn(), delete: vi.fn() },
     },
+    // Editors imported by AdminProgramDetail call these on open. Tests below
+    // never open the drawers, so the mocks only need to exist (for module
+    // resolution) — actual return values are irrelevant.
+    namedWorkouts: { list: vi.fn() },
+    movements: { list: vi.fn(), detect: vi.fn() },
   },
+  TYPE_ABBR: {
+    STRENGTH: 'S', FOR_TIME: 'F', EMOM: 'E', CARDIO: 'C',
+    AMRAP: 'A', METCON: 'M', WARMUP: 'W',
+  },
+}))
+
+vi.mock('../context/MovementsContext.tsx', () => ({
+  useMovements: () => [],
 }))
 
 import { api } from '../lib/api'
@@ -43,6 +65,8 @@ function makeWorkout(overrides: Partial<Workout> = {}): Workout {
     program: { id: 'p-1', name: 'CrossFit Mainsite' },
     namedWorkoutId: null,
     namedWorkout: null,
+    timeCapSeconds: null,
+    tracksRounds: false,
     _count: { results: 0 },
     createdAt: '2026-04-15T10:00:00.000Z',
     updatedAt: '2026-04-15T10:00:00.000Z',
@@ -89,5 +113,12 @@ describe('AdminProgramDetail', () => {
   it('shows empty-state copy when no workouts', async () => {
     renderPage()
     expect(await screen.findByText('No workouts yet.')).toBeInTheDocument()
+  })
+
+  it('renders the New Workout + Edit + Delete affordances (slice 3)', async () => {
+    renderPage()
+    expect(await screen.findByRole('button', { name: '+ New Workout' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Delete program/ })).toBeInTheDocument()
   })
 })

--- a/apps/web/src/pages/AdminProgramDetail.tsx
+++ b/apps/web/src/pages/AdminProgramDetail.tsx
@@ -1,29 +1,36 @@
 import { useEffect, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import type { Program, Workout } from '../lib/api'
 import { adminProgramScope } from '../lib/adminProgramScope'
 import { WORKOUT_TYPE_STYLES } from '../lib/workoutTypeStyles'
+import Button from '../components/ui/Button'
 import Skeleton from '../components/ui/Skeleton'
 import ProgramOverviewMeta from '../components/ProgramOverviewMeta'
+import ProgramFormDrawer from '../components/ProgramFormDrawer'
+import WorkoutDrawer from '../components/WorkoutDrawer'
 import { VisibilityBadge } from './ProgramDetail'
 
 /**
- * WODalytics admin: program detail + workouts list (#160).
- * Mounted at `/admin/programs/:id`. Read-only in slice 2; edit affordances
- * land in slice 3 along with the shared editor components driven by the
- * `ProgramScope` adapter.
+ * WODalytics admin: program detail + workouts list with edit affordances (#160).
+ * Mounted at `/admin/programs/:id`. The shared `ProgramFormDrawer` and
+ * `WorkoutDrawer` components handle the actual editing — they receive
+ * `adminProgramScope` and adapt their UI to the admin context (no gym-default
+ * toggle, no draft/publish flow, no workout reorder).
  *
  * Reuses `ProgramOverviewMeta` and `VisibilityBadge` so the visual surface
- * matches the gym-scoped `ProgramDetail` page exactly. The data shape
- * differs (admin gets `Program`, gym path gets `GymProgram`) but the
- * components only see fields that exist on both.
+ * matches the gym-scoped `ProgramDetail` page exactly.
  */
 export default function AdminProgramDetail() {
   const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
   const [program, setProgram] = useState<Program | null>(null)
   const [workouts, setWorkouts] = useState<Workout[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [programDrawerOpen, setProgramDrawerOpen] = useState(false)
+  const [workoutDrawerKey, setWorkoutDrawerKey] = useState<string | null>(null)
+  const [editingWorkout, setEditingWorkout] = useState<Workout | undefined>(undefined)
+  const [deleting, setDeleting] = useState(false)
 
   useEffect(() => {
     if (!id) return
@@ -49,6 +56,51 @@ export default function AdminProgramDetail() {
     } finally {
       if (!signal?.cancelled) setLoading(false)
     }
+  }
+
+  function refreshAfterMutation() {
+    if (id) load(id)
+  }
+
+  function handleProgramSaved(updated: Program) {
+    setProgramDrawerOpen(false)
+    setProgram(updated)
+    if (id) load(id)
+  }
+
+  async function handleDeleteProgram() {
+    if (!program) return
+    if (!window.confirm(`Delete program "${program.name}"? This cannot be undone. ${workouts.length} workout${workouts.length === 1 ? '' : 's'} will be deleted along with it.`)) return
+    setDeleting(true)
+    setError(null)
+    try {
+      await adminProgramScope.deleteProgram(program.id)
+      navigate('/admin/programs', { replace: true })
+    } catch (e) {
+      setError((e as Error).message)
+      setDeleting(false)
+    }
+  }
+
+  function openCreateWorkout() {
+    setEditingWorkout(undefined)
+    // Default new workouts to today's date — admins can pick any date in
+    // the drawer, but every code path needs a non-null dateKey to render.
+    const today = new Date()
+    const y = today.getFullYear()
+    const m = String(today.getMonth() + 1).padStart(2, '0')
+    const d = String(today.getDate()).padStart(2, '0')
+    setWorkoutDrawerKey(`${y}-${m}-${d}`)
+  }
+
+  function openEditWorkout(w: Workout) {
+    setEditingWorkout(w)
+    setWorkoutDrawerKey(w.scheduledAt.slice(0, 10))
+  }
+
+  function closeWorkoutDrawer() {
+    setWorkoutDrawerKey(null)
+    setEditingWorkout(undefined)
   }
 
   if (loading) return <Skeleton variant="feed-row" count={3} />
@@ -81,6 +133,7 @@ export default function AdminProgramDetail() {
             <p className="mt-1 text-sm text-gray-400">{program.description}</p>
           )}
         </div>
+        <Button variant="secondary" onClick={() => setProgramDrawerOpen(true)}>Edit</Button>
       </div>
 
       {error && <p className="text-red-400 mb-4">{error}</p>}
@@ -88,22 +141,54 @@ export default function AdminProgramDetail() {
       <ProgramOverviewMeta program={program} />
 
       <section>
-        <h2 className="text-lg font-semibold mb-3">Workouts</h2>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-lg font-semibold">Workouts</h2>
+          <Button variant="primary" onClick={openCreateWorkout}>+ New Workout</Button>
+        </div>
         {workouts.length === 0 ? (
           <p className="text-sm text-gray-500">No workouts yet.</p>
         ) : (
           <ul className="space-y-2">
             {workouts.map((w) => (
-              <AdminWorkoutRow key={w.id} workout={w} />
+              <AdminWorkoutRow key={w.id} workout={w} onClick={() => openEditWorkout(w)} />
             ))}
           </ul>
         )}
       </section>
+
+      <div className="mt-10 pt-6 border-t border-gray-800">
+        <h3 className="text-xs uppercase tracking-wider text-gray-400 mb-3">Danger zone</h3>
+        <Button variant="destructive" onClick={handleDeleteProgram} disabled={deleting}>
+          {deleting ? 'Deleting…' : 'Delete program'}
+        </Button>
+      </div>
+
+      <ProgramFormDrawer
+        scope={adminProgramScope}
+        program={program}
+        open={programDrawerOpen}
+        onClose={() => setProgramDrawerOpen(false)}
+        onSaved={handleProgramSaved}
+      />
+
+      <WorkoutDrawer
+        scope={adminProgramScope}
+        dateKey={workoutDrawerKey}
+        workout={editingWorkout}
+        defaultProgramId={program.id}
+        onClose={closeWorkoutDrawer}
+        onSaved={() => { closeWorkoutDrawer(); refreshAfterMutation() }}
+      />
     </div>
   )
 }
 
-function AdminWorkoutRow({ workout }: { workout: Workout }) {
+interface AdminWorkoutRowProps {
+  workout: Workout
+  onClick: () => void
+}
+
+function AdminWorkoutRow({ workout, onClick }: AdminWorkoutRowProps) {
   const style = WORKOUT_TYPE_STYLES[workout.type]
   const date = new Date(workout.scheduledAt).toLocaleDateString(undefined, {
     weekday: 'short',
@@ -112,24 +197,30 @@ function AdminWorkoutRow({ workout }: { workout: Workout }) {
     year: 'numeric',
   })
   return (
-    <li className="bg-gray-900 border border-gray-800 rounded-lg p-3 flex items-start gap-3">
-      <span
-        className={`shrink-0 inline-flex items-center justify-center w-10 h-10 rounded-md text-xs font-bold ${style.bg} ${style.tint}`}
-        aria-label={style.label}
+    <li>
+      <button
+        type="button"
+        onClick={onClick}
+        className="w-full bg-gray-900 border border-gray-800 rounded-lg p-3 flex items-start gap-3 text-left hover:border-gray-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
       >
-        {style.abbr}
-      </span>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 flex-wrap">
-          <h3 className="font-medium text-white truncate">{workout.title}</h3>
-          {workout.status === 'DRAFT' && (
-            <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-300">
-              Draft
-            </span>
-          )}
+        <span
+          className={`shrink-0 inline-flex items-center justify-center w-10 h-10 rounded-md text-xs font-bold ${style.bg} ${style.tint}`}
+          aria-label={style.label}
+        >
+          {style.abbr}
+        </span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="font-medium text-white truncate">{workout.title}</h3>
+            {workout.status === 'DRAFT' && (
+              <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-300">
+                Draft
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-gray-400 mt-0.5">{date}</p>
         </div>
-        <p className="text-xs text-gray-400 mt-0.5">{date}</p>
-      </div>
+      </button>
     </li>
   )
 }

--- a/apps/web/src/pages/AdminProgramsIndex.tsx
+++ b/apps/web/src/pages/AdminProgramsIndex.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react'
 import type { Program } from '../lib/api'
 import { adminProgramScope } from '../lib/adminProgramScope'
+import Button from '../components/ui/Button'
 import EmptyState from '../components/ui/EmptyState'
 import Skeleton from '../components/ui/Skeleton'
 import ProgramCard from '../components/ProgramCard'
+import ProgramFormDrawer from '../components/ProgramFormDrawer'
 
 /**
  * WODalytics admin: list of unaffiliated/public-catalog programs (#160).
@@ -11,13 +13,14 @@ import ProgramCard from '../components/ProgramCard'
  * the web app additionally hides the route from the sidebar for non-admins.
  *
  * Uses the shared `ProgramCard` component, same as the gym-scoped Programs
- * page. The scope adapter (`adminProgramScope`) is the only piece that knows
- * we're on the admin path.
+ * page, and the shared `ProgramFormDrawer` for create. The scope adapter
+ * (`adminProgramScope`) is the only piece that knows we're on the admin path.
  */
 export default function AdminProgramsIndex() {
   const [programs, setPrograms] = useState<Program[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [drawerOpen, setDrawerOpen] = useState(false)
 
   useEffect(() => {
     const signal = { cancelled: false }
@@ -38,16 +41,24 @@ export default function AdminProgramsIndex() {
     }
   }
 
+  function handleCreated(_created: Program) {
+    setDrawerOpen(false)
+    load()
+  }
+
   return (
     <div>
-      <div className="mb-6">
-        <div className="flex items-center gap-3">
-          <h1 className="text-2xl font-bold">Admin · Programs</h1>
-          <span className="bg-gray-700 text-sm px-2 py-0.5 rounded-full">{programs.length}</span>
+      <div className="flex items-start justify-between mb-6 gap-4">
+        <div>
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold">Admin · Programs</h1>
+            <span className="bg-gray-700 text-sm px-2 py-0.5 rounded-full">{programs.length}</span>
+          </div>
+          <p className="mt-1 text-sm text-gray-400">
+            Unaffiliated programs surfaced from public sources (e.g. CrossFit Mainsite). Editable by WODalytics staff.
+          </p>
         </div>
-        <p className="mt-1 text-sm text-gray-400">
-          Unaffiliated programs surfaced from public sources (e.g. CrossFit Mainsite). Editable by WODalytics staff.
-        </p>
+        <Button variant="primary" onClick={() => setDrawerOpen(true)}>+ New Program</Button>
       </div>
 
       {error && <p className="text-red-400 mb-4">{error}</p>}
@@ -56,7 +67,8 @@ export default function AdminProgramsIndex() {
       {!loading && programs.length === 0 && !error && (
         <EmptyState
           title="No unaffiliated programs"
-          body="Programs imported from external sources will appear here once an ingest job runs."
+          body="Programs imported from external sources will appear here once an ingest job runs — or create one yourself."
+          cta={{ label: '+ New Program', onClick: () => setDrawerOpen(true) }}
         />
       )}
 
@@ -67,6 +79,13 @@ export default function AdminProgramsIndex() {
           ))}
         </div>
       )}
+
+      <ProgramFormDrawer
+        scope={adminProgramScope}
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        onSaved={handleCreated}
+      />
     </div>
   )
 }

--- a/apps/web/src/pages/Calendar.tsx
+++ b/apps/web/src/pages/Calendar.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { api, type Workout } from '../lib/api'
 import { useGym } from '../context/GymContext.tsx'
+import { makeGymProgramScope } from '../lib/gymProgramScope'
 import { useMovements } from '../context/MovementsContext.tsx'
 import { useProgramFilter } from '../context/ProgramFilterContext.tsx'
 import CalendarCell from '../components/CalendarCell'
@@ -21,6 +22,10 @@ const DAY_HEADERS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
 export default function Calendar() {
   const { gymId, gymRole: userGymRole } = useGym()
+  const scope = useMemo(
+    () => makeGymProgramScope({ gymId: gymId ?? '', gymRole: userGymRole ?? null }),
+    [gymId, userGymRole],
+  )
   const allMovements = useMovements()
   const { selected: programIds, available, clear: clearProgramFilter } = useProgramFilter()
   const today = new Date()
@@ -240,7 +245,7 @@ export default function Calendar() {
       </div>
 
       <WorkoutDrawer
-        gymId={gymId}
+        scope={scope}
         dateKey={selectedDate}
         workout={selectedWorkout}
         workoutsOnDay={workoutsOnDay}

--- a/apps/web/src/pages/ProgramDetail.tsx
+++ b/apps/web/src/pages/ProgramDetail.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { api, type GymProgram, type Program, type ProgramVisibility } from '../lib/api'
 import { useGym } from '../context/GymContext.tsx'
+import { makeGymProgramScope } from '../lib/gymProgramScope'
 import Button from '../components/ui/Button'
 import Skeleton from '../components/ui/Skeleton'
 import ProgramFormDrawer from '../components/ProgramFormDrawer'
@@ -24,6 +25,12 @@ export default function ProgramDetail() {
   const canWrite = gymRole === 'OWNER' || gymRole === 'PROGRAMMER'
   const canDelete = gymRole === 'OWNER'
   const canSeeMembers = canWrite || gymRole === 'COACH'
+  // Detail row carries gymId; the scope only really needs it once detail
+  // resolves, so derive lazily.
+  const scope = useMemo(
+    () => makeGymProgramScope({ gymId: detail?.gymId ?? '', gymRole: gymRole ?? null }),
+    [detail?.gymId, gymRole],
+  )
 
   useEffect(() => {
     if (!id) return
@@ -167,10 +174,9 @@ export default function ProgramDetail() {
       )}
 
       <ProgramFormDrawer
-        gymId={detail.gymId}
+        scope={scope}
         program={program}
         isDefault={detail.isDefault}
-        canSetDefault={gymRole === 'OWNER'}
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
         onSaved={handleSaved}

--- a/apps/web/src/pages/ProgramsIndex.tsx
+++ b/apps/web/src/pages/ProgramsIndex.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { api, type GymProgram, type Program } from '../lib/api'
 import { useGym } from '../context/GymContext.tsx'
+import { makeGymProgramScope } from '../lib/gymProgramScope'
 import Button from '../components/ui/Button'
 import EmptyState from '../components/ui/EmptyState'
 import Skeleton from '../components/ui/Skeleton'
@@ -15,6 +16,10 @@ export default function ProgramsIndex() {
   const [drawerOpen, setDrawerOpen] = useState(false)
 
   const canWrite = gymRole === 'OWNER' || gymRole === 'PROGRAMMER'
+  const scope = useMemo(
+    () => makeGymProgramScope({ gymId: gymId ?? '', gymRole: gymRole ?? null }),
+    [gymId, gymRole],
+  )
 
   useEffect(() => {
     if (!gymId) return
@@ -90,8 +95,7 @@ export default function ProgramsIndex() {
       )}
 
       <ProgramFormDrawer
-        gymId={gymId}
-        canSetDefault={gymRole === 'OWNER'}
+        scope={scope}
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
         onSaved={handleCreated}

--- a/apps/web/tests/admin-programs.spec.ts
+++ b/apps/web/tests/admin-programs.spec.ts
@@ -92,6 +92,46 @@ test('admin sees the WODalytics Admin nav and can list + view an unaffiliated pr
   }
 })
 
+test('admin can create a workout under an unaffiliated program (slice 3)', async ({ page, context }) => {
+  const fx = await seedAdminFixture(randomUUID().slice(0, 8))
+  let createdWorkoutId: string | null = null
+  const newTitle = `Admin E2E New Workout ${randomUUID().slice(0, 8)}`
+  try {
+    await loginAs(context, fx.adminUserId, 'OWNER')
+    await page.goto(`/admin/programs/${fx.programId}`)
+
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Admin E2E')
+    await page.getByRole('button', { name: '+ New Workout' }).click()
+
+    // The shared WorkoutDrawer opens. Title input renders immediately;
+    // programs load asynchronously into the picker — wait for the select
+    // to settle on the seeded program before filling the form so the
+    // create call carries the right programId.
+    const title = page.getByPlaceholder('e.g. Fran')
+    await expect(title).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('select#wd-program')).toHaveValue(/.+/, { timeout: 10000 })
+
+    await title.fill(newTitle)
+    await page.getByPlaceholder(/Workout details/).fill('21-15-9 thrusters / pull-ups')
+
+    // Admin path: single Save button (no Draft/Publish split — admin
+    // workouts auto-publish).
+    await page.getByRole('button', { name: 'Save', exact: true }).click()
+
+    // The drawer closes and the new workout appears in the list.
+    await expect(page.getByText(newTitle)).toBeVisible({ timeout: 10000 })
+
+    const created = await prisma.workout.findFirst({ where: { title: newTitle } })
+    if (!created) throw new Error('Created workout not found in DB')
+    createdWorkoutId = created.id
+    expect(created.programId).toBe(fx.programId)
+    expect(created.status).toBe('PUBLISHED')
+  } finally {
+    if (createdWorkoutId) await prisma.workout.delete({ where: { id: createdWorkoutId } }).catch(() => {})
+    await teardown(fx)
+  }
+})
+
 test('non-admin user does not see the WODalytics Admin sidebar entry', async ({ page, context }) => {
   const fx = await seedAdminFixture(randomUUID().slice(0, 8))
   const ts = randomUUID().slice(0, 8)


### PR DESCRIPTION
## Summary

Closes #160 — admins can now create, edit, and delete unaffiliated/public-catalog programs and their workouts. Honors the parent issue's hard requirement: **no parallel editor components**. Both `ProgramFormDrawer` and `WorkoutDrawer` are now scope-aware; gym staff and admins mount the same drawers, just with different `ProgramScope` implementations.

### API

Six new endpoints, all gated by `requireAuth + requireWodalyticsAdmin`:

```
POST   /api/admin/programs                   create
PATCH  /api/admin/programs/:id               update
DELETE /api/admin/programs/:id               delete (cascades to workouts)
POST   /api/admin/programs/:id/workouts      create workout (auto-PUBLISHED)
PATCH  /api/admin/workouts/:id               update workout
DELETE /api/admin/workouts/:id               delete workout
```

Every mutation re-checks the target program is in the public catalog — no gym affiliation AND no `ownerUserId`. **The Personal Programs work landed on main between slices 2 and 3, so this PR also tightens slice-2's `findUnaffiliatedProgramByIdWithCounts` filter to exclude `ownerUserId != null`** — without that, admins would have started seeing users' private Personal Programs in the admin list. Caught and fixed in the same PR via the shared `ADMIN_CATALOG_WHERE` predicate.

### Web — ProgramScope adapter (the load-bearing part)

`ProgramScope` is now the contract for both editor components. Two implementations:

- **`gymProgramScope`** (new): built from `useGym()` context, routes through `api.gyms.* / api.programs.* / api.workouts.*`. Carries the gym-default toggle methods (`setProgramAsDefault` / `clearProgramDefault`) as optional contract members.
- **`adminProgramScope`** (expanded from slice 2): routes through the new `api.admin.*` namespace. Capabilities omit `canSetDefault` / `canSeeMembers` since those are gym concepts.

Both `ProgramFormDrawer` and `WorkoutDrawer` now accept a `scope` prop and dispatch every mutation through it. Gym-only affordances are hidden when the scope's capability flag is false:

- **Gym default toggle** — hidden in `ProgramFormDrawer` when `scope.capabilities.canSetDefault === false`
- **Draft/Publish split + reorder** — replaced with a single "Save" button in `WorkoutDrawer` when `scope.kind === 'admin'` (admin catalog has no draft/staging — workouts ship live)
- **`workoutsOnDay` day-navigation** — `WorkoutDrawer` props relaxed to make day-context fields optional; admin mounts without them

The result: editing a CrossFit Mainsite workout from `/admin/programs/:id` opens **the exact same `WorkoutDrawer`** an OWNER opens from `/calendar`. Search the diff for `Admin*Drawer` — there's nothing.

## Tests

**Unit** (`apps/web/src/pages/AdminProgramDetail.test.tsx`):
- renders without crashing
- renders the workouts section header
- lists workouts when present
- shows empty-state copy when no workouts
- renders the New Workout + Edit + Delete affordances (slice 3 — confirms the editing entry points appear)

**Unit** (`apps/web/src/pages/AdminProgramsIndex.test.tsx` — slice 2, unchanged):
- renders without crashing
- shows the empty state when no unaffiliated programs exist
- lists program cards when the API returns programs

**Unit** (`apps/web/src/components/WorkoutDrawer.test.tsx`):
- All existing autosave / prescription / suggestion-pill specs continue to pass after the gym path was migrated to `gymProgramScope`. The scope wraps the existing `api.workouts.create / update / publish / delete` calls so `expect(api.workouts.create).toHaveBeenCalled()` assertions remain valid.

**API integration** (`apps/api/tests/admin-programs-mutations.ts` — new):
- T1: `POST /api/admin/programs` no auth → 401
- T2: `POST /api/admin/programs` non-admin → 403
- T3: `POST /api/admin/programs` admin invalid (empty name) → 400
- T4: `POST /api/admin/programs` admin → 201, defaults visibility=PUBLIC, persists name
- T5: `PATCH /api/admin/programs/:id` no auth → 401
- T6: `PATCH /api/admin/programs/:id` non-admin → 403
- T7: `PATCH /api/admin/programs/:id` admin rename → 200
- T8: `PATCH /api/admin/programs/:id` admin on **affiliated** program → 404
- T9: `PATCH /api/admin/programs/:id` admin on **Personal Program** → 404
- T10: `DELETE /api/admin/programs/:id` no auth → 401
- T11: `DELETE /api/admin/programs/:id` non-admin → 403
- T12: `DELETE /api/admin/programs/:id` admin on affiliated → 404
- T13: `DELETE /api/admin/programs/:id` admin on Personal Program → 404
- T14: `DELETE /api/admin/programs/:id` admin → 204
- T15: deleted program returns 404 on subsequent GET
- T16: `POST /api/admin/programs/:id/workouts` non-admin → 403
- T17: `POST /api/admin/programs/:id/workouts` admin on affiliated program → 404
- T18: `POST /api/admin/programs/:id/workouts` admin on Personal Program → 404
- T19: `POST /api/admin/programs/:id/workouts` admin → 201, programId from URL wins, status=PUBLISHED
- T20: `PATCH /api/admin/workouts/:id` non-admin → 403
- T21: `PATCH /api/admin/workouts/:id` admin on affiliated workout → 404
- T22: `PATCH /api/admin/workouts/:id` admin rename → 200
- T23: `DELETE /api/admin/workouts/:id` non-admin → 403
- T24: `DELETE /api/admin/workouts/:id` admin on affiliated workout → 404
- T25: `DELETE /api/admin/workouts/:id` admin → 204

**Playwright E2E** (`apps/web/tests/admin-programs.spec.ts`):
- T1: admin sees the WODalytics Admin nav and can list + view an unaffiliated program (slice 2)
- T2: **admin can create a workout under an unaffiliated program (slice 3)** — opens the shared `WorkoutDrawer` from `/admin/programs/:id`, fills title + description, clicks the unified "Save" button, verifies the new row appears AND the DB record is `programId=<this program>` + `status=PUBLISHED`
- T3: non-admin user does not see the WODalytics Admin sidebar entry (slice 2)

**Roles tested:**
- Allowlisted (`WODALYTICS_ADMIN_EMAILS`) admin user — full CRUD on public-catalog programs and workouts.
- Non-allowlisted authenticated MEMBER — 403 on every mutation; admin nav hidden.
- Unauthenticated — 401 on every mutation.
- Personal Program owner — admin cannot mutate Personal Programs through this surface (404 from the public-catalog filter).

**Mobile parity:** desk-suitable only — no mobile counterpart. WODalytics admin curation is heavy authoring of public-catalog programs (workout descriptions, movement prescriptions, scheduling); the gym-side `WorkoutDrawer` is web-only for the same reason. Mobile staff/admin work continues to be tracked under #130 if/when needed.

**Not automated / manual verification needed:**
- [ ] Visual: confirm the WorkoutDrawer footer renders the single "Save" button on `/admin/programs/:id` and the existing "Save as Draft / Publish" split on `/calendar`. Tested implicitly by E2E T2 (admin saves via "Save") but no snapshot.

## Test run

- `turbo lint`: clean (after refactoring 3 callsites of `ProgramFormDrawer` + `WorkoutDrawer`)
- `npm run test:unit --workspace=@wodalytics/web`: **177 passed, 0 failed**
- `npm run test:worktree -- api` (against the live worktree dev stack, auto-bootstrapped via `dev:worktree`'s preflight from #190): **all suites pass** (admin-programs-mutations: 31/31, plus existing admin-auth and admin-programs)
- `npm run test:worktree -- e2e`: **39 passed**, 1 pre-existing failure unrelated to this PR (`programs.spec.ts:277 — MEMBER joins a PUBLIC program from Browse`). Verified the failure also reproduces 3/3 with `--repeat-each=3` against the merged-from-main code; this PR does not touch `BrowsePrograms` or the join flow.

## Out of scope (future)

- Migrating the gym-scoped `Calendar` workout editor to use a unified single-button save (currently kept on Draft/Publish flow because gym staff have an explicit publish concept). Not required by #160; can ship if/when the drafting flow is reconsidered.
- "Adopt to gym" — promoting an admin program into a gym's catalog. Out of scope for #160 entirely.
- Bulk import / sync controls beyond what the existing CrossFit ingest job already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)