### PR TITLE
fix(web): resolve QA build errors in personal program scope

### DIFF
--- a/apps/web/src/components/WorkoutDrawer.tsx
+++ b/apps/web/src/components/WorkoutDrawer.tsx
@@ -198,6 +198,7 @@ function buildSnapshot(args: {
 
 export default function WorkoutDrawer({ scope, dateKey, workout, workoutsOnDay = [], userGymRole, defaultProgramId, onClose, onSaved, onAutoSaved, onReordered, onWorkoutSelect, onNewWorkout }: WorkoutDrawerProps) {
   const isOpen = dateKey !== null
+  const isGymScope = scope.kind === 'gym'
 
   const allMovements = useMovements()
   const [programs, setPrograms] = useState<Program[]>([])

--- a/apps/web/src/lib/personalProgramScope.ts
+++ b/apps/web/src/lib/personalProgramScope.ts
@@ -78,6 +78,9 @@ export function makePersonalProgramScope({ program }: PersonalScopeOpts): Progra
       return api.me.personalProgram.workouts.create(data)
     },
     updateWorkout: (workoutId, data) => api.workouts.update(workoutId, data),
+    // Personal workouts auto-publish on create; this is never reached from the
+    // UI (guarded by isGymScope), but satisfies the ProgramScope contract.
+    publishWorkout: (workoutId) => api.workouts.publish(workoutId),
     deleteWorkout: (workoutId) => api.workouts.delete(workoutId),
 
     // Personal programs aren't gym defaults — leave the optional methods


### PR DESCRIPTION
Two TypeScript errors broke the QA builder, both introduced by the personal-program feature branch that was merged to QA ahead of main.

## Changes

**`WorkoutDrawer.tsx`** — `isGymScope` was referenced at line 679 (guards the Draft/Published status badge and the publish footer button) but was never assigned in the cherry-picked version of the file. Added:
```ts
const isGymScope = scope.kind === 'gym'
```

**`personalProgramScope.ts`** — `publishWorkout` is a required method on the `ProgramScope` interface (added in the admin publish follow-up), but `makePersonalProgramScope` omitted it. Personal workouts auto-publish on create and the publish button is hidden from the UI when `isGymScope` is false, so this path is unreachable. Added it anyway to satisfy the type contract:
```ts
publishWorkout: (workoutId) => api.workouts.publish(workoutId),
```

## Tests

**Type check:**
- `tsc -b tsconfig.app.json --noEmit` passes clean in the worktree after fixes

**Not automated / manual verification needed:**
- [x] QA builder passes after merge and deploy

**Mobile parity:** desk-suitable admin fix — N/A on mobile.