### PR TITLE
chore(db): data migration to fix CrossFit Mainsite WOD scheduledAt dates

### DIFF
--- a/packages/db/prisma/migrations/20260503131526_fix_crossfit_wod_scheduled_at/migration.sql
+++ b/packages/db/prisma/migrations/20260503131526_fix_crossfit_wod_scheduled_at/migration.sql
@@ -1,0 +1,17 @@
+-- CrossFit posts each day's WOD at 23:55 UTC; the ingest job previously used
+-- `publishingDate` as `scheduledAt`, placing every WOD one day early.
+-- The correct scheduledAt is UTC midnight of the YYYYMMDD date encoded in
+-- externalSourceId (e.g. "crossfit-mainsite:w20260425" → 2026-04-25 00:00:00 UTC).
+UPDATE "Workout"
+SET "scheduledAt" = (
+  to_date(
+    substring("externalSourceId" FROM 'crossfit-mainsite:w([0-9]{8})'),
+    'YYYYMMDD'
+  )::timestamp AT TIME ZONE 'UTC'
+)
+WHERE "externalSourceId" LIKE 'crossfit-mainsite:w%'
+  AND date_trunc('day', "scheduledAt" AT TIME ZONE 'UTC') <>
+      (to_date(
+        substring("externalSourceId" FROM 'crossfit-mainsite:w([0-9]{8})'),
+        'YYYYMMDD'
+      )::timestamp AT TIME ZONE 'UTC');


### PR DESCRIPTION
Part of #199

## Summary

Adds a data-only Prisma migration that corrects `scheduledAt` for any existing CrossFit Mainsite WOD rows that were stored one day early.

**Root cause:** The ingest job used CrossFit's `publishingDate` (`"2026-04-24T23:55:00+00:00"`) as `scheduledAt` for the April 25 WOD. CrossFit posts at 23:55 UTC, so every stored WOD landed on the wrong calendar day. The job-level fix ships in PR #200; this migration repairs the historical data.

**How the migration works:**
- Extracts the `YYYYMMDD` from `externalSourceId` (`"crossfit-mainsite:w20260425"` → `"20260425"`)
- Computes the correct `scheduledAt` as UTC midnight of that date (`2026-04-25 00:00:00+00`)
- Updates only rows where the stored date doesn't already match the id (idempotent)
- Scoped to `externalSourceId LIKE 'crossfit-mainsite:w%'` — no other rows touched

**Deploy order:** This migration should land before or alongside PR #200. Both are backwards-compatible — the column type doesn't change, only the data values.

## Tests

**Migration** (`packages/db/prisma/migrations/20260503131526_fix_crossfit_wod_scheduled_at/migration.sql`):
- Applied to local dev DB via `npm run setup:worktree` — ran clean, 0 errors

**Not automated / manual verification needed:**
- [x] After deploy to QA/prod: confirm CrossFit Mainsite WOD rows now appear on the correct calendar dates (was: one day behind; should be: matches the `wYYYYMMDD` in `externalSourceId`)

**Mobile parity:** data-only migration, no surface change — N/A