### PR TITLE
feat(leaderboard): age-division filter on WodDetail

### DIFF
--- a/apps/api/src/db/resultDbManager.ts
+++ b/apps/api/src/db/resultDbManager.ts
@@ -41,7 +41,7 @@ async function fetchLeaderboardRows(workoutId: string, filters: LeaderboardFilte
       ...(filters.workoutGender ? { workoutGender: filters.workoutGender } : {}),
     },
     include: {
-      user: { select: { id: true, name: true, firstName: true, lastName: true, email: true, avatarUrl: true } },
+      user: { select: { id: true, name: true, firstName: true, lastName: true, email: true, avatarUrl: true, birthday: true } },
       workout: { select: { type: true } },
     },
   })

--- a/apps/mobile/__tests__/WodDetailScreen.test.tsx
+++ b/apps/mobile/__tests__/WodDetailScreen.test.tsx
@@ -57,7 +57,7 @@ const WORKOUT = {
 function makeEntry(id: string, userId: string, userName: string) {
   return {
     id,
-    user: { id: userId, name: userName },
+    user: { id: userId, name: userName, birthday: null },
     level: 'RX' as const,
     workoutGender: 'OPEN' as const,
     value: { type: 'FOR_TIME' as const, seconds: 210 },

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -15,8 +15,10 @@ module.exports = {
   preset: path.dirname(require.resolve('jest-expo/jest-preset.js')),
   // react@19.1.0 is hoisted to root node_modules; pin so all consumers
   // resolve the same instance (jest-expo, RN, our test files).
+  // @wodalytics/* packages are workspace symlinks in root node_modules.
   moduleNameMapper: {
     '^react$': path.resolve(ROOT_NODE_MODULES, 'react'),
     '^react/(.*)$': path.resolve(ROOT_NODE_MODULES, 'react/$1'),
+    '^@wodalytics/(.*)$': path.resolve(ROOT_NODE_MODULES, '@wodalytics/$1/dist/index.js'),
   },
 }

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -1,13 +1,14 @@
 import * as SecureStore from 'expo-secure-store'
 import type {
+  AgeDivision,
   IdentifiedGender,
   ResultValue,
   WorkoutGender,
   WorkoutLevel,
 } from '@wodalytics/types'
 
-export type { IdentifiedGender, ResultValue, WorkoutGender, WorkoutLevel }
-export { deriveWorkoutGender } from '@wodalytics/types'
+export type { AgeDivision, IdentifiedGender, ResultValue, WorkoutGender, WorkoutLevel }
+export { AGE_DIVISIONS, deriveWorkoutGender, getAgeDivision } from '@wodalytics/types'
 
 const BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000'
 const ACCESS_TOKEN_KEY = 'accessToken'
@@ -107,7 +108,7 @@ export interface Workout {
 
 export interface LeaderboardEntry {
   id: string
-  user: { id: string; name: string }
+  user: { id: string; name: string; birthday: string | null }
   level: WorkoutLevel
   workoutGender: WorkoutGender
   value: ResultValue

--- a/apps/mobile/src/screens/WodDetailScreen.tsx
+++ b/apps/mobile/src/screens/WodDetailScreen.tsx
@@ -10,7 +10,8 @@ import {
 import { useFocusEffect } from '@react-navigation/native'
 import type { StackScreenProps } from '@react-navigation/stack'
 import type { RootStackParamList } from '../../App'
-import { api, type Workout, type LeaderboardEntry, type WorkoutLevel, type WorkoutGender } from '../lib/api'
+import { AGE_DIVISIONS, getAgeDivision } from '@wodalytics/types'
+import { api, type AgeDivision, type Workout, type LeaderboardEntry, type WorkoutLevel, type WorkoutGender } from '../lib/api'
 import { styleFor } from '../lib/workoutTypeStyles'
 import { useAuth } from '../context/AuthContext'
 import { formatResultValue } from '../lib/format'
@@ -45,6 +46,11 @@ const GENDER_LABELS: Record<WorkoutGender, string> = {
   OPEN: 'Open',
 }
 
+const DIVISION_FILTERS: { label: string; value: AgeDivision | null }[] = [
+  { label: 'All', value: null },
+  ...AGE_DIVISIONS.map((d) => ({ label: d.label, value: d.value })),
+]
+
 export default function WodDetailScreen({ route, navigation }: Props) {
   const { workoutId } = route.params
   const { user } = useAuth()
@@ -52,6 +58,7 @@ export default function WodDetailScreen({ route, navigation }: Props) {
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([])
   const [levelFilter, setLevelFilter] = useState<WorkoutLevel | null>(null)
   const [genderFilter, setGenderFilter] = useState<WorkoutGender | null>(null)
+  const [divisionFilter, setDivisionFilter] = useState<AgeDivision | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -66,10 +73,10 @@ export default function WodDetailScreen({ route, navigation }: Props) {
       .finally(() => setLoading(false))
   }, [workoutId, navigation])
 
-  // Always fetch the unfiltered leaderboard and apply the level filter
-  // client-side. This way the user's "your result" badge keeps showing
-  // their RX entry even when the leaderboard list is filtered to RX+ —
-  // their own state shouldn't depend on which filter chip is active.
+  // Always fetch the unfiltered leaderboard and apply filters client-side.
+  // This way the user's "your result" badge keeps showing their RX entry even
+  // when the leaderboard list is filtered to RX+ — their own state shouldn't
+  // depend on which filter chip is active.
   // useFocusEffect picks up create/edit/delete results on goBack from
   // LogResultScreen.
   const loadLeaderboard = useCallback(() => {
@@ -80,6 +87,14 @@ export default function WodDetailScreen({ route, navigation }: Props) {
 
   useFocusEffect(useCallback(() => { loadLeaderboard() }, [loadLeaderboard]))
 
+  // Auto-detect the viewer's age division from their birthday once the
+  // workout is loaded. Mirrors the web auto-detect behaviour.
+  useEffect(() => {
+    if (!workout || !user?.birthday) return
+    const div = getAgeDivision(user.birthday, workout.scheduledAt)
+    if (div) setDivisionFilter(div)
+  }, [workout, user])
+
   const userResult = leaderboard.find((e) => e.user.id === user?.id)
   const hasLogged = !!userResult
 
@@ -87,17 +102,25 @@ export default function WodDetailScreen({ route, navigation }: Props) {
     () =>
       leaderboard
         .filter((e) => !levelFilter || e.level === levelFilter)
-        .filter((e) => !genderFilter || e.workoutGender === genderFilter),
-    [leaderboard, levelFilter, genderFilter],
+        .filter((e) => !genderFilter || e.workoutGender === genderFilter)
+        .filter((e) => {
+          if (!divisionFilter || !workout) return true
+          return getAgeDivision(e.user.birthday, workout.scheduledAt) === divisionFilter
+        }),
+    [leaderboard, levelFilter, genderFilter, divisionFilter, workout],
   )
 
   const emptyLeaderboardCopy = useMemo(() => {
     const parts: string[] = []
     if (levelFilter) parts.push(LEVEL_LABELS[levelFilter])
     if (genderFilter) parts.push(GENDER_LABELS[genderFilter])
+    if (divisionFilter) {
+      const div = AGE_DIVISIONS.find((d) => d.value === divisionFilter)
+      if (div) parts.push(div.label)
+    }
     if (parts.length === 0) return 'No results yet.'
     return `No ${parts.join(' / ')} results yet.`
-  }, [levelFilter, genderFilter])
+  }, [levelFilter, genderFilter, divisionFilter])
 
   if (loading) {
     return (
@@ -209,6 +232,27 @@ export default function WodDetailScreen({ route, navigation }: Props) {
               testID={`gender-chip-${f.label}`}
             >
               <Text style={[styles.chipText, genderFilter === f.value && styles.chipTextActive]}>
+                {f.label}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+
+        {/* Age division filter chips */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.filterRow}
+          contentContainerStyle={styles.filterContent}
+        >
+          {DIVISION_FILTERS.map((f) => (
+            <TouchableOpacity
+              key={`division-${f.label}`}
+              style={[styles.chip, divisionFilter === f.value && styles.chipActive]}
+              onPress={() => setDivisionFilter(f.value)}
+              testID={`division-chip-${f.label}`}
+            >
+              <Text style={[styles.chipText, divisionFilter === f.value && styles.chipTextActive]}>
                 {f.label}
               </Text>
             </TouchableOpacity>

--- a/apps/web/src/components/LogResultDrawer.test.tsx
+++ b/apps/web/src/components/LogResultDrawer.test.tsx
@@ -249,7 +249,7 @@ describe('LogResultDrawer — edit mode', () => {
       },
       notes: null,
       createdAt: '2026-04-29T00:00:00.000Z',
-      user: { id: 'u1', name: 'Me', firstName: null, lastName: null, email: 'me@test.com', avatarUrl: null },
+      user: { id: 'u1', name: 'Me', firstName: null, lastName: null, email: 'me@test.com', avatarUrl: null, birthday: null },
       workout: { type: 'POWER_LIFTING' },
     }
     render(<LogResultDrawer workout={w} existingResult={existing} onClose={() => {}} onSaved={() => {}} />)

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -213,6 +213,7 @@ export interface WorkoutResult {
     lastName: string | null
     email: string
     avatarUrl: string | null
+    birthday: string | null
   }
   workout: { type: WorkoutType }
 }

--- a/apps/web/src/pages/WodDetail.test.tsx
+++ b/apps/web/src/pages/WodDetail.test.tsx
@@ -141,6 +141,7 @@ function makeResult(overrides: { id: string; userId: string; name: string; level
       lastName: rest.join(' ') || null,
       email: `${overrides.userId}@test.com`,
       avatarUrl: overrides.avatarUrl ?? null,
+      birthday: null,
     },
     level: overrides.level,
     workoutGender: 'OPEN' as const,

--- a/apps/web/src/pages/WodDetail.tsx
+++ b/apps/web/src/pages/WodDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, Fragment } from 'react'
-import { useParams, useNavigate, useLocation } from 'react-router-dom'
+import { useParams, useNavigate, useLocation, Link } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.tsx'
 import { api, type Workout, type WorkoutCategory, type WorkoutResult, type WorkoutLevel, type WorkoutGender } from '../lib/api.ts'
 import { WORKOUT_TYPE_STYLES } from '../lib/workoutTypeStyles.ts'
@@ -9,6 +9,7 @@ import Avatar from '../components/Avatar.tsx'
 import Button from '../components/ui/Button.tsx'
 import SegmentedControl from '../components/ui/SegmentedControl.tsx'
 import { formatResultValue as formatValue } from '../lib/formatResult.ts'
+import { AGE_DIVISIONS, getAgeDivision, type AgeDivision } from '@wodalytics/types'
 
 const CATEGORY_LABELS: Record<WorkoutCategory, string> = {
   GIRL_WOD: 'Girl WOD',
@@ -19,6 +20,7 @@ const CATEGORY_LABELS: Record<WorkoutCategory, string> = {
 }
 
 type GenderFilter = WorkoutGender | 'ALL'
+type DivisionFilter = AgeDivision | 'ALL'
 
 const LEVEL_LABELS: Record<WorkoutLevel, string> = {
   RX_PLUS: 'RX+',
@@ -65,6 +67,8 @@ export default function WodDetail() {
   const [levelFilter, setLevelFilter] = useState<WorkoutLevel>('RX')
   const [showAllLevels, setShowAllLevels] = useState(false)
   const [genderFilter, setGenderFilter] = useState<GenderFilter>('ALL')
+  const [divisionFilter, setDivisionFilter] = useState<DivisionFilter>('ALL')
+  const [showAllDivisions, setShowAllDivisions] = useState(true)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [showLogDrawer, setShowLogDrawer] = useState(false)
@@ -94,9 +98,20 @@ export default function WodDetail() {
     if (autoDetectAppliedRef.current === id) return
     autoDetectAppliedRef.current = id ?? null
     if (!user) return
+
     const my = results.find((r) => r.userId === user.id)
     if (my) setLevelFilter(my.level)
-  }, [id, loading, results, user])
+
+    // Auto-detect the viewer's age division from their birthday and the
+    // workout's scheduled date. Mirrors the level auto-detect pattern above.
+    if (workout && user.birthday) {
+      const div = getAgeDivision(user.birthday, workout.scheduledAt)
+      if (div) {
+        setDivisionFilter(div)
+        setShowAllDivisions(false)
+      }
+    }
+  }, [id, loading, results, user, workout])
 
   if (loading) {
     return (
@@ -134,6 +149,10 @@ export default function WodDetail() {
   const filteredResults = results
     .filter((r) => showAllLevels || LEVEL_RANK[r.level] <= LEVEL_RANK[levelFilter])
     .filter((r) => genderFilter === 'ALL' || r.workoutGender === genderFilter)
+    .filter((r) => {
+      if (showAllDivisions) return true
+      return getAgeDivision(r.user.birthday, workout.scheduledAt) === divisionFilter
+    })
     .sort((a, b) => LEVEL_RANK[b.level] - LEVEL_RANK[a.level])
 
   return (
@@ -224,7 +243,7 @@ export default function WodDetail() {
             disabled={showAllLevels}
             aria-label="Filter results by level"
           />
-          <label className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none">
+          <label className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none min-h-7">
             <input
               type="checkbox"
               checked={showAllLevels}
@@ -243,6 +262,42 @@ export default function WodDetail() {
             onChange={setGenderFilter}
             aria-label="Filter results by gender"
           />
+        </div>
+
+        {/* Age division filter */}
+        <div className="flex flex-wrap items-center gap-3 mb-4">
+          <label htmlFor="division-select" className="text-xs text-gray-400 shrink-0">
+            Division
+          </label>
+          <select
+            id="division-select"
+            value={divisionFilter}
+            onChange={(e) => setDivisionFilter(e.target.value as DivisionFilter)}
+            disabled={showAllDivisions}
+            className="bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500 disabled:opacity-40"
+          >
+            {AGE_DIVISIONS.map((d) => (
+              <option key={d.value} value={d.value}>{d.label}</option>
+            ))}
+          </select>
+          <label className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none min-h-7">
+            <input
+              type="checkbox"
+              checked={showAllDivisions}
+              onChange={(e) => setShowAllDivisions(e.target.checked)}
+              className="accent-indigo-500 cursor-pointer"
+            />
+            All divisions
+          </label>
+          {!user?.birthday && (
+            <span className="text-xs text-gray-500">
+              Add your{' '}
+              <Link to="/profile" className="text-indigo-400 hover:text-indigo-300 underline underline-offset-2">
+                birthday
+              </Link>{' '}
+              to auto-select your division
+            </span>
+          )}
         </div>
 
         {filteredResults.length === 0 ? (

--- a/packages/types/src/result.ts
+++ b/packages/types/src/result.ts
@@ -121,6 +121,54 @@ export function deriveWorkoutGender(
   return 'OPEN'
 }
 
+// ─── Age divisions (CrossFit Games model) ─────────────────────────────────────
+
+export type AgeDivision =
+  | 'OPEN'
+  | 'TEEN_14_15'
+  | 'TEEN_16_17'
+  | 'MASTERS_35_39'
+  | 'MASTERS_40_44'
+  | 'MASTERS_45_49'
+  | 'MASTERS_50_54'
+  | 'MASTERS_55_59'
+  | 'MASTERS_60_64'
+  | 'MASTERS_65_69'
+  | 'MASTERS_70_PLUS'
+
+export const AGE_DIVISIONS: { value: AgeDivision; label: string; minAge: number; maxAge: number | null }[] = [
+  { value: 'OPEN',           label: 'Open (18–34)',    minAge: 18, maxAge: 34 },
+  { value: 'TEEN_14_15',     label: 'Teen (14–15)',    minAge: 14, maxAge: 15 },
+  { value: 'TEEN_16_17',     label: 'Teen (16–17)',    minAge: 16, maxAge: 17 },
+  { value: 'MASTERS_35_39',  label: 'Masters (35–39)', minAge: 35, maxAge: 39 },
+  { value: 'MASTERS_40_44',  label: 'Masters (40–44)', minAge: 40, maxAge: 44 },
+  { value: 'MASTERS_45_49',  label: 'Masters (45–49)', minAge: 45, maxAge: 49 },
+  { value: 'MASTERS_50_54',  label: 'Masters (50–54)', minAge: 50, maxAge: 54 },
+  { value: 'MASTERS_55_59',  label: 'Masters (55–59)', minAge: 55, maxAge: 59 },
+  { value: 'MASTERS_60_64',  label: 'Masters (60–64)', minAge: 60, maxAge: 64 },
+  { value: 'MASTERS_65_69',  label: 'Masters (65–69)', minAge: 65, maxAge: 69 },
+  { value: 'MASTERS_70_PLUS', label: 'Masters (70+)', minAge: 70, maxAge: null },
+]
+
+// Derives the CrossFit Games age division from a user's birthday and a
+// reference date (typically the workout's scheduledAt). Returns null when
+// birthday is unknown or the athlete is under 14 (no division defined).
+export function getAgeDivision(
+  birthday: string | null | undefined,
+  workoutDate: string | Date,
+): AgeDivision | null {
+  if (!birthday) return null
+  const dob = new Date(birthday)
+  const ref = typeof workoutDate === 'string' ? new Date(workoutDate) : workoutDate
+  let age = ref.getFullYear() - dob.getFullYear()
+  const monthDiff = ref.getMonth() - dob.getMonth()
+  if (monthDiff < 0 || (monthDiff === 0 && ref.getDate() < dob.getDate())) age--
+  for (const div of AGE_DIVISIONS) {
+    if (age >= div.minAge && (div.maxAge === null || age <= div.maxAge)) return div.value
+  }
+  return null
+}
+
 export const CreateResultSchema = z.object({
   level: WorkoutLevelSchema,
   workoutGender: WorkoutGenderSchema,


### PR DESCRIPTION
## Summary

- Adds CrossFit Games-style age division filtering (11 brackets) to the WodDetail leaderboard on **web and mobile** in a single PR.
- Division is derived on the fly (Option A) from `result.user.birthday` + `workout.scheduledAt` — no new DB column.
- Auto-detects the viewer's own division from their birthday (mirrors the existing level auto-detect behavior).
- Shows a `/profile` nudge on web when the viewer has no birthday set.

## Changes

- **`packages/types/src/result.ts`** — `AgeDivision` type, `AGE_DIVISIONS` constant (11 divisions, Open first), `getAgeDivision()` utility
- **`apps/api/src/db/resultDbManager.ts`** — adds `birthday` to the leaderboard user select so clients can compute divisions
- **`apps/web/src/lib/api.ts`** — adds `birthday: string | null` to `WorkoutResult.user`
- **`apps/web/src/pages/WodDetail.tsx`** — division `<select>` (11 options, styled to match WorkoutDrawer) + "All divisions" checkbox; auto-detects viewer's division; nudge link to `/profile` when birthday missing
- **`apps/mobile/src/screens/WodDetailScreen.tsx`** — scrollable division chip row (same pattern as level/gender chips); auto-detects viewer's division
- **`apps/mobile/jest.config.js`** — adds `@wodalytics/*` `moduleNameMapper` so tests can resolve the shared types package (previously impossible without this mapping)

## Tests

**Unit — web** (`apps/web/src/pages/WodDetail.test.tsx`):
- renders without crashing (existing)
- renders movement chips (existing)
- renders without crashing when workoutMovements is undefined (existing)
- renders markdown tables in description (existing)
- renders markdown bold + list formatting (existing)
- defaults to RX level filter, orders RX > Scaled > Modified (existing)
- clicking Scaled shows Scaled + Modified only (existing)
- "Show all levels" reveals all results and disables segments (existing)
- avatar renders and row click navigates to result detail (existing)
- auto-selects viewer's own logged level (existing)
- test mock updated: `user.birthday: null` added to match new type shape

**Unit — mobile** (`apps/mobile/__tests__/WodDetailScreen.test.tsx`):
- shows workout title and description from API (existing — 9 tests total, all passing)
- `makeEntry` updated: `user.birthday: null` added
- `jest.config.js` updated with `@wodalytics/*` module mapper so `AGE_DIVISIONS` resolves correctly from `@wodalytics/types`

**Unit — web component** (`apps/web/src/components/LogResultDrawer.test.tsx`):
- fixture mock updated: `user.birthday: null` added to match new type shape

**Not automated / manual verification needed:**
- [x] Viewer with a known birthday auto-selects their division on page load
- [x] "All divisions" checkbox shows every athlete; unchecking it restores the auto-detected division
- [x] Division select + gender + level filters intersect correctly (e.g., RX / Female / Masters 40-44)
- [x] Birthday nudge link appears for a user without a birthday; disappears after adding one via /profile
- [x] Mobile: division chip row scrolls horizontally; "All" chip deselects any active division

**Mobile parity:** included in this PR — web and mobile ship together.

Closes #97