### PR TITLE
fix(web): omit rounds from AMRAP score when tracksRounds is false

### DIFF
--- a/apps/web/src/components/LogResultDrawer.tsx
+++ b/apps/web/src/components/LogResultDrawer.tsx
@@ -172,7 +172,7 @@ export default function LogResultDrawer({ workout, existingResult, onClose, onSa
     }
     let score: Record<string, unknown> | undefined
     if (mode === 'score') {
-      const built = buildScore(scoreKind, scoreFields)
+      const built = buildScore(scoreKind, scoreFields, workout.tracksRounds)
       if (!built.ok) return built
       score = built.score
     }
@@ -748,13 +748,16 @@ function ScoreFields({
 
 type Result<T> = { ok: true } & T | { ok: false; error: string }
 
-function buildScore(kind: ScoreKind, f: ScoreFieldState): Result<{ score: Record<string, unknown> }> {
+function buildScore(kind: ScoreKind, f: ScoreFieldState, tracksRounds?: boolean): Result<{ score: Record<string, unknown> }> {
   if (kind === 'ROUNDS_REPS') {
-    const r = parseInt(f.rounds || '0', 10)
     const rp = parseInt(f.reps || '0', 10)
-    if (!Number.isInteger(r) || r < 0) return { ok: false, error: 'Rounds must be a non-negative number.' }
     if (!Number.isInteger(rp) || rp < 0) return { ok: false, error: 'Reps must be a non-negative number.' }
-    return { ok: true, score: { kind: 'ROUNDS_REPS', rounds: r, reps: rp, cappedOut: false } }
+    if (tracksRounds) {
+      const r = parseInt(f.rounds || '0', 10)
+      if (!Number.isInteger(r) || r < 0) return { ok: false, error: 'Rounds must be a non-negative number.' }
+      return { ok: true, score: { kind: 'ROUNDS_REPS', rounds: r, reps: rp, cappedOut: false } }
+    }
+    return { ok: true, score: { kind: 'ROUNDS_REPS', reps: rp, cappedOut: false } }
   }
   if (kind === 'TIME') {
     const m = parseInt(f.minutes || '0', 10)

--- a/apps/web/src/lib/formatResult.test.ts
+++ b/apps/web/src/lib/formatResult.test.ts
@@ -20,6 +20,10 @@ describe('formatResultValue', () => {
     expect(formatResultValue({ score: { kind: 'ROUNDS_REPS', reps: 95, cappedOut: false } })).toBe('95 reps')
   })
 
+  test('ROUNDS_REPS with rounds=0 and tracksRounds:false → "Y reps" only', () => {
+    expect(formatResultValue({ score: { kind: 'ROUNDS_REPS', rounds: 0, reps: 45, cappedOut: false } }, { tracksRounds: false })).toBe('45 reps')
+  })
+
   test('LOAD score → "value unit"', () => {
     expect(formatResultValue({ score: { kind: 'LOAD', load: 225, unit: 'LB' } })).toBe('225 lb')
     expect(formatResultValue({ score: { kind: 'LOAD', load: 100, unit: 'KG' } })).toBe('100 kg')

--- a/apps/web/src/lib/formatResult.ts
+++ b/apps/web/src/lib/formatResult.ts
@@ -39,7 +39,10 @@ function formatSeconds(totalSec: number): string {
   return `${m}:${String(s).padStart(2, '0')}`
 }
 
-export function formatResultValue(value: Record<string, unknown> | undefined | null): string {
+export function formatResultValue(
+  value: Record<string, unknown> | undefined | null,
+  options?: { tracksRounds?: boolean },
+): string {
   if (!value) return '—'
   const v = value as unknown as ResultValueShape
   const score = v.score
@@ -47,7 +50,8 @@ export function formatResultValue(value: Record<string, unknown> | undefined | n
     switch (score.kind) {
       case 'ROUNDS_REPS': {
         if (score.cappedOut && (score.reps ?? 0) === 0 && !score.rounds) return 'CAPPED'
-        return score.rounds !== undefined
+        const showRounds = options?.tracksRounds !== false && score.rounds !== undefined
+        return showRounds
           ? `${score.rounds} rounds + ${score.reps ?? 0} reps`
           : `${score.reps ?? 0} reps`
       }

--- a/apps/web/src/pages/WodDetail.tsx
+++ b/apps/web/src/pages/WodDetail.tsx
@@ -52,8 +52,8 @@ const GENDER_OPTIONS: { value: GenderFilter; label: string }[] = [
   { value: 'FEMALE', label: 'Female' },
 ]
 
-function formatResultValue(result: WorkoutResult): string {
-  return formatValue(result.value)
+function formatResultValue(result: WorkoutResult, tracksRounds?: boolean): string {
+  return formatValue(result.value, { tracksRounds })
 }
 
 // Derives the crossfit.com permalink from an externalSourceId like
@@ -260,7 +260,7 @@ export default function WodDetail() {
         <div className="px-4 py-3 rounded-lg bg-gray-900 border border-gray-700">
           <div className="flex items-center gap-3">
             <span className="text-xs font-semibold text-gray-400 uppercase tracking-wide">Your Result</span>
-            <span className="text-sm font-medium text-white">{formatResultValue(myResult)}</span>
+            <span className="text-sm font-medium text-white">{formatResultValue(myResult, workout?.tracksRounds)}</span>
             <span className="text-xs text-gray-400">{LEVEL_LABELS[myResult.level]}</span>
             <button
               onClick={() => setShowLogDrawer(true)}
@@ -404,7 +404,7 @@ export default function WodDetail() {
                           </span>
                         </td>
                         <td className="py-2.5 pr-4 text-gray-400">{LEVEL_LABELS[result.level]}</td>
-                        <td className="py-2.5 font-mono">{formatResultValue(result)}</td>
+                        <td className="py-2.5 font-mono">{formatResultValue(result, workout?.tracksRounds)}</td>
                       </tr>
                       {result.notes && (
                         <tr className="border-b border-gray-900">


### PR DESCRIPTION
## Problem

When a member logs a result on an AMRAP workout where `tracksRounds=false`, the leaderboard showed **"0 rounds + N reps"** instead of just **"N reps"**.

**Root cause (two halves):**

1. `buildScore` in `LogResultDrawer.tsx` always included `rounds` in the submitted score — even when the rounds input was hidden. The hidden field defaults to `''`, which `parseInt` turns into `0`, so every non-rounds-tracking AMRAP result was stored as `{ kind: 'ROUNDS_REPS', rounds: 0, reps: N }`.

2. `formatResultValue` in `formatResult.ts` checked `score.rounds !== undefined` to decide whether to show rounds. Since `0 !== undefined`, it rendered "0 rounds + N reps".

## Fix

- **`LogResultDrawer.tsx` — `buildScore`**: passes `tracksRounds` through; only includes and validates `rounds` when `tracksRounds=true`. New submissions on reps-only AMRAPs store a clean `{ kind: 'ROUNDS_REPS', reps: N }` with no `rounds` key.
- **`formatResult.ts` — `formatResultValue`**: accepts an optional `{ tracksRounds?: boolean }` second argument. When `tracksRounds: false`, rounds are suppressed from display regardless of what's stored — this also corrects any existing results that were stored with `rounds: 0` before this fix.
- **`WodDetail.tsx`**: threads `workout?.tracksRounds` into both display sites (the "Your Result" banner and the leaderboard rows).

## Tests

**Unit** (`apps/web/src/lib/formatResult.test.ts`):
- Existing: `ROUNDS_REPS with rounds → "X rounds + Y reps"` — unchanged behavior, no options passed
- Existing: `ROUNDS_REPS without rounds → "Y reps"` — unchanged, rounds field absent
- **New:** `ROUNDS_REPS with rounds=0 and tracksRounds:false → "Y reps" only` — covers the exact bug

All 351 unit tests pass.

**Not automated / manual verification needed:**
- [x] Log a result on an AMRAP with `tracksRounds=false` and confirm leaderboard shows "N reps"
- [x] Log a result on an AMRAP with `tracksRounds=true` and confirm leaderboard still shows "X rounds + Y reps"

**Mobile parity:** desk-suitable only — N/A on mobile (result logging for AMRAP is tracked in #130).