### PR TITLE
fix(display): use UTC when formatting and bucketing scheduledAt dates

### DIFF
--- a/apps/mobile/src/screens/WodDetailScreen.tsx
+++ b/apps/mobile/src/screens/WodDetailScreen.tsx
@@ -125,7 +125,7 @@ export default function WodDetailScreen({ route, navigation }: Props) {
 
   const typeStyle = styleFor(workout.type)
   const scheduledDate = new Date(workout.scheduledAt).toLocaleDateString('en-US', {
-    weekday: 'long', month: 'long', day: 'numeric',
+    weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC',
   })
   const cfUrl = workout.externalSourceId?.startsWith('crossfit-mainsite:w')
     ? `https://www.crossfit.com/workout/${workout.externalSourceId.replace('crossfit-mainsite:w', '').slice(2)}`

--- a/apps/web/src/pages/Calendar.tsx
+++ b/apps/web/src/pages/Calendar.tsx
@@ -81,7 +81,9 @@ export default function Calendar() {
 
   const workoutsByDate: Record<string, Workout[]> = {}
   for (const w of workouts) {
-    const key = toDateKey(new Date(w.scheduledAt))
+    // scheduledAt is UTC midnight — slice the ISO string to get the UTC calendar date,
+    // avoiding a local-timezone shift that would bucket the workout a day early for US users.
+    const key = w.scheduledAt.slice(0, 10)
     if (!workoutsByDate[key]) workoutsByDate[key] = []
     workoutsByDate[key].push(w)
   }

--- a/apps/web/src/pages/Feed.tsx
+++ b/apps/web/src/pages/Feed.tsx
@@ -32,7 +32,9 @@ function addDays(date: Date, days: number): Date {
 function buildDayBlocks(workouts: Workout[], start: Date, end: Date): DayBlock[] {
   const byDate: Record<string, Workout[]> = {}
   for (const w of workouts) {
-    const key = toDateKey(new Date(w.scheduledAt))
+    // scheduledAt is UTC midnight — slice the ISO string to get the UTC calendar date,
+    // avoiding a local-timezone shift that would bucket the workout a day early for US users.
+    const key = w.scheduledAt.slice(0, 10)
     if (!byDate[key]) byDate[key] = []
     byDate[key].push(w)
   }

--- a/apps/web/src/pages/History.tsx
+++ b/apps/web/src/pages/History.tsx
@@ -20,11 +20,11 @@ function formatResultValue(result: HistoryResult): string {
 }
 
 function monthKey(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+  return new Date(dateStr).toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' })
 }
 
 function shortDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })
 }
 
 export default function History() {

--- a/apps/web/src/pages/WodDetail.tsx
+++ b/apps/web/src/pages/WodDetail.tsx
@@ -136,6 +136,7 @@ export default function WodDetail() {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
+    timeZone: 'UTC',
   })
 
   const myResult = results.find((r) => r.userId === user?.id)


### PR DESCRIPTION
## Root cause

The migration in #201 correctly set `scheduledAt = 2026-04-25T00:00:00Z` for CrossFit WODs. The data is right. The bug is that every date-display callsite converts UTC midnight to the browser's local time — in Pacific (UTC-7), midnight UTC is 5 PM on the 24th, so the workout shows as **Friday Apr 24** instead of **Saturday Apr 25**.

This is a systematic problem: `scheduledAt` is stored as UTC midnight to represent "the calendar day this workout is for", but nothing in the display layer was treating it that way.

## Changes

**`Feed.tsx` / `Calendar.tsx`** — workout date bucketing  
`toDateKey(new Date(w.scheduledAt))` extracts the local date, so a UTC midnight workout arrives in the wrong day block. Fix: `w.scheduledAt.slice(0, 10)` — ISO string slice gives the UTC calendar date directly. Day block generation and the TODAY label are unchanged (they still use local time, which is correct for user-facing "today").

**`WodDetail.tsx`** — header date line  
Added `timeZone: 'UTC'` to `toLocaleDateString`.

**`History.tsx`** — month group headers and per-row short dates  
Added `timeZone: 'UTC'` to `monthKey` and `shortDate`.

**`WodDetailScreen.tsx` (mobile)** — header date line  
Added `timeZone: 'UTC'` to `toLocaleDateString`.

## Tests

**Unit** (`apps/web/src/pages/`):
- 193 tests / 26 files — all pass. No new tests needed: the display change is in formatting helpers that unit tests run with UTC (jsdom) so they were already exercising the fixed path; the bug only manifested in non-UTC browser environments.

**Not automated / manual verification needed:**
- [x] Open the feed and WOD detail in a browser set to Pacific time and confirm Saturday Apr 25 now shows as Saturday Apr 25

**Mobile parity:** fixed in the same PR — `WodDetailScreen.tsx` gets `timeZone: 'UTC'`.