### PR TITLE
fix(e2e): scope Browse→Join button to prevent strict-mode flake

### DIFF
--- a/apps/web/tests/programs.spec.ts
+++ b/apps/web/tests/programs.spec.ts
@@ -290,9 +290,13 @@ test.describe('Programs CRUD E2E', () => {
     await page.goto('/browse-programs')
     await expect(page.locator('h1', { hasText: 'Browse programs' })).toBeVisible()
 
-    // The seeded PUBLIC program is on the page; click Join
+    // The seeded PUBLIC program is on the page; click Join.
+    // Scope to the section containing this program to avoid a strict-mode
+    // violation when the public-catalog section also loads Join buttons.
     await expect(page.getByText(name)).toBeVisible({ timeout: 5000 })
-    await page.getByRole('button', { name: 'Join' }).click()
+    await page.locator('section').filter({ has: page.getByText(name) })
+      .getByRole('button', { name: 'Join' })
+      .click()
 
     // Lands on /feed (program filter set to the joined program by the page)
     await page.waitForURL('**/feed**')


### PR DESCRIPTION
## Summary

- `BrowsePrograms` renders two independent `<section>` elements — "Public programs" (unaffiliated catalog) and "From your gym" — each with their own "Join" buttons.
- The test at `programs.spec.ts:277` used an unscoped `getByRole('button', { name: 'Join' })`. When the public-catalog API response happened to resolve before the test clicked, Playwright's strict mode found 2+ matching buttons and threw — producing the ~1/42 flake.
- Fix: scope the locator to the `<section>` that contains the seeded program name, so exactly one "Join" button is matched regardless of which section loads first.

## Tests

**Playwright E2E** (`apps/web/tests/programs.spec.ts`):
- T1: `MEMBER joins a PUBLIC program from Browse and lands on its filtered Feed` — the test being fixed; the scoped locator eliminates the strict-mode race.
- All other tests in the suite are unchanged.

**Not automated / manual verification needed:**
- None — this is a test-only selector change with no production code impact.

Mobile parity: desk-suitable only — N/A on mobile (test infrastructure change).