### PR TITLE
fix(web): redirect to /feed after login

### DIFF
--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -18,7 +18,7 @@ export default function Login() {
     try {
       const data = await api.auth.login({ email, password })
       login(data.accessToken, data.user)
-      navigate('/dashboard', { replace: true })
+      navigate('/feed', { replace: true })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Network error — is the API running?')
     } finally {


### PR DESCRIPTION
Redirects to `/feed` after a successful login instead of `/dashboard`, which is still in progress.

## Tests

**Existing coverage:**
- Login flow is covered by `apps/web/tests/` E2E specs

**Not automated / manual verification needed:**
- [ ] Log in and confirm landing page is `/feed`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)