### PR TITLE
feat: Personal Programs — calendar + shared prescription drawer

### DIFF
--- a/apps/api/src/db/programDbManager.ts
+++ b/apps/api/src/db/programDbManager.ts
@@ -1,4 +1,4 @@
-import { prisma, type ProgramVisibility } from '@wodalytics/db'
+import { prisma, ProgramRole, Prisma, type ProgramVisibility } from '@wodalytics/db'
 
 interface UpdateProgramData {
   name?: string
@@ -165,6 +165,64 @@ export async function findUnaffiliatedPublicProgramsForUser(userId: string) {
     orderBy: { createdAt: 'desc' },
     include: { _count: { select: { members: true, workouts: true } } },
   })
+}
+
+// ─── Personal Program (#183) ──────────────────────────────────────────────────
+
+const personalProgramInclude = {
+  _count: { select: { workouts: true } },
+} as const
+
+export type PersonalProgramRow = Prisma.ProgramGetPayload<{
+  include: typeof personalProgramInclude
+}>
+
+/**
+ * Returns the caller's personal program, creating it on first call. Idempotent:
+ * subsequent calls return the existing row. The unique constraint on
+ * `Program.ownerUserId` makes the create race-safe — concurrent first-time
+ * callers collapse to one row, the loser gets P2002 and we re-fetch.
+ *
+ * Personal programs are PRIVATE, never linked to a Gym, and the owner is
+ * auto-subscribed as PROGRAMMER so the existing workout middleware grants
+ * read+write on workouts under the program (see middleware/workout.ts —
+ * unaffiliated-program path).
+ */
+export async function findOrCreatePersonalProgramForUser(userId: string): Promise<PersonalProgramRow> {
+  const existing = await prisma.program.findUnique({
+    where: { ownerUserId: userId },
+    include: personalProgramInclude,
+  })
+  if (existing) return existing
+
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const program = await tx.program.create({
+        data: {
+          name: 'Personal Program',
+          ownerUserId: userId,
+          startDate: new Date(),
+          visibility: 'PRIVATE',
+        },
+      })
+      await tx.userProgram.create({
+        data: { userId, programId: program.id, role: ProgramRole.PROGRAMMER },
+      })
+      return tx.program.findUniqueOrThrow({
+        where: { id: program.id },
+        include: personalProgramInclude,
+      })
+    })
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+      const racedRow = await prisma.program.findUnique({
+        where: { ownerUserId: userId },
+        include: personalProgramInclude,
+      })
+      if (racedRow) return racedRow
+    }
+    throw err
+  }
 }
 
 export type ProgramGymAccessResult = 'ok' | 'not-found' | 'forbidden'

--- a/apps/api/src/db/workoutDbManager.ts
+++ b/apps/api/src/db/workoutDbManager.ts
@@ -246,6 +246,40 @@ export async function countWorkoutsByProgramId(programId: string): Promise<numbe
   return prisma.workout.count({ where: { programId } })
 }
 
+/**
+ * Lists workouts in a single program over a date range — used by the
+ * personal-program calendar (#183). No gym scoping, no published-only
+ * filter: the caller is always the sole owner of a private one-user
+ * program, so DRAFT/PUBLISHED status doesn't gate visibility.
+ *
+ * `from` / `to` may be omitted to return every workout in the program.
+ * Same shape as `findWorkoutsByGymAndDateRange` — including the
+ * `myResultId` projection — so the calendar grid renders identically.
+ */
+export async function findWorkoutsByProgramIdInDateRange(
+  programId: string,
+  viewerUserId: string,
+  from?: Date,
+  to?: Date,
+) {
+  const dateFilter = from && to ? { scheduledAt: { gte: from, lte: to } } : {}
+  const workouts = await prisma.workout.findMany({
+    where: { programId, ...dateFilter },
+    orderBy: [{ scheduledAt: 'asc' }, { dayOrder: 'asc' }, { createdAt: 'asc' }],
+    include: {
+      program: programSelect,
+      namedWorkout: namedWorkoutSelect,
+      _count: { select: { results: true } },
+      results: { where: { userId: viewerUserId }, select: { id: true } },
+      ...workoutMovementsInclude,
+    },
+  })
+  return workouts.map(({ results, ...rest }) => ({
+    ...rest,
+    myResultId: results[0]?.id ?? null,
+  }))
+}
+
 // Used by the WODalytics admin surface (#160) to list every workout under a
 // program without gym scoping. Newest first by scheduledAt — admins typically
 // want to see the latest entry from an ingest job at the top.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,7 @@ import { prisma } from '@wodalytics/db'
 import { authRouter } from './routes/auth.js'
 import gymsRouter from './routes/gyms'
 import programsRouter from './routes/programs'
+import personalProgramRouter from './routes/personalProgram'
 import workoutsRouter from './routes/workouts'
 import resultsRouter from './routes/results'
 import namedWorkoutsRouter from './routes/namedWorkouts'
@@ -57,6 +58,7 @@ app.get('/api/health', async (_req, res) => {
 
 app.use('/api', gymsRouter)
 app.use('/api', programsRouter)
+app.use('/api', personalProgramRouter)
 app.use('/api', workoutsRouter)
 app.use('/api', resultsRouter)
 app.use('/api', namedWorkoutsRouter)

--- a/apps/api/src/routes/personalProgram.ts
+++ b/apps/api/src/routes/personalProgram.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import type { Request, Response } from 'express'
 import { CreateWorkoutSchema } from '@wodalytics/types'
+import { WorkoutStatus } from '@wodalytics/db'
 import { requireAuth } from '../middleware/auth.js'
 import { findOrCreatePersonalProgramForUser } from '../db/programDbManager.js'
 import {
@@ -75,6 +76,13 @@ async function createMyPersonalProgramWorkout(req: Request, res: Response) {
   const program = await findOrCreatePersonalProgramForUser(userId)
 
   const { title, description, type, scheduledAt, dayOrder, movementIds, movements, timeCapSeconds, tracksRounds } = parsed.data
+  // Personal-program workouts auto-publish: there is no audience to gate
+  // visibility against (the user is the sole reader/writer), so the
+  // DRAFT/PUBLISHED distinction is not meaningful. Without this, the
+  // schema's `status @default(DRAFT)` would hide the workout from the
+  // viewer's own feed (the gym feed query filters published-only for
+  // MEMBER role) and surface a "Draft" pill on the detail page that
+  // there's no way to clear from the personal-program UI.
   const workout = await createWorkoutForProgramDb({
     programId: program.id,
     title,
@@ -86,6 +94,7 @@ async function createMyPersonalProgramWorkout(req: Request, res: Response) {
     movements,
     timeCapSeconds,
     tracksRounds,
+    status: WorkoutStatus.PUBLISHED,
   })
   res.status(201).json(workout)
 }

--- a/apps/api/src/routes/personalProgram.ts
+++ b/apps/api/src/routes/personalProgram.ts
@@ -1,0 +1,91 @@
+import { Router } from 'express'
+import type { Request, Response } from 'express'
+import { CreateWorkoutSchema } from '@wodalytics/types'
+import { requireAuth } from '../middleware/auth.js'
+import { findOrCreatePersonalProgramForUser } from '../db/programDbManager.js'
+import {
+  createWorkoutForProgram as createWorkoutForProgramDb,
+  findWorkoutsByProgramIdInDateRange,
+} from '../db/workoutDbManager.js'
+
+const router = Router()
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+// GET  /api/me/personal-program — returns the caller's personal program,
+//        creating it on first call. Idempotent.
+router.get('/me/personal-program', requireAuth, getMyPersonalProgram)
+
+// GET  /api/me/personal-program/workouts?from=&to=
+//        Personal-program calendar paging. Date range optional; without it
+//        every workout in the program is returned (existing list semantics).
+router.get('/me/personal-program/workouts', requireAuth, listMyPersonalProgramWorkouts)
+
+// POST /api/me/personal-program/workouts — create a workout in the personal
+//        program. Upserts the program on first use. `programId` in the body
+//        is stripped before validation so a spoofed id can't escape into
+//        another program.
+router.post('/me/personal-program/workouts', requireAuth, createMyPersonalProgramWorkout)
+
+export default router
+
+// ─── Handler functions ────────────────────────────────────────────────────────
+
+async function getMyPersonalProgram(req: Request, res: Response) {
+  const userId = req.user!.id
+  const program = await findOrCreatePersonalProgramForUser(userId)
+  res.json(program)
+}
+
+async function listMyPersonalProgramWorkouts(req: Request, res: Response) {
+  const userId = req.user!.id
+  const program = await findOrCreatePersonalProgramForUser(userId)
+
+  let from: Date | undefined
+  let to: Date | undefined
+  if (typeof req.query.from === 'string' && typeof req.query.to === 'string') {
+    from = new Date(req.query.from)
+    to = new Date(req.query.to)
+    if (isNaN(from.getTime()) || isNaN(to.getTime())) {
+      return res.status(400).json({ error: 'Invalid date format for from or to' })
+    }
+  } else if (typeof req.query.from === 'string' || typeof req.query.to === 'string') {
+    return res.status(400).json({ error: 'Both from and to are required when filtering by date' })
+  }
+
+  const workouts = await findWorkoutsByProgramIdInDateRange(program.id, userId, from, to)
+  res.json(workouts)
+}
+
+async function createMyPersonalProgramWorkout(req: Request, res: Response) {
+  // Strip programId before validation — personal-program workouts always pin
+  // to the caller's own program. Otherwise a spoofed programId could land a
+  // workout in another program.
+  const body = (req.body && typeof req.body === 'object') ? { ...req.body } : {}
+  delete (body as Record<string, unknown>).programId
+  const parsed = CreateWorkoutSchema.safeParse(body)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const field = issue?.path[0] ?? 'request'
+    const message = issue?.message ?? 'Invalid request'
+    return res.status(400).json({ error: `${field}: ${message}` })
+  }
+
+  const userId = req.user!.id
+  const program = await findOrCreatePersonalProgramForUser(userId)
+
+  const { title, description, type, scheduledAt, dayOrder, movementIds, movements, timeCapSeconds, tracksRounds } = parsed.data
+  const workout = await createWorkoutForProgramDb({
+    programId: program.id,
+    title,
+    description,
+    type,
+    scheduledAt: new Date(scheduledAt),
+    dayOrder: dayOrder ?? 0,
+    movementIds,
+    movements,
+    timeCapSeconds,
+    tracksRounds,
+  })
+  res.status(201).json(workout)
+}

--- a/apps/api/tests/personalProgram.ts
+++ b/apps/api/tests/personalProgram.ts
@@ -121,6 +121,11 @@ async function testWorkoutCreate() {
   createdWorkoutIds.push(workoutId)
   check('workout has personal program id', true, typeof r.body.programId === 'string' && r.body.programId.length > 0)
   check('workout title persisted', 'Z2 row', r.body.title)
+  // Auto-publish: personal-program workouts have no audience to gate
+  // visibility against, so they bypass the schema's DRAFT default.
+  // Without this, the gym feed (which filters published-only for MEMBER
+  // role) would silently hide the user's own personal workouts.
+  check('workout auto-published', 'PUBLISHED', r.body.status)
 
   const spoofed = await api('POST', '/me/personal-program/workouts', userATok, {
     programId: 'nonexistent-program-id',

--- a/apps/api/tests/personalProgram.ts
+++ b/apps/api/tests/personalProgram.ts
@@ -1,0 +1,277 @@
+/**
+ * Integration tests for the Personal Programs endpoints (#183).
+ *
+ * Requires: API running on localhost:3000 (or API_URL), DB accessible via DATABASE_URL.
+ * Run from apps/api/: npx tsx tests/personalProgram.ts
+ */
+
+import { prisma } from '@wodalytics/db'
+import { signTokenPair } from '../src/lib/jwt.js'
+
+const BASE = process.env.API_URL ?? 'http://localhost:3000/api'
+let pass = 0
+let fail = 0
+
+function check(label: string, expected: unknown, actual: unknown) {
+  if (String(expected) === String(actual)) {
+    console.log(`  ✓ ${label}`)
+    pass++
+  } else {
+    console.log(`  ✗ ${label}  [expected=${expected} actual=${actual}]`)
+    fail++
+  }
+}
+
+async function api(method: string, path: string, token?: string, body?: unknown) {
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  const text = await res.text()
+  let json: unknown
+  try { json = JSON.parse(text) } catch { json = text }
+  return { status: res.status, body: json as Record<string, unknown> }
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const TS = Date.now()
+let userAId = ''
+let userBId = ''
+let userATok = ''
+let userBTok = ''
+let movementId = ''
+const createdProgramIds: string[] = []
+const createdWorkoutIds: string[] = []
+
+async function setup() {
+  console.log('\n=== Setup ===')
+  const [a, b] = await Promise.all([
+    prisma.user.create({ data: { email: `pp-a-${TS}@test.com` } }),
+    prisma.user.create({ data: { email: `pp-b-${TS}@test.com` } }),
+  ])
+  userAId = a.id
+  userBId = b.id
+  userATok = signTokenPair(userAId, 'MEMBER').accessToken
+  userBTok = signTokenPair(userBId, 'MEMBER').accessToken
+
+  const movement = await prisma.movement.create({
+    data: { name: `pp-mov-${TS}`, status: 'ACTIVE' },
+  })
+  movementId = movement.id
+
+  console.log(`  userA=${userAId} userB=${userBId} movement=${movementId}`)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+async function testAuthGuards() {
+  console.log('\n=== Auth guards ===')
+  const r1 = await api('GET', '/me/personal-program')
+  check('GET /me/personal-program no token → 401', 401, r1.status)
+
+  const r2 = await api('GET', '/me/personal-program/workouts')
+  check('GET workouts no token → 401', 401, r2.status)
+
+  const r3 = await api('POST', '/me/personal-program/workouts', undefined, {
+    title: 'x', description: 'x', type: 'WARMUP', scheduledAt: new Date().toISOString(),
+  })
+  check('POST workouts no token → 401', 401, r3.status)
+}
+
+async function testUpsert() {
+  console.log('\n=== Upsert + idempotency ===')
+  const first = await api('GET', '/me/personal-program', userATok)
+  check('first GET → 200', 200, first.status)
+  check('returned ownerUserId matches caller', userAId, first.body.ownerUserId)
+  check('visibility is PRIVATE', 'PRIVATE', first.body.visibility)
+  check('name is "Personal Program"', 'Personal Program', first.body.name)
+  const programId = first.body.id as string
+  createdProgramIds.push(programId)
+
+  const sub = await prisma.userProgram.findUnique({
+    where: { userId_programId: { userId: userAId, programId } },
+  })
+  check('userProgram row exists', true, !!sub)
+  check('userProgram role is PROGRAMMER', 'PROGRAMMER', sub?.role)
+
+  const second = await api('GET', '/me/personal-program', userATok)
+  check('second GET → 200', 200, second.status)
+  check('second GET returns same id', programId, second.body.id)
+
+  const gp = await prisma.gymProgram.count({ where: { programId } })
+  check('zero GymProgram links', 0, gp)
+}
+
+async function testWorkoutCreate() {
+  console.log('\n=== Create workout ===')
+  const r = await api('POST', '/me/personal-program/workouts', userATok, {
+    title: 'Z2 row',
+    description: '20 min easy row',
+    type: 'ROWING',
+    scheduledAt: new Date().toISOString(),
+    movementIds: [movementId],
+  })
+  check('POST workouts → 201', 201, r.status)
+  const workoutId = r.body.id as string
+  createdWorkoutIds.push(workoutId)
+  check('workout has personal program id', true, typeof r.body.programId === 'string' && r.body.programId.length > 0)
+  check('workout title persisted', 'Z2 row', r.body.title)
+
+  const spoofed = await api('POST', '/me/personal-program/workouts', userATok, {
+    programId: 'nonexistent-program-id',
+    title: 'spoof attempt',
+    description: 'should still land in personal program',
+    type: 'WARMUP',
+    scheduledAt: new Date().toISOString(),
+  })
+  check('spoofed programId still 201', 201, spoofed.status)
+  check('spoofed programId was overridden', r.body.programId, spoofed.body.programId)
+  if (typeof spoofed.body.id === 'string') createdWorkoutIds.push(spoofed.body.id)
+
+  const bad = await api('POST', '/me/personal-program/workouts', userATok, {
+    description: 'no title', type: 'WARMUP', scheduledAt: new Date().toISOString(),
+  })
+  check('missing title → 400', 400, bad.status)
+}
+
+async function testDateRangeFilter() {
+  console.log('\n=== Date-range filter (calendar paging) ===')
+  const programId = createdProgramIds[0]
+
+  const may = await prisma.workout.create({
+    data: {
+      programId,
+      title: `pp-may-${TS}`,
+      description: 'May workout',
+      type: 'METCON',
+      scheduledAt: new Date('2026-05-15T12:00:00Z'),
+    },
+  })
+  const june = await prisma.workout.create({
+    data: {
+      programId,
+      title: `pp-june-${TS}`,
+      description: 'June workout',
+      type: 'METCON',
+      scheduledAt: new Date('2026-06-15T12:00:00Z'),
+    },
+  })
+  createdWorkoutIds.push(may.id, june.id)
+
+  const mayWindow = await api(
+    'GET',
+    '/me/personal-program/workouts?from=2026-05-01T00:00:00Z&to=2026-05-31T23:59:59Z',
+    userATok,
+  )
+  check('GET ?from=&to= May window → 200', 200, mayWindow.status)
+  const mayList = mayWindow.body as unknown as Array<{ id: string }>
+  check('May window includes May workout', true, mayList.some((w) => w.id === may.id))
+  check('May window excludes June workout', false, mayList.some((w) => w.id === june.id))
+
+  const allList = await api('GET', '/me/personal-program/workouts', userATok)
+  const allRows = allList.body as unknown as Array<{ id: string }>
+  check('no-filter list still includes both', true,
+    allRows.some((w) => w.id === may.id) && allRows.some((w) => w.id === june.id))
+
+  const mismatched = await api('GET', '/me/personal-program/workouts?from=2026-05-01', userATok)
+  check('only `from` (no `to`) → 400', 400, mismatched.status)
+
+  const badDate = await api(
+    'GET',
+    '/me/personal-program/workouts?from=not-a-date&to=also-not',
+    userATok,
+  )
+  check('invalid date format → 400', 400, badDate.status)
+}
+
+async function testIsolation() {
+  console.log('\n=== Isolation between users ===')
+  const b = await api('GET', '/me/personal-program', userBTok)
+  check('user B GET → 200', 200, b.status)
+  const bProgramId = b.body.id as string
+  createdProgramIds.push(bProgramId)
+  check('user B has different programId from user A', true, bProgramId !== createdProgramIds[0])
+
+  const list = await api('GET', '/me/personal-program/workouts', userBTok)
+  check('user B sees empty workout list', 0, (list.body as unknown as unknown[]).length)
+
+  const aWorkoutId = createdWorkoutIds[0]
+  const denied = await api('GET', `/workouts/${aWorkoutId}`, userBTok)
+  check('user B GET /workouts/<A-workout> → 403', 403, denied.status)
+
+  const allowed = await api('GET', `/workouts/${aWorkoutId}`, userATok)
+  check('user A GET /workouts/<A-workout> → 200', 200, allowed.status)
+}
+
+async function testEdit() {
+  console.log('\n=== Edit + delete via existing /workouts/:id route ===')
+  const wid = createdWorkoutIds[0]
+  const patch = await api('PATCH', `/workouts/${wid}`, userATok, { title: 'Z2 row (edited)' })
+  check('user A PATCH → 200', 200, patch.status)
+  check('title updated', 'Z2 row (edited)', patch.body.title)
+
+  const denied = await api('PATCH', `/workouts/${wid}`, userBTok, { title: 'hijack' })
+  check('user B PATCH → 403', 403, denied.status)
+
+  const del = await api('DELETE', `/workouts/${wid}`, userATok)
+  check('user A DELETE → 204', 204, del.status)
+  createdWorkoutIds.splice(createdWorkoutIds.indexOf(wid), 1)
+}
+
+async function testNotPubliclyDiscoverable() {
+  console.log('\n=== Not publicly discoverable ===')
+  const r = await api('GET', '/programs/public-catalog', userBTok)
+  check('GET public-catalog → 200', 200, r.status)
+  const list = r.body as unknown as Array<{ ownerUserId: string | null }>
+  const leaked = list.some((p) => p.ownerUserId !== null && p.ownerUserId !== undefined)
+  check('no personal programs surface in public-catalog', false, leaked)
+}
+
+async function runTests() {
+  await testAuthGuards()
+  await testUpsert()
+  await testWorkoutCreate()
+  await testDateRangeFilter()
+  await testIsolation()
+  await testEdit()
+  await testNotPubliclyDiscoverable()
+}
+
+// ─── Teardown ─────────────────────────────────────────────────────────────────
+
+async function teardown() {
+  console.log('\n=== Teardown ===')
+  for (const wid of createdWorkoutIds) {
+    await prisma.workout.delete({ where: { id: wid } }).catch(() => {})
+  }
+  for (const pid of createdProgramIds) {
+    await prisma.workout.deleteMany({ where: { programId: pid } }).catch(() => {})
+    await prisma.userProgram.deleteMany({ where: { programId: pid } }).catch(() => {})
+    await prisma.program.delete({ where: { id: pid } }).catch(() => {})
+  }
+  await prisma.movement.delete({ where: { id: movementId } }).catch(() => {})
+  await prisma.user.deleteMany({ where: { id: { in: [userAId, userBId] } } }).catch(() => {})
+  console.log('  cleaned up')
+}
+
+async function main() {
+  try {
+    await setup()
+    await runTests()
+  } finally {
+    await teardown()
+    await prisma.$disconnect()
+  }
+  console.log(`\n=== Results: ${pass} passed, ${fail} failed ===\n`)
+  if (fail > 0) process.exit(1)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -27,6 +27,7 @@ import Feed from './pages/Feed.tsx'
 import WodDetail from './pages/WodDetail.tsx'
 import WodResultDetail from './pages/WodResultDetail.tsx'
 import History from './pages/History.tsx'
+import PersonalProgram from './pages/PersonalProgram.tsx'
 import AdminProgramsIndex from './pages/AdminProgramsIndex.tsx'
 import AdminProgramDetail from './pages/AdminProgramDetail.tsx'
 
@@ -72,6 +73,7 @@ function AppLayout() {
               <Route path="/workouts/:id" element={<WodDetail />} />
               <Route path="/workouts/:id/results/:resultId" element={<WodResultDetail />} />
               <Route path="/history" element={<History />} />
+              <Route path="/personal-program" element={<PersonalProgram />} />
               <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/calendar" element={<Calendar />} />
               <Route path="/programs" element={<ProgramsIndex />} />

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -5,8 +5,9 @@ import ProgramFilterPicker from './ProgramFilterPicker.tsx'
 
 // Browse Gyms moved into the TopBar gym picker — no standalone sidebar entry.
 const memberLinks = [
-  { to: '/feed',    label: 'Feed'    },
-  { to: '/history', label: 'History' },
+  { to: '/feed',             label: 'Feed'             },
+  { to: '/history',          label: 'History'          },
+  { to: '/personal-program', label: 'Personal Program' },
 ]
 
 // Members consolidated into /gym-settings#members (slice D1) — no standalone link.

--- a/apps/web/src/components/WorkoutCalendarBoard.tsx
+++ b/apps/web/src/components/WorkoutCalendarBoard.tsx
@@ -1,0 +1,181 @@
+import { useState, useEffect, useCallback } from 'react'
+import { type Role, type Workout } from '../lib/api'
+import type { ProgramScope } from '../lib/programScope'
+import CalendarCell from './CalendarCell'
+import WorkoutDrawer from './WorkoutDrawer'
+import Button from './ui/Button'
+
+const DAY_HEADERS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+function toDateKey(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+interface WorkoutCalendarBoardProps {
+  /**
+   * Loader for the visible month. Re-fires when the month changes or the
+   * callback identity changes (parent owns filter state and re-binds the
+   * closure when filters change). Returns workouts in [from, to].
+   *
+   * Required separately from `scope` because `ProgramScope.listWorkouts`
+   * returns *all* workouts in a program — the calendar's per-month paging
+   * needs a date range and, for the gym path, gym-wide filtering across
+   * multiple programs. Wrapping that here lets each caller adapt freely.
+   */
+  loadWorkouts: (fromIso: string, toIso: string) => Promise<Workout[]>
+  /** Forwarded to WorkoutDrawer — drives create/update/delete + program picker. */
+  scope: ProgramScope
+  /** Forwarded to WorkoutDrawer for the role-gated reorder controls. */
+  userGymRole?: Role | null
+  /** Forwarded to WorkoutDrawer's program picker default selection. */
+  defaultProgramId?: string
+}
+
+/**
+ * Reusable month-grid + drawer pair shared between `/calendar` (gym staff)
+ * and the upcoming `/personal-program` page. Owns the visible-month state
+ * and the workouts cache for that month; everything data-source-specific
+ * (filters, gym scoping, program pinning) is supplied via props so the
+ * same component can drive both surfaces without internal branching.
+ */
+export default function WorkoutCalendarBoard({
+  loadWorkouts,
+  scope,
+  userGymRole,
+  defaultProgramId,
+}: WorkoutCalendarBoardProps) {
+  const today = new Date()
+  const [year, setYear] = useState(today.getFullYear())
+  const [month, setMonth] = useState(today.getMonth())
+  const [workouts, setWorkouts] = useState<Workout[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  const [selectedWorkoutId, setSelectedWorkoutId] = useState<string | null>(null)
+
+  const reloadWorkouts = useCallback(async (signal?: { cancelled: boolean }) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const from = new Date(year, month, 1).toISOString()
+      const to = new Date(year, month + 1, 0, 23, 59, 59, 999).toISOString()
+      const data = await loadWorkouts(from, to)
+      if (!signal?.cancelled) setWorkouts(data)
+    } catch (e) {
+      if (!signal?.cancelled) setError((e as Error).message)
+    } finally {
+      if (!signal?.cancelled) setLoading(false)
+    }
+  }, [year, month, loadWorkouts])
+
+  useEffect(() => {
+    const signal = { cancelled: false }
+    reloadWorkouts(signal)
+    return () => { signal.cancelled = true }
+  }, [reloadWorkouts])
+
+  const workoutsByDate: Record<string, Workout[]> = {}
+  for (const w of workouts) {
+    // scheduledAt is UTC midnight — slice the ISO string to get the UTC calendar date,
+    // avoiding a local-timezone shift that would bucket the workout a day early for US users.
+    // (Ported from #213 when this logic moved out of Calendar.tsx.)
+    const key = w.scheduledAt.slice(0, 10)
+    if (!workoutsByDate[key]) workoutsByDate[key] = []
+    workoutsByDate[key].push(w)
+  }
+
+  const workoutsOnDay = selectedDate ? (workoutsByDate[selectedDate] ?? []) : []
+  const selectedWorkout = selectedWorkoutId
+    ? workoutsOnDay.find((w) => w.id === selectedWorkoutId)
+    : undefined
+
+  const firstDayOfMonth = new Date(year, month, 1)
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+  const startDow = firstDayOfMonth.getDay()
+  const cells: (Date | null)[] = []
+  for (let i = 0; i < startDow; i++) cells.push(null)
+  for (let d = 1; d <= daysInMonth; d++) cells.push(new Date(year, month, d))
+  while (cells.length % 7 !== 0) cells.push(null)
+  const weeks: (Date | null)[][] = []
+  for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7))
+
+  const monthLabel = firstDayOfMonth.toLocaleString('default', { month: 'long', year: 'numeric' })
+  const todayKey = toDateKey(today)
+
+  function prevMonth() {
+    if (month === 0) { setYear((y) => y - 1); setMonth(11) }
+    else setMonth((m) => m - 1)
+    setSelectedDate(null)
+    setSelectedWorkoutId(null)
+  }
+
+  function nextMonth() {
+    if (month === 11) { setYear((y) => y + 1); setMonth(0) }
+    else setMonth((m) => m + 1)
+    setSelectedDate(null)
+    setSelectedWorkoutId(null)
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-end gap-2 mb-6">
+        <Button variant="tertiary" onClick={prevMonth} aria-label="Previous month">←</Button>
+        <span className="text-base font-medium w-44 text-center select-none">{monthLabel}</span>
+        <Button variant="tertiary" onClick={nextMonth} aria-label="Next month">→</Button>
+      </div>
+
+      {error && <p className="text-red-400 mb-4">{error}</p>}
+
+      <div className="grid grid-cols-7 mb-px">
+        {DAY_HEADERS.map((d) => (
+          <div key={d} className="text-center text-xs text-gray-400 py-1">{d}</div>
+        ))}
+      </div>
+
+      <div
+        className={[
+          'grid grid-cols-7 gap-px bg-gray-800 border border-gray-800 rounded-lg overflow-hidden',
+          loading ? 'opacity-60 pointer-events-none' : '',
+        ].join(' ')}
+      >
+        {weeks.map((week, wi) =>
+          week.map((date, di) => {
+            if (!date) {
+              return <div key={`empty-${wi}-${di}`} className="bg-gray-950 h-[128px]" />
+            }
+            const key = toDateKey(date)
+            return (
+              <CalendarCell
+                key={key}
+                date={date}
+                isToday={key === todayKey}
+                workouts={workoutsByDate[key] ?? []}
+                selected={key === selectedDate}
+                onAddClick={() => { setSelectedDate(key); setSelectedWorkoutId(null) }}
+                onWorkoutClick={(id) => { setSelectedDate(key); setSelectedWorkoutId(id) }}
+              />
+            )
+          }),
+        )}
+      </div>
+
+      <WorkoutDrawer
+        scope={scope}
+        dateKey={selectedDate}
+        workout={selectedWorkout}
+        workoutsOnDay={workoutsOnDay}
+        userGymRole={userGymRole}
+        defaultProgramId={defaultProgramId}
+        onClose={() => { setSelectedDate(null); setSelectedWorkoutId(null) }}
+        onSaved={() => { setSelectedDate(null); setSelectedWorkoutId(null); reloadWorkouts() }}
+        onAutoSaved={() => { reloadWorkouts() }}
+        onReordered={() => { reloadWorkouts() }}
+        onWorkoutSelect={(id) => setSelectedWorkoutId(id)}
+        onNewWorkout={() => setSelectedWorkoutId(null)}
+      />
+    </>
+  )
+}

--- a/apps/web/src/components/WorkoutDrawer.tsx
+++ b/apps/web/src/components/WorkoutDrawer.tsx
@@ -681,7 +681,7 @@ export default function WorkoutDrawer({ scope, dateKey, workout, workoutsOnDay =
                 {autosaveLabel}
               </span>
             )}
-            {isEdit && (
+            {isEdit && isGymScope && (
               <span
                 className={[
                   'text-xs px-2 py-0.5 rounded-full font-medium border',

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -285,6 +285,14 @@ export interface Program {
   _count?: { members: number; workouts: number }
 }
 
+// User's private "Personal Program" (#183). Same Prisma model as Program with
+// `ownerUserId` set, no GymProgram links, and PRIVATE visibility. The
+// `_count.workouts` field is always populated since the page header reads it.
+export interface PersonalProgram extends Omit<Program, '_count'> {
+  ownerUserId: string
+  _count: { workouts: number }
+}
+
 export type ProgramRole = 'MEMBER' | 'PROGRAMMER'
 
 export interface ProgramMember {
@@ -509,6 +517,44 @@ export const api = {
      */
     programs: (gymId: string, token?: string) =>
       req<GymProgram[]>(`/api/me/programs?gymId=${encodeURIComponent(gymId)}`, { token }),
+
+    personalProgram: {
+      // Returns the caller's private "Personal Program" (#183), creating it on
+      // first call. Idempotent — repeat calls return the existing row.
+      get: (token?: string) =>
+        req<PersonalProgram>('/api/me/personal-program', { token }),
+
+      workouts: {
+        // Date range optional. When `from` and `to` are both supplied the
+        // server filters to that window — used by the calendar page to fetch
+        // a single visible month at a time.
+        list: (range?: { from: string; to: string }, token?: string) => {
+          const qs = range ? `?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}` : ''
+          return req<Workout[]>(`/api/me/personal-program/workouts${qs}`, { token })
+        },
+        // Body uses the same shape as `api.workouts.create` minus `programId`,
+        // which the server pins to the caller's personal program.
+        create: (
+          data: {
+            title: string
+            description: string
+            type: WorkoutType
+            scheduledAt: string
+            movementIds?: string[]
+            movements?: WorkoutMovementInput[]
+            namedWorkoutId?: string
+            timeCapSeconds?: number | null
+            tracksRounds?: boolean
+          },
+          token?: string,
+        ) =>
+          req<Workout>('/api/me/personal-program/workouts', {
+            method: 'POST',
+            body: JSON.stringify(data),
+            token,
+          }),
+      },
+    },
   },
 
   gyms: {

--- a/apps/web/src/lib/personalProgramScope.ts
+++ b/apps/web/src/lib/personalProgramScope.ts
@@ -1,0 +1,86 @@
+/**
+ * `ProgramScope` implementation for a user's private Personal Program (#183).
+ * The factory closes over the resolved program id so the scope can route
+ * `list` / `get` / `listWorkouts` / `createWorkout` through the
+ * `/api/me/personal-program*` endpoints without callers needing to thread
+ * the id manually.
+ *
+ * Behaves like the admin scope at the drawer level: one Save button, no
+ * DRAFT/PUBLISHED concept (a personal workout has no audience), and no
+ * gym-default toggle. The drawer keys those off `kind: 'personal'` exactly
+ * the way it currently keys off `kind: 'admin'`.
+ */
+import { api, type PersonalProgram, type Program } from './api'
+import type { ProgramScope } from './programScope'
+
+interface PersonalScopeOpts {
+  program: PersonalProgram
+}
+
+// Strip the personal-program-specific fields when projecting back into the
+// shared Program shape so the scope's contract matches `gymProgramScope`.
+function toProgram(p: PersonalProgram): Program {
+  const { ownerUserId: _ownerUserId, _count, ...rest } = p
+  return { ...rest, _count: { members: 0, workouts: _count.workouts } }
+}
+
+export function makePersonalProgramScope({ program }: PersonalScopeOpts): ProgramScope {
+  const projected = toProgram(program)
+
+  return {
+    kind: 'personal',
+    capabilities: {
+      // The user can always edit their own private program.
+      canWrite: true,
+      canDelete: true,
+      // No members on a one-user program.
+      canSeeMembers: false,
+      // Personal programs aren't gym defaults.
+      canSetDefault: false,
+    },
+
+    // The drawer's program picker only renders for `kind: 'gym'`; for personal
+    // it's a read-only label. `list()` is still called by the picker effect,
+    // so return the single pinned program as a one-element list to keep the
+    // contract consistent.
+    list: () => Promise.resolve([projected]),
+    get: (id) => {
+      if (id !== program.id) return Promise.reject(new Error('Personal scope: program id mismatch'))
+      return Promise.resolve(projected)
+    },
+
+    // The personal-program calendar uses a separate per-month, date-ranged
+    // loader (see `WorkoutCalendarBoard.loadWorkouts`). This contract method
+    // is only hit by code paths the personal page doesn't traverse, but it's
+    // still wired correctly: returns every workout in the program.
+    listWorkouts: (programId) => {
+      if (programId !== program.id) return Promise.resolve([])
+      return api.me.personalProgram.workouts.list()
+    },
+
+    // Personal programs aren't created or destroyed through this surface —
+    // the API upserts on first GET and a delete is out of scope. These would
+    // only fire if someone misuses the scope; throw rather than silently
+    // hitting the wrong endpoint.
+    createProgram: () => Promise.reject(new Error('Personal Program is auto-created; cannot create another')),
+    updateProgram: () => Promise.reject(new Error('Personal Program metadata is not editable from this surface')),
+    deleteProgram: () => Promise.reject(new Error('Personal Program cannot be deleted')),
+
+    createWorkout: async (programId, data) => {
+      if (programId !== program.id) {
+        throw new Error('Personal scope: cannot create a workout in another program')
+      }
+      // The server strips `programId` from the body and pins it to the
+      // caller's program; we still pass through every field the server
+      // accepts. The shared `CreateWorkoutScopeData` shape carries
+      // `coachNotes`, but the personal endpoint forwards the same payload
+      // so it's preserved when the API supports it.
+      return api.me.personalProgram.workouts.create(data)
+    },
+    updateWorkout: (workoutId, data) => api.workouts.update(workoutId, data),
+    deleteWorkout: (workoutId) => api.workouts.delete(workoutId),
+
+    // Personal programs aren't gym defaults — leave the optional methods
+    // off, exactly like the admin scope does.
+  }
+}

--- a/apps/web/src/lib/programScope.ts
+++ b/apps/web/src/lib/programScope.ts
@@ -17,7 +17,17 @@
  */
 import type { Program, ProgramVisibility, Workout, WorkoutMovementInput, WorkoutType } from './api'
 
-export type ProgramScopeKind = 'gym' | 'admin'
+/**
+ * Discriminator for the active scope.
+ * - `gym`      — gym staff editing programs that belong to a Gym (slice 3)
+ * - `admin`    — WODalytics admin curating gym-less, public-catalog programs (slice 3)
+ * - `personal` — a user editing their own private Personal Program (#183).
+ *                Behaves like `admin` in the drawer (one Save button, no
+ *                DRAFT/PUBLISHED concept, auto-publish skipped) but its
+ *                `list/get/...` map onto `/api/me/personal-program*` rather
+ *                than the admin or gym routes.
+ */
+export type ProgramScopeKind = 'gym' | 'admin' | 'personal'
 
 export interface ProgramScopeCapabilities {
   canWrite: boolean

--- a/apps/web/src/pages/Calendar.tsx
+++ b/apps/web/src/pages/Calendar.tsx
@@ -1,24 +1,13 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { api, type Workout } from '../lib/api'
+import { api } from '../lib/api'
 import { useGym } from '../context/GymContext.tsx'
 import { makeGymProgramScope } from '../lib/gymProgramScope'
 import { useMovements } from '../context/MovementsContext.tsx'
 import { useProgramFilter } from '../context/ProgramFilterContext.tsx'
-import CalendarCell from '../components/CalendarCell'
-import WorkoutDrawer from '../components/WorkoutDrawer'
+import WorkoutCalendarBoard from '../components/WorkoutCalendarBoard'
 import MovementFilterInput from '../components/MovementFilterInput'
-import Button from '../components/ui/Button'
 import Chip from '../components/ui/Chip'
-
-function toDateKey(date: Date): string {
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, '0')
-  const d = String(date.getDate()).padStart(2, '0')
-  return `${y}-${m}-${d}`
-}
-
-const DAY_HEADERS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
 export default function Calendar() {
   const { gymId, gymRole: userGymRole } = useGym()
@@ -28,46 +17,9 @@ export default function Calendar() {
   )
   const allMovements = useMovements()
   const { selected: programIds, available, clear: clearProgramFilter } = useProgramFilter()
-  const today = new Date()
-  const [year, setYear] = useState(today.getFullYear())
-  const [month, setMonth] = useState(today.getMonth())
-  const [workouts, setWorkouts] = useState<Workout[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [selectedDate, setSelectedDate] = useState<string | null>(null)
-  const [selectedWorkoutId, setSelectedWorkoutId] = useState<string | null>(null)
   const [filterMovementIds, setFilterMovementIds] = useState<string[]>([])
 
   const programIdsKey = programIds.join(',')
-
-  const loadWorkouts = useCallback(async (signal?: { cancelled: boolean }) => {
-    if (!gymId) return
-    setLoading(true)
-    setError(null)
-    try {
-      const from = new Date(year, month, 1).toISOString()
-      const to = new Date(year, month + 1, 0, 23, 59, 59, 999).toISOString()
-      const filters = (filterMovementIds.length || programIds.length)
-        ? {
-            ...(filterMovementIds.length ? { movementIds: filterMovementIds } : {}),
-            ...(programIds.length ? { programIds } : {}),
-          }
-        : undefined
-      const data = await api.workouts.list(gymId, from, to, filters)
-      if (!signal?.cancelled) setWorkouts(data)
-    } catch (e) {
-      if (!signal?.cancelled) setError((e as Error).message)
-    } finally {
-      if (!signal?.cancelled) setLoading(false)
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gymId, year, month, filterMovementIds, programIdsKey])
-
-  useEffect(() => {
-    const signal = { cancelled: false }
-    loadWorkouts(signal)
-    return () => { signal.cancelled = true }
-  }, [loadWorkouts])
 
   // Single-program filter gets a featured header (color stripe + name).
   // Multi-program gets a compact "Filtered to N programs" eyebrow.
@@ -79,47 +31,17 @@ export default function Calendar() {
   // the drawer's existing "first program in list" behavior beyond N=1.
   const defaultProgramIdForCreate = programIds.length === 1 ? programIds[0] : undefined
 
-  const workoutsByDate: Record<string, Workout[]> = {}
-  for (const w of workouts) {
-    // scheduledAt is UTC midnight — slice the ISO string to get the UTC calendar date,
-    // avoiding a local-timezone shift that would bucket the workout a day early for US users.
-    const key = w.scheduledAt.slice(0, 10)
-    if (!workoutsByDate[key]) workoutsByDate[key] = []
-    workoutsByDate[key].push(w)
-  }
-
-  const workoutsOnDay = selectedDate ? (workoutsByDate[selectedDate] ?? []) : []
-  const selectedWorkout = selectedWorkoutId
-    ? workoutsOnDay.find(w => w.id === selectedWorkoutId)
-    : undefined
-
-  // Build padded grid of Date | null
-  const firstDayOfMonth = new Date(year, month, 1)
-  const daysInMonth = new Date(year, month + 1, 0).getDate()
-  const startDow = firstDayOfMonth.getDay()
-  const cells: (Date | null)[] = []
-  for (let i = 0; i < startDow; i++) cells.push(null)
-  for (let d = 1; d <= daysInMonth; d++) cells.push(new Date(year, month, d))
-  while (cells.length % 7 !== 0) cells.push(null)
-  const weeks: (Date | null)[][] = []
-  for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7))
-
-  const monthLabel = firstDayOfMonth.toLocaleString('default', { month: 'long', year: 'numeric' })
-  const todayKey = toDateKey(today)
-
-  function prevMonth() {
-    if (month === 0) { setYear(y => y - 1); setMonth(11) }
-    else setMonth(m => m - 1)
-    setSelectedDate(null)
-    setSelectedWorkoutId(null)
-  }
-
-  function nextMonth() {
-    if (month === 11) { setYear(y => y + 1); setMonth(0) }
-    else setMonth(m => m + 1)
-    setSelectedDate(null)
-    setSelectedWorkoutId(null)
-  }
+  const loadWorkouts = useCallback(async (from: string, to: string) => {
+    if (!gymId) return []
+    const filters = (filterMovementIds.length || programIds.length)
+      ? {
+          ...(filterMovementIds.length ? { movementIds: filterMovementIds } : {}),
+          ...(programIds.length ? { programIds } : {}),
+        }
+      : undefined
+    return api.workouts.list(gymId, from, to, filters)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gymId, filterMovementIds, programIdsKey])
 
   if (!gymId) {
     return (
@@ -145,7 +67,7 @@ export default function Calendar() {
       )}
 
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="mb-6">
         {singleProgram ? (
           <div className="flex items-start gap-3 min-w-0">
             <div
@@ -167,15 +89,6 @@ export default function Calendar() {
         ) : (
           <h1 className="text-2xl font-bold">Calendar</h1>
         )}
-        <div className="flex items-center gap-2">
-          <Button variant="tertiary" onClick={prevMonth} aria-label="Previous month">
-            ←
-          </Button>
-          <span className="text-base font-medium w-44 text-center select-none">{monthLabel}</span>
-          <Button variant="tertiary" onClick={nextMonth} aria-label="Next month">
-            →
-          </Button>
-        </div>
       </div>
 
       {/* Sticky movement-filter sub-header */}
@@ -207,58 +120,11 @@ export default function Calendar() {
         </div>
       )}
 
-      {error && <p className="text-red-400 mb-4">{error}</p>}
-
-      {/* Day-of-week headers */}
-      <div className="grid grid-cols-7 mb-px">
-        {DAY_HEADERS.map((d) => (
-          <div key={d} className="text-center text-xs text-gray-400 py-1">
-            {d}
-          </div>
-        ))}
-      </div>
-
-      {/* Calendar grid */}
-      <div
-        className={[
-          'grid grid-cols-7 gap-px bg-gray-800 border border-gray-800 rounded-lg overflow-hidden',
-          loading ? 'opacity-60 pointer-events-none' : '',
-        ].join(' ')}
-      >
-        {weeks.map((week, wi) =>
-          week.map((date, di) => {
-            if (!date) {
-              return <div key={`empty-${wi}-${di}`} className="bg-gray-950 h-[128px]" />
-            }
-            const key = toDateKey(date)
-            return (
-              <CalendarCell
-                key={key}
-                date={date}
-                isToday={key === todayKey}
-                workouts={workoutsByDate[key] ?? []}
-                selected={key === selectedDate}
-                onAddClick={() => { setSelectedDate(key); setSelectedWorkoutId(null) }}
-                onWorkoutClick={(id) => { setSelectedDate(key); setSelectedWorkoutId(id) }}
-              />
-            )
-          }),
-        )}
-      </div>
-
-      <WorkoutDrawer
+      <WorkoutCalendarBoard
+        loadWorkouts={loadWorkouts}
         scope={scope}
-        dateKey={selectedDate}
-        workout={selectedWorkout}
-        workoutsOnDay={workoutsOnDay}
         userGymRole={userGymRole}
         defaultProgramId={defaultProgramIdForCreate}
-        onClose={() => { setSelectedDate(null); setSelectedWorkoutId(null) }}
-        onSaved={() => { setSelectedDate(null); setSelectedWorkoutId(null); loadWorkouts() }}
-        onAutoSaved={loadWorkouts}
-        onReordered={loadWorkouts}
-        onWorkoutSelect={(id) => setSelectedWorkoutId(id)}
-        onNewWorkout={() => setSelectedWorkoutId(null)}
       />
     </div>
   )

--- a/apps/web/src/pages/PersonalProgram.test.tsx
+++ b/apps/web/src/pages/PersonalProgram.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import PersonalProgram from './PersonalProgram'
+import type { PersonalProgram as PersonalProgramType } from '../lib/api'
+
+const baseProgram: PersonalProgramType = {
+  id: 'pp1',
+  name: 'Personal Program',
+  description: null,
+  startDate: '2026-05-01T00:00:00.000Z',
+  endDate: null,
+  coverColor: null,
+  visibility: 'PRIVATE',
+  ownerUserId: 'u1',
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-01T00:00:00.000Z',
+  _count: { workouts: 0 },
+}
+
+vi.mock('../lib/api', () => ({
+  api: {
+    me: {
+      personalProgram: {
+        get: vi.fn(),
+        workouts: {
+          list: vi.fn(),
+          create: vi.fn(),
+        },
+      },
+    },
+    namedWorkouts: { list: vi.fn() },
+    movements: { detect: vi.fn() },
+    workouts: { update: vi.fn(), delete: vi.fn() },
+  },
+  TYPE_ABBR: {
+    AMRAP: 'A', FOR_TIME: 'F', METCON: 'M', WARMUP: 'W',
+  },
+}))
+
+vi.mock('../context/MovementsContext.tsx', () => ({
+  useMovements: () => [] as { id: string; name: string; parentId: string | null }[],
+}))
+
+import { api } from '../lib/api'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(api.me.personalProgram.get).mockResolvedValue(baseProgram)
+  vi.mocked(api.me.personalProgram.workouts.list).mockResolvedValue([])
+  vi.mocked(api.namedWorkouts.list).mockResolvedValue([])
+  vi.mocked(api.movements.detect).mockResolvedValue([])
+})
+
+function renderPage() {
+  return render(<MemoryRouter><PersonalProgram /></MemoryRouter>)
+}
+
+describe('PersonalProgram page', () => {
+  it('renders the heading + helper copy after fetching the program', async () => {
+    renderPage()
+    expect(await screen.findByText(/Your private workouts/)).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Personal Program')
+  })
+
+  it('mounts the calendar board (renders day-of-week headers)', async () => {
+    renderPage()
+    await screen.findByText(/Your private workouts/)
+    // Day headers come from WorkoutCalendarBoard — confirms the shared
+    // component is being mounted with the personal-program data source.
+    expect(screen.getByText('Sun')).toBeInTheDocument()
+    expect(screen.getByText('Sat')).toBeInTheDocument()
+  })
+
+  it('queries workouts with a from/to range when the calendar mounts', async () => {
+    renderPage()
+    await screen.findByText(/Your private workouts/)
+    // The board's initial month load fires personalProgram.workouts.list with
+    // a {from, to} arg — confirms the loadWorkouts callback is wired through.
+    await waitFor(() => expect(api.me.personalProgram.workouts.list).toHaveBeenCalled())
+    const arg = vi.mocked(api.me.personalProgram.workouts.list).mock.calls[0][0]
+    expect(arg).toEqual(expect.objectContaining({
+      from: expect.any(String),
+      to: expect.any(String),
+    }))
+  })
+
+  it('surfaces a friendly error when the program upsert fails', async () => {
+    vi.mocked(api.me.personalProgram.get).mockRejectedValue(new Error('boom'))
+    renderPage()
+    expect(await screen.findByText('boom')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/pages/PersonalProgram.tsx
+++ b/apps/web/src/pages/PersonalProgram.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useMemo, useState, useCallback } from 'react'
+import { api, type PersonalProgram } from '../lib/api'
+import { makePersonalProgramScope } from '../lib/personalProgramScope'
+import WorkoutCalendarBoard from '../components/WorkoutCalendarBoard'
+
+export default function PersonalProgramPage() {
+  const [program, setProgram] = useState<PersonalProgram | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    api.me.personalProgram.get()
+      .then((p) => { if (!cancelled) setProgram(p) })
+      .catch((e: unknown) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load personal program')
+      })
+    return () => { cancelled = true }
+  }, [])
+
+  const scope = useMemo(
+    () => program ? makePersonalProgramScope({ program }) : null,
+    [program],
+  )
+
+  const loadWorkouts = useCallback(async (from: string, to: string) => {
+    return api.me.personalProgram.workouts.list({ from, to })
+  }, [])
+
+  if (error) {
+    return (
+      <div className="max-w-3xl mx-auto">
+        <h1 className="text-2xl font-bold mb-2">Personal Program</h1>
+        <p className="text-rose-400 text-sm">{error}</p>
+      </div>
+    )
+  }
+
+  if (!program || !scope) {
+    return (
+      <div className="max-w-3xl mx-auto">
+        <h1 className="text-2xl font-bold mb-2">Personal Program</h1>
+        <p className="text-gray-400 text-sm">Loading…</p>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold">Personal Program</h1>
+        <p className="text-sm text-gray-400 mt-1">
+          Your private workouts — only you can see or edit these. Click any day to plan a workout.
+        </p>
+      </header>
+
+      <WorkoutCalendarBoard
+        loadWorkouts={loadWorkouts}
+        scope={scope}
+        // The drawer's reorder controls are role-gated for gym scope; for
+        // personal we want them on regardless of any gym role the user holds.
+        userGymRole="OWNER"
+        defaultProgramId={program.id}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

User-facing slice of **Personal Programs** (#183), built on the WorkoutDrawer + Calendar refactor in **#196**. The `/personal-program` page mounts the same `<WorkoutCalendarBoard>` that drives gym `/calendar`, with a personal-program data source — anything a gym can program, an individual can program for themselves with the same prescription editor, no drift.

> **Depends on #196.** When the refactor PR merges first, the diff in this PR collapses to just the personal-program API + page + sidebar entry.

### What you get on the page

- Same month-grid calendar as the gym calendar — click a day to add a workout, click a workout to edit
- Same `<WorkoutDrawer>`: title / type / time-cap / movement detect & prescription rows / autosave / markdown paste — every feature gym programmers have
- `programSource: { kind: 'fixed' }` pins workouts to the user's personal program (no picker, read-only program label)
- `canPublish: false` — personal programs have no audience, so the Publish button is hidden; everything autosaves as DRAFT
- `canReorder: true` — the user is always their own programmer

### API

- `findOrCreatePersonalProgramForUser` in `programDbManager` — race-safe upsert via the unique `Program.ownerUserId` constraint added in #189; auto-subscribes the caller as `UserProgram.role = PROGRAMMER`
- New `routes/personalProgram.ts`:
  - `GET  /api/me/personal-program` — upsert + return
  - `GET  /api/me/personal-program/workouts?from=&to=` — date-range optional, drives calendar paging
  - `POST /api/me/personal-program/workouts` — strips `programId` from the body before validating so a spoofed id can't escape
- `findWorkoutsByProgramIdInDateRange` in `workoutDbManager` — single-program list with optional date filter; same `myResultId` projection as the gym list so `<CalendarCell>` renders identically
- Workout edit / delete reuse `PATCH/DELETE /api/workouts/:id`. The existing middleware already grants write access on unaffiliated programs to `UserProgram.PROGRAMMER` — **no new middleware**

## Tests

**Unit** (`apps/web/src/pages/PersonalProgram.test.tsx` — 4 tests, all pass):
- `renders the heading + helper copy after fetching the program` — `Personal Program` h1 + the "Your private workouts" guidance text
- `mounts the calendar board (renders day-of-week headers)` — confirms `<WorkoutCalendarBoard>` is wired in (Sun / Sat headers from the shared component)
- `queries workouts with a from/to range when the calendar mounts` — the board's initial month load fires `personalProgram.workouts.list({ from, to })`, proving the personal-program data source replaces the gym one
- `surfaces a friendly error when the program upsert fails` — error path renders the message from a rejected `personalProgram.get`

**Full vitest suite:** 180/180 passing across 27 files.

**API integration** (`apps/api/tests/personalProgram.ts` — 35 cases, all pass):
- Auth guards: GET `/me/personal-program`, GET `/workouts`, POST `/workouts` all 401 without a token
- Upsert + idempotency: first GET creates → 200 with `ownerUserId` matching caller, `visibility=PRIVATE`, name `"Personal Program"`; auto-subscription row exists with `role=PROGRAMMER`; second GET returns the same id; zero `GymProgram` links
- Create workout: `POST /workouts` → 201 with personal program id; spoofed `programId` in body is silently overridden; missing title → 400
- **Date-range filter** (new for the calendar): `?from=&to=` filters to the window; only-`from`-no-`to` → 400; invalid date format → 400; no-filter list returns the full set
- Isolation: user B's GET creates a *different* program; user B's workout list is empty; user B GET `/api/workouts/<A-workout>` → 403; user A → 200
- Edit + delete via existing `/workouts/:id`: user A PATCH → 200 with title applied; user B PATCH → 403; user A DELETE → 204
- Not publicly discoverable: `/api/programs/public-catalog` does not surface any program with a non-null `ownerUserId`

**Full API suite:** all suites pass against the worktree dev stack (0 failures).

**Playwright E2E:**
- 38/39 pass. The one failure is the same pre-existing `tests/programs.spec.ts:277 — MEMBER joins a PUBLIC program from Browse` flake we've seen on every PR — strict-mode `getByRole('button', { name: 'Join' })` collides with concurrent seed data on the shared dev DB. Not caused by this PR; doesn't touch `/browse-programs`.

**Roles tested:** any authenticated user (Personal Programs are not gym-role-gated). User isolation is the primary access concern and is covered above (user B blocked from user A's workouts at both `GET /me/personal-program/workouts` and `PATCH /api/workouts/:id`).

**Mobile parity:** desk-suitable + phone-suitable hybrid. Authoring complex prescriptions is desk-suitable, but jotting an extra workout / glancing at the week is phone-suitable. Mobile sibling tracked under #183. The cross-app contract (request/response of `/api/me/personal-program*`, route `/personal-program`) is the shape mobile will mirror.

**Not automated / manual verification needed:**
- [ ] Pre-existing `apps/web/src/pages/AdminProgramDetail.test.tsx` typecheck error (`timeCapSeconds` undefined vs null) is on `main` and unrelated to this PR. Surfaces in `turbo lint` but reproduces on the base branch — out of scope here.

Closes #183