### PR TITLE
feat(web): feed empty-day tiles + infinite scroll

### DIFF
--- a/apps/web/src/pages/Feed.test.tsx
+++ b/apps/web/src/pages/Feed.test.tsx
@@ -79,15 +79,18 @@ const ALL_TYPES: WorkoutType[] = [
 ]
 
 function makeWorkout(type: WorkoutType, idx: number) {
-  // Space scheduledAt across distinct days so they render as separate cards.
-  const day = String(idx + 1).padStart(2, '0')
+  // Space scheduledAt across distinct days relative to today so they always
+  // fall within the initial 30-day fetch window (today-30 … today+14).
+  const d = new Date()
+  d.setDate(d.getDate() - idx)
+  d.setHours(12, 0, 0, 0)
   return {
     id: `w-${type}`,
     title: `${type} workout`,
     description: null,
     type,
     status: 'PUBLISHED' as const,
-    scheduledAt: `2026-04-${day}T12:00:00.000Z`,
+    scheduledAt: d.toISOString(),
     dayOrder: 0,
     workoutMovements: [],
     programId: null,
@@ -95,8 +98,8 @@ function makeWorkout(type: WorkoutType, idx: number) {
     namedWorkoutId: null,
     namedWorkout: null,
     _count: { results: 0 },
-    createdAt: '2026-04-01T00:00:00.000Z',
-    updatedAt: '2026-04-01T00:00:00.000Z',
+    createdAt: d.toISOString(),
+    updatedAt: d.toISOString(),
   }
 }
 
@@ -196,6 +199,40 @@ describe('Feed — workout-type tokens', () => {
       expect(abbr.className).toContain(styles.bg)
       expect(abbr.className).toContain(styles.tint)
     }
+  })
+})
+
+// ─── Empty-day tiles ─────────────────────────────────────────────────────────
+
+describe('Feed — empty-day tiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFilter.selected = []
+    mockFilter.available = []
+  })
+
+  it('renders "No workouts planned" tiles when the API returns no workouts', async () => {
+    vi.mocked(api.workouts.list).mockResolvedValue([] as never)
+    renderFeed()
+    const tiles = await screen.findAllByText('No workouts planned')
+    expect(tiles.length).toBeGreaterThan(0)
+  })
+
+  it('renders a day header for days with no workouts alongside the empty-tile text', async () => {
+    vi.mocked(api.workouts.list).mockResolvedValue([] as never)
+    renderFeed()
+    // TODAY label should always appear (it's within the initial range)
+    expect(await screen.findByText('TODAY')).toBeInTheDocument()
+  })
+
+  it('renders workout cards for days that do have workouts and empty tiles for days that do not', async () => {
+    const w = makeWorkout('AMRAP', 0)   // scheduled today
+    vi.mocked(api.workouts.list).mockResolvedValue([w] as never)
+    renderFeed()
+    expect(await screen.findByRole('button', { name: /AMRAP workout/ })).toBeInTheDocument()
+    // Other days in the range have no workouts → at least one empty tile
+    const emptyTiles = await screen.findAllByText('No workouts planned')
+    expect(emptyTiles.length).toBeGreaterThan(0)
   })
 })
 

--- a/apps/web/src/pages/Feed.tsx
+++ b/apps/web/src/pages/Feed.tsx
@@ -1,19 +1,50 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { api, type Workout } from '../lib/api.ts'
 import { WORKOUT_TYPE_STYLES } from '../lib/workoutTypeStyles.ts'
 import { useGym } from '../context/GymContext.tsx'
 import { useProgramFilter } from '../context/ProgramFilterContext.tsx'
-import EmptyState from '../components/ui/EmptyState.tsx'
 import Skeleton from '../components/ui/Skeleton.tsx'
 import BarbellIcon from '../components/icons/BarbellIcon.tsx'
 import UsersIcon from '../components/icons/UsersIcon.tsx'
+
+const INITIAL_FUTURE_DAYS = 14
+const INITIAL_PAST_DAYS = 30
+const PAGE_DAYS = 30
+
+type DayBlock = { dateKey: string; workouts: Workout[] }
 
 function toDateKey(date: Date): string {
   const y = date.getFullYear()
   const m = String(date.getMonth() + 1).padStart(2, '0')
   const d = String(date.getDate()).padStart(2, '0')
   return `${y}-${m}-${d}`
+}
+
+function addDays(date: Date, days: number): Date {
+  const d = new Date(date)
+  d.setDate(d.getDate() + days)
+  return d
+}
+
+// Builds a contiguous DayBlock[] from `start` to `end`, newest-first.
+// Days without workouts get an empty array so they render as "No workouts planned".
+function buildDayBlocks(workouts: Workout[], start: Date, end: Date): DayBlock[] {
+  const byDate: Record<string, Workout[]> = {}
+  for (const w of workouts) {
+    const key = toDateKey(new Date(w.scheduledAt))
+    if (!byDate[key]) byDate[key] = []
+    byDate[key].push(w)
+  }
+  const blocks: DayBlock[] = []
+  const startMidnight = new Date(start.getFullYear(), start.getMonth(), start.getDate())
+  let cursor = new Date(end.getFullYear(), end.getMonth(), end.getDate())
+  while (cursor >= startMidnight) {
+    const key = toDateKey(cursor)
+    blocks.push({ dateKey: key, workouts: byDate[key] ?? [] })
+    cursor = addDays(cursor, -1)
+  }
+  return blocks
 }
 
 function formatDayLabel(dateKey: string, todayKey: string): string {
@@ -34,8 +65,16 @@ export default function Feed() {
   const { gymId } = useGym()
   const { selected: programIds, available, clear: clearProgramFilter } = useProgramFilter()
   const [workouts, setWorkouts] = useState<Workout[]>([])
+  const [fetchStart, setFetchStart] = useState<Date | null>(null)
+  const [fetchEnd, setFetchEnd] = useState<Date | null>(null)
   const [loading, setLoading] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Refs let loadMore read current values without needing them in its dep array,
+  // so the IntersectionObserver doesn't reconnect on every page load.
+  const fetchStartRef = useRef<Date | null>(null)
+  const loadingMoreRef = useRef(false)
+  const sentinelRef = useRef<HTMLDivElement>(null)
   const navigate = useNavigate()
 
   const programIdsKey = programIds.join(',')
@@ -45,11 +84,15 @@ export default function Feed() {
     let cancelled = false
     setLoading(true)
     setError(null)
+    setWorkouts([])
+    setFetchStart(null)
+    setFetchEnd(null)
+    fetchStartRef.current = null
+    loadingMoreRef.current = false
     const today = new Date()
-    const from = new Date(today)
-    from.setDate(today.getDate() - 30)
+    const from = addDays(today, -INITIAL_PAST_DAYS)
     const to = new Date(today)
-    to.setDate(today.getDate() + 14)
+    to.setDate(today.getDate() + INITIAL_FUTURE_DAYS)
     to.setHours(23, 59, 59, 999)
     api.workouts.list(
       gymId,
@@ -57,11 +100,54 @@ export default function Feed() {
       to.toISOString(),
       programIds.length ? { programIds } : undefined,
     )
-      .then((data) => { if (!cancelled) setWorkouts(data.filter((w) => w.status === 'PUBLISHED')) })
+      .then((data) => {
+        if (!cancelled) {
+          setWorkouts(data.filter((w) => w.status === 'PUBLISHED'))
+          fetchStartRef.current = from
+          setFetchStart(from)
+          setFetchEnd(to)
+        }
+      })
       .catch((e) => { if (!cancelled) setError((e as Error).message) })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
   }, [gymId, programIdsKey])  // eslint-disable-line react-hooks/exhaustive-deps
+
+  const loadMore = useCallback(() => {
+    if (!gymId || !fetchStartRef.current || loadingMoreRef.current) return
+    loadingMoreRef.current = true
+    setLoadingMore(true)
+    const newFrom = addDays(fetchStartRef.current, -PAGE_DAYS)
+    const newTo = addDays(fetchStartRef.current, -1)
+    newTo.setHours(23, 59, 59, 999)
+    api.workouts.list(
+      gymId,
+      newFrom.toISOString(),
+      newTo.toISOString(),
+      programIds.length ? { programIds } : undefined,
+    )
+      .then((data) => {
+        setWorkouts((prev) => [...prev, ...data.filter((w) => w.status === 'PUBLISHED')])
+        fetchStartRef.current = newFrom
+        setFetchStart(newFrom)
+      })
+      .catch((e) => setError((e as Error).message))
+      .finally(() => {
+        loadingMoreRef.current = false
+        setLoadingMore(false)
+      })
+  }, [gymId, programIdsKey])  // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!sentinel) return
+    const observer = new IntersectionObserver(
+      (entries) => { if (entries[0].isIntersecting) loadMore() },
+      { rootMargin: '200px' },
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [loadMore])
 
   if (!gymId) {
     return (
@@ -75,17 +161,7 @@ export default function Feed() {
   const today = new Date()
   const todayKey = toDateKey(today)
 
-  const workoutsByDate: Record<string, Workout[]> = {}
-  for (const w of workouts) {
-    const key = toDateKey(new Date(w.scheduledAt))
-    if (!workoutsByDate[key]) workoutsByDate[key] = []
-    workoutsByDate[key].push(w)
-  }
-
-  const allKeys = Object.keys(workoutsByDate)
-  const futureKeys = allKeys.filter((k) => k >= todayKey).sort()
-  const pastKeys = allKeys.filter((k) => k < todayKey).sort().reverse()
-  const sortedKeys = [...futureKeys, ...pastKeys]
+  const dayBlocks = fetchStart && fetchEnd ? buildDayBlocks(workouts, fetchStart, fetchEnd) : []
 
   // Single-program filter gets a featured header (color stripe + name).
   // Multi-program gets a compact chip pointing at the picker.
@@ -133,15 +209,8 @@ export default function Feed() {
 
       {loading && <Skeleton variant="feed-row" count={4} />}
 
-      {!loading && sortedKeys.length === 0 && (
-        <EmptyState
-          title="No published workouts"
-          body="Nothing posted in the last 30 days."
-        />
-      )}
-
       <div className="space-y-8">
-        {sortedKeys.map((dateKey) => (
+        {dayBlocks.map(({ dateKey, workouts: dayWorkouts }) => (
           <div key={dateKey}>
             <div className="flex items-center gap-3 mb-3">
               <span className="text-xs font-semibold tracking-widest text-gray-400">
@@ -150,38 +219,45 @@ export default function Feed() {
               <hr className="flex-1 border-gray-800" />
             </div>
 
-            <div className="space-y-2">
-              {workoutsByDate[dateKey].map((workout) => {
-                const styles = WORKOUT_TYPE_STYLES[workout.type]
-                return (
-                <button
-                  key={workout.id}
-                  onClick={() => navigate(`/workouts/${workout.id}`)}
-                  className={`w-full flex items-start gap-3 px-4 py-3 rounded-lg bg-gray-900 hover:bg-gray-800 transition-colors text-left group border-l-4 ${styles.accentBar}`}
-                >
-                  <span className={`shrink-0 mt-0.5 w-7 h-6 flex items-center justify-center rounded text-xs font-bold ${styles.bg} ${styles.tint}`}>
-                    {styles.abbr}
-                  </span>
-                  <span className="flex-1 min-w-0">
-                    <span className="block text-sm font-medium text-white break-words">
-                      {workout.title}
-                    </span>
-                    {workout.namedWorkout && (
-                      <span className="text-xs text-indigo-400">● {workout.namedWorkout.name}</span>
-                    )}
-                    <FeedTileBadgeRow
-                      logged={Boolean(workout.myResultId)}
-                      resultCount={workout._count.results}
-                    />
-                  </span>
-                  <span className="shrink-0 mt-0.5 text-gray-400 group-hover:text-white transition-colors">›</span>
-                </button>
-                )
-              })}
-            </div>
+            {dayWorkouts.length === 0 ? (
+              <p className="text-sm text-gray-500 pl-1">No workouts planned</p>
+            ) : (
+              <div className="space-y-2">
+                {dayWorkouts.map((workout) => {
+                  const styles = WORKOUT_TYPE_STYLES[workout.type]
+                  return (
+                    <button
+                      key={workout.id}
+                      onClick={() => navigate(`/workouts/${workout.id}`)}
+                      className={`w-full flex items-start gap-3 px-4 py-3 rounded-lg bg-gray-900 hover:bg-gray-800 transition-colors text-left group border-l-4 ${styles.accentBar}`}
+                    >
+                      <span className={`shrink-0 mt-0.5 w-7 h-6 flex items-center justify-center rounded text-xs font-bold ${styles.bg} ${styles.tint}`}>
+                        {styles.abbr}
+                      </span>
+                      <span className="flex-1 min-w-0">
+                        <span className="block text-sm font-medium text-white break-words">
+                          {workout.title}
+                        </span>
+                        {workout.namedWorkout && (
+                          <span className="text-xs text-indigo-400">● {workout.namedWorkout.name}</span>
+                        )}
+                        <FeedTileBadgeRow
+                          logged={Boolean(workout.myResultId)}
+                          resultCount={workout._count.results}
+                        />
+                      </span>
+                      <span className="shrink-0 mt-0.5 text-gray-400 group-hover:text-white transition-colors">›</span>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
           </div>
         ))}
       </div>
+
+      <div ref={sentinelRef} className="h-1" />
+      {loadingMore && <Skeleton variant="feed-row" count={2} />}
     </div>
   )
 }

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+
+// jsdom doesn't implement IntersectionObserver; provide a no-op stub so
+// components that use it (Feed infinite scroll) don't throw during tests.
+class MockIntersectionObserver {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+  constructor(_cb: IntersectionObserverCallback, _opts?: IntersectionObserverInit) {}
+}
+Object.defineProperty(globalThis, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: MockIntersectionObserver,
+})


### PR DESCRIPTION
## Summary

- Ports mobile's contiguous day-grid to the web feed. Every calendar day in the loaded range now renders a tile — days with no scheduled workout show "No workouts planned" instead of being silently skipped.
- Adds an `IntersectionObserver` sentinel at the bottom of the list that loads the next 30-day chunk (`PAGE_DAYS = 30`) as the user scrolls, matching mobile's pagination behaviour.
- Uses local calendar time for date-key grouping (same as mobile), so a workout scheduled in the evening doesn't fall onto the next UTC day.

Closes #194

## Implementation notes

`buildDayBlocks(workouts, start, end)` generates a contiguous `DayBlock[]` newest-first for every day in `[start, end]`, inserting `workouts: []` for days the API returned nothing. The `IntersectionObserver` is wired to a 1px sentinel div; `fetchStartRef` / `loadingMoreRef` are refs (not state) so the observer doesn't reconnect on every pagination fetch.

## Tests

**Unit** (`apps/web/src/pages/Feed.test.tsx`):
- `omits programIds from the filters bag when no programs are selected` — API call args + Feed heading renders
- `passes programIds in the filters bag and renders the single-program header` — filter forwarded, program name shown
- `renders the multi-program header when 2+ programs are selected` — "Filtered to N programs" eyebrow
- `shows a "Back to all workouts" link when any program is selected`
- `renders each workout type card with its expected accentBar class` — all 25 types covered
- `applies each type chip bg + tint to the abbreviation span` — all 25 types covered
- `renders "No workouts planned" tiles when the API returns no workouts` — empty-day tile (new)
- `renders a day header for days with no workouts alongside the empty-tile text` — TODAY label present (new)
- `renders workout cards for days that do have workouts and empty tiles for days that do not` — mix of cards + empty tiles (new)
- `shows the loaded-barbell + result count when the viewer has logged and others have results`
- `shows the empty-barbell + result count when the viewer has not logged but others have`
- `renders neither badge when the workout has no results and the viewer has not logged`
- `hides the count when only the viewer has logged`

All 179 tests pass.

**Not automated / manual verification needed:**
- [ ] Scroll to the bottom of the feed and confirm the next 30-day chunk appends (IntersectionObserver doesn't fire in jsdom)
- [ ] Verify "No workouts planned" tiles appear for rest days in the gym's programme

**Mobile parity:** This PR closes an existing mobile-parity gap — mobile already has the feature; this issue (#194) tracked bringing web to the same state.