### PR TITLE
fix: score Intervals workouts as reps, not time

### DIFF
--- a/apps/mobile/src/screens/LogResultScreen.tsx
+++ b/apps/mobile/src/screens/LogResultScreen.tsx
@@ -67,7 +67,7 @@ function loggingModeFor(workout: Workout): LoggingMode {
 }
 
 function scoreKindFor(workout: Workout): ScoreKind {
-  if (workout.type === 'AMRAP') return 'ROUNDS_REPS'
+  if (workout.type === 'AMRAP' || workout.type === 'INTERVALS') return 'ROUNDS_REPS'
   if (TYPE_CATEGORY[workout.type] === 'Metcon') return 'TIME'
   // MonoStructural — distance / cal / time all valid; pick by which
   // prescription the programmer filled in. Default to TIME.

--- a/apps/web/src/components/LogResultDrawer.test.tsx
+++ b/apps/web/src/components/LogResultDrawer.test.tsx
@@ -216,6 +216,23 @@ describe('LogResultDrawer — score-mode workouts', () => {
     expect(body.value.movementResults).toEqual([])
   })
 
+  test('INTERVALS shows reps input (not time) and posts ROUNDS_REPS score', async () => {
+    const w = makeWorkout({ type: 'INTERVALS', tracksRounds: false })
+    render(<LogResultDrawer workout={w} onClose={() => {}} onSaved={() => {}} />)
+
+    expect(screen.queryByLabelText(/^Min$/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/^Sec$/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/^Rounds$/i)).not.toBeInTheDocument()
+    expect(screen.getByLabelText(/^Reps$/i)).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText(/^Reps$/i), { target: { value: '45' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save Result' }))
+
+    await waitFor(() => expect(FETCH_MOCK).toHaveBeenCalledTimes(1))
+    const body = JSON.parse(FETCH_MOCK.mock.calls[0][1].body)
+    expect(body.value.score).toEqual({ kind: 'ROUNDS_REPS', reps: 45, cappedOut: false })
+  })
+
   test('FOR_TIME posts TIME score with collapsed seconds', async () => {
     const w = makeWorkout({ type: 'FOR_TIME' })
     render(<LogResultDrawer workout={w} onClose={() => {}} onSaved={() => {}} />)

--- a/apps/web/src/components/LogResultDrawer.tsx
+++ b/apps/web/src/components/LogResultDrawer.tsx
@@ -51,7 +51,7 @@ function loggingModeFor(workout: Workout): LoggingMode {
 }
 
 function scoreKindFor(workout: Workout): ScoreKind {
-  if (workout.type === 'AMRAP') return 'ROUNDS_REPS'
+  if (workout.type === 'AMRAP' || workout.type === 'INTERVALS') return 'ROUNDS_REPS'
   if (WORKOUT_TYPE_STYLES[workout.type].category === 'Metcon') return 'TIME'
   // MonoStructural — distance/cal/time all valid; pick by which prescription
   // the programmer filled in. Default to TIME.
@@ -172,7 +172,7 @@ export default function LogResultDrawer({ workout, existingResult, onClose, onSa
     }
     let score: Record<string, unknown> | undefined
     if (mode === 'score') {
-      const built = buildScore(scoreKind, scoreFields)
+      const built = buildScore(scoreKind, scoreFields, workout.tracksRounds)
       if (!built.ok) return built
       score = built.score
     }
@@ -748,13 +748,16 @@ function ScoreFields({
 
 type Result<T> = { ok: true } & T | { ok: false; error: string }
 
-function buildScore(kind: ScoreKind, f: ScoreFieldState): Result<{ score: Record<string, unknown> }> {
+function buildScore(kind: ScoreKind, f: ScoreFieldState, tracksRounds?: boolean): Result<{ score: Record<string, unknown> }> {
   if (kind === 'ROUNDS_REPS') {
-    const r = parseInt(f.rounds || '0', 10)
     const rp = parseInt(f.reps || '0', 10)
-    if (!Number.isInteger(r) || r < 0) return { ok: false, error: 'Rounds must be a non-negative number.' }
     if (!Number.isInteger(rp) || rp < 0) return { ok: false, error: 'Reps must be a non-negative number.' }
-    return { ok: true, score: { kind: 'ROUNDS_REPS', rounds: r, reps: rp, cappedOut: false } }
+    if (tracksRounds) {
+      const r = parseInt(f.rounds || '0', 10)
+      if (!Number.isInteger(r) || r < 0) return { ok: false, error: 'Rounds must be a non-negative number.' }
+      return { ok: true, score: { kind: 'ROUNDS_REPS', rounds: r, reps: rp, cappedOut: false } }
+    }
+    return { ok: true, score: { kind: 'ROUNDS_REPS', reps: rp, cappedOut: false } }
   }
   if (kind === 'TIME') {
     const m = parseInt(f.minutes || '0', 10)


### PR DESCRIPTION
## Summary

- `scoreKindFor` now returns `ROUNDS_REPS` for `INTERVALS` (alongside `AMRAP`), replacing the incorrect `TIME` fallback
- `buildScore` omits `rounds` from the stored score object when `tracksRounds` is false — so Intervals results are stored as `{ kind: 'ROUNDS_REPS', reps: N }` with no rounds field
- Same one-line fix applied to mobile (`LogResultScreen.tsx`) — `INTERVALS` added to the AMRAP special-case in `scoreKindFor`

## Tests

**Unit** (`apps/web/src/components/LogResultDrawer.test.tsx`):
- INTERVALS shows reps input (not time), no rounds input, posts `ROUNDS_REPS` score with reps only
- AMRAP with `tracksRounds=false` hides rounds input (existing)
- AMRAP with `tracksRounds=true` posts `ROUNDS_REPS` score with rounds + reps (existing)
- FOR_TIME posts TIME score (existing — regression guard)

**Not automated / manual verification needed:**
- [ ] Log a result on an Intervals workout in the browser and confirm only the Reps field appears
- [ ] Log a result on an Intervals workout in Expo Go and confirm the same

**Mobile parity:** fix applied to `apps/mobile/src/screens/LogResultScreen.tsx` in this same PR.