### PR TITLE
fix(web): restrict future empty tiles to last scheduled workout

### DIFF
--- a/apps/web/src/pages/Feed.test.tsx
+++ b/apps/web/src/pages/Feed.test.tsx
@@ -218,10 +218,9 @@ describe('Feed — empty-day tiles', () => {
     expect(tiles.length).toBeGreaterThan(0)
   })
 
-  it('renders a day header for days with no workouts alongside the empty-tile text', async () => {
+  it('renders a TODAY label when there are no workouts', async () => {
     vi.mocked(api.workouts.list).mockResolvedValue([] as never)
     renderFeed()
-    // TODAY label should always appear (it's within the initial range)
     expect(await screen.findByText('TODAY')).toBeInTheDocument()
   })
 
@@ -233,6 +232,31 @@ describe('Feed — empty-day tiles', () => {
     // Other days in the range have no workouts → at least one empty tile
     const emptyTiles = await screen.findAllByText('No workouts planned')
     expect(emptyTiles.length).toBeGreaterThan(0)
+  })
+
+  it('does not render future empty tiles when no future workouts exist', async () => {
+    // Only a past workout — feed should end at today with no TOMORROW tile
+    const w = makeWorkout('AMRAP', 2)   // 2 days ago
+    vi.mocked(api.workouts.list).mockResolvedValue([w] as never)
+    renderFeed()
+    await screen.findByText('TODAY')
+    expect(screen.queryByText('TOMORROW')).not.toBeInTheDocument()
+  })
+
+  it('renders future empty tiles only up to the last day with a workout', async () => {
+    // Workout scheduled 3 days from now — TOMORROW tile should appear
+    const d = new Date()
+    d.setDate(d.getDate() + 3)
+    d.setHours(12, 0, 0, 0)
+    const w = {
+      ...makeWorkout('AMRAP', 0),
+      id: 'w-future',
+      scheduledAt: d.toISOString(),
+    }
+    vi.mocked(api.workouts.list).mockResolvedValue([w] as never)
+    renderFeed()
+    // TOMORROW is between today and the future workout → empty tile expected
+    expect(await screen.findByText('TOMORROW')).toBeInTheDocument()
   })
 })
 

--- a/apps/web/src/pages/Feed.tsx
+++ b/apps/web/src/pages/Feed.tsx
@@ -8,7 +8,7 @@ import Skeleton from '../components/ui/Skeleton.tsx'
 import BarbellIcon from '../components/icons/BarbellIcon.tsx'
 import UsersIcon from '../components/icons/UsersIcon.tsx'
 
-const INITIAL_FUTURE_DAYS = 14
+const INITIAL_FUTURE_DAYS = 30
 const INITIAL_PAST_DAYS = 30
 const PAGE_DAYS = 30
 
@@ -161,7 +161,15 @@ export default function Feed() {
   const today = new Date()
   const todayKey = toDateKey(today)
 
-  const dayBlocks = fetchStart && fetchEnd ? buildDayBlocks(workouts, fetchStart, fetchEnd) : []
+  // Future tiles only extend as far as the last day with a workout scheduled.
+  // If nothing is planned ahead, the feed ends at today.
+  const latestFutureWorkout = workouts.reduce<Date | null>((latest, w) => {
+    const d = new Date(w.scheduledAt)
+    return toDateKey(d) > todayKey ? (!latest || d > latest ? d : latest) : latest
+  }, null)
+  const blockEnd = latestFutureWorkout ?? today
+
+  const dayBlocks = fetchStart ? buildDayBlocks(workouts, fetchStart, blockEnd) : []
 
   // Single-program filter gets a featured header (color stripe + name).
   // Multi-program gets a compact chip pointing at the picker.


### PR DESCRIPTION
## Summary

- Future empty-day tiles now only extend as far as the last date with a workout scheduled. If nothing is planned ahead, the feed ends at today.
- Gaps between today and a future workout are still filled with empty tiles.
- Bumps `INITIAL_FUTURE_DAYS` from 14 → 30 to look further ahead for upcoming workouts.

Part of #194 (follow-up to #198 — that PR merged the initial empty-tile implementation but missed this commit).

## Tests

**Unit** (`apps/web/src/pages/Feed.test.tsx`):
- `does not render future empty tiles when no future workouts exist` — TOMORROW tile absent when only a past workout exists
- `renders future empty tiles only up to the last day with a workout` — TOMORROW tile present when a workout is scheduled 3 days out

All 181 tests pass.

**Not automated / manual verification needed:**
- [x] Confirm no empty tiles appear beyond today when no future workouts are scheduled
- [x] Confirm empty gap tiles appear between today and a future scheduled workout

**Mobile parity:** Closes the remaining gap from #194 — mobile already stops the contiguous grid at the last scheduled day.