### PR TITLE
chore(db): Invitation model + migration for invite-code system

### DIFF
--- a/packages/db/prisma/migrations/20260503160414_add_invitation_model/migration.sql
+++ b/packages/db/prisma/migrations/20260503160414_add_invitation_model/migration.sql
@@ -1,0 +1,45 @@
+-- CreateEnum
+CREATE TYPE "InvitationStatus" AS ENUM ('PENDING', 'ACCEPTED', 'DECLINED', 'REVOKED', 'EXPIRED');
+
+-- CreateEnum
+CREATE TYPE "InvitationChannel" AS ENUM ('EMAIL', 'SMS');
+
+-- CreateTable
+CREATE TABLE "Invitation" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "channel" "InvitationChannel" NOT NULL,
+    "email" TEXT,
+    "phone" TEXT,
+    "gymId" TEXT,
+    "roleToGrant" "Role" NOT NULL DEFAULT 'MEMBER',
+    "invitedById" TEXT NOT NULL,
+    "status" "InvitationStatus" NOT NULL DEFAULT 'PENDING',
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "acceptedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Invitation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Invitation_code_key" ON "Invitation"("code");
+
+-- CreateIndex
+CREATE INDEX "Invitation_email_status_idx" ON "Invitation"("email", "status");
+
+-- CreateIndex
+CREATE INDEX "Invitation_gymId_status_idx" ON "Invitation"("gymId", "status");
+
+-- CreateIndex
+CREATE INDEX "Invitation_invitedById_idx" ON "Invitation"("invitedById");
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_gymId_fkey" FOREIGN KEY ("gymId") REFERENCES "Gym"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_invitedById_fkey" FOREIGN KEY ("invitedById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_acceptedById_fkey" FOREIGN KEY ("acceptedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -122,6 +122,20 @@ enum MembershipRequestStatus {
   EXPIRED
 }
 
+enum InvitationStatus {
+  PENDING
+  ACCEPTED
+  DECLINED
+  REVOKED
+  EXPIRED
+}
+
+// Channel used to deliver an Invitation — EMAIL sends a deep link, SMS sends a short code.
+enum InvitationChannel {
+  EMAIL
+  SMS
+}
+
 enum WorkoutCategory {
   GIRL_WOD // e.g. Fran, Cindy, Grace
   HERO_WOD // e.g. Murph, Badger, DT
@@ -200,6 +214,8 @@ model User {
   membershipInvitesSent GymMembershipRequest[] @relation("InvitedBy")
   membershipDecisions   GymMembershipRequest[] @relation("DecidedBy")
   workoutImports        WorkoutImport[]
+  sentInvitations       Invitation[]           @relation("SentInvitations")
+  receivedInvitations   Invitation[]           @relation("ReceivedInvitations")
 }
 
 model OAuthAccount {
@@ -236,6 +252,7 @@ model Gym {
   members            UserGym[]
   programs           GymProgram[]
   membershipRequests GymMembershipRequest[]
+  invitations        Invitation[]
 }
 
 model UserGym {
@@ -344,6 +361,35 @@ model GymMembershipRequest {
   @@index([gymId, status])
   @@index([userId, status])
   @@index([email, status])
+}
+
+// Invite-code-based invitation for both app-only and gym-context invites.
+// gymId null = app-only invite (join WODalytics, no gym affiliation).
+// gymId set  = gym-context invite; on acceptance a UserGym row is created.
+// Separate from GymMembershipRequest which handles the USER_REQUESTED join flow.
+model Invitation {
+  id           String            @id @default(cuid())
+  // 6-char uppercase alphanumeric code (no ambiguous 0/O/1/I). Unique.
+  code         String            @unique
+  channel      InvitationChannel
+  email        String?
+  phone        String?
+  gymId        String?
+  roleToGrant  Role              @default(MEMBER)
+  invitedById  String
+  status       InvitationStatus  @default(PENDING)
+  expiresAt    DateTime
+  acceptedById String?
+  createdAt    DateTime          @default(now())
+  updatedAt    DateTime          @updatedAt
+
+  gym        Gym?  @relation(fields: [gymId], references: [id], onDelete: Cascade)
+  invitedBy  User  @relation("SentInvitations", fields: [invitedById], references: [id], onDelete: Cascade)
+  acceptedBy User? @relation("ReceivedInvitations", fields: [acceptedById], references: [id], onDelete: SetNull)
+
+  @@index([email, status])
+  @@index([gymId, status])
+  @@index([invitedById])
 }
 
 model NamedWorkout {


### PR DESCRIPTION
Closes #203
Part of #202

## What

Adds the `Invitation` model to the Prisma schema along with two new enums (`InvitationStatus`, `InvitationChannel`) to support the invite-code-based invitation system (#202).

### New model

```prisma
enum InvitationStatus  { PENDING, ACCEPTED, DECLINED, REVOKED, EXPIRED }
enum InvitationChannel { EMAIL, SMS }

model Invitation {
  id           String            @id @default(cuid())
  code         String            @unique  // 6-char alphanumeric, no 0/O/1/I
  channel      InvitationChannel          // EMAIL = deep link, SMS = short code
  email        String?
  phone        String?
  gymId        String?                    // null = app-only invite
  roleToGrant  Role              @default(MEMBER)
  invitedById  String
  status       InvitationStatus  @default(PENDING)
  expiresAt    DateTime
  acceptedById String?
  ...
}
```

Relations added: `User.sentInvitations`, `User.receivedInvitations`, `Gym.invitations`.

### Design note

`Invitation` is intentionally separate from `GymMembershipRequest` because it needs fields (`code`, `phone`, `channel`) that the existing model doesn't support, and it needs to work for app-only invites (no gym context).

### Also commits

The placeholder migration `20260503131526_fix_crossfit_wod_scheduled_at` — this migration was applied to the dev DB on 2026-05-03 but its file was never committed. The DB schema is consistent with `schema.prisma`; the placeholder exists to resolve the Prisma drift warning in dev. The checksum in `_prisma_migrations` was updated to match the placeholder file. **Note for production deploy:** this migration is a no-op; no schema changes need to apply.

## Tests

**Not automated / manual verification needed:**
- [x] `npm run db:migrate` applies cleanly (verified in worktree)
- [x] `prisma migrate diff --from-schema-datasource --to-schema-datamodel` shows zero drift after migration
- [ ] Prisma `migrate deploy` in QA/prod — migration is additive-only, no breaking changes

**Mobile parity:** N/A — schema migration only.