### PR TITLE
feat(feed): + add-personal-workout button + segregated personal tiles

### DIFF
--- a/apps/web/src/components/icons/PersonalProgramIcon.tsx
+++ b/apps/web/src/components/icons/PersonalProgramIcon.tsx
@@ -1,0 +1,42 @@
+interface PersonalProgramIconProps {
+  size?: number
+  className?: string
+  /**
+   * Accessible label. When omitted the icon is rendered as decorative
+   * (`aria-hidden`); the consumer is expected to pair it with adjacent text.
+   */
+  title?: string
+}
+
+/**
+ * Single-person silhouette with a small "+" badge — reads as "extra work for
+ * just me" alongside the gym's class programming. Pairs visually with
+ * `UsersIcon` (multiple people = leaderboard / shared) so the contrast on the
+ * feed tiles is unambiguous.
+ */
+export default function PersonalProgramIcon({ size = 16, className, title }: PersonalProgramIconProps) {
+  const decorative = !title
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role={decorative ? undefined : 'img'}
+      aria-hidden={decorative ? true : undefined}
+      aria-label={title}
+      className={className}
+    >
+      {/* Single person */}
+      <circle cx={10} cy={8} r={3.2} />
+      <path d="M4 19c0-3.3 2.7-6 6-6s6 2.7 6 6" />
+      {/* Small "+" badge top-right corner — "you, plus extra" */}
+      <path d="M18 4v5" />
+      <path d="M15.5 6.5h5" />
+    </svg>
+  )
+}

--- a/apps/web/src/pages/Feed.test.tsx
+++ b/apps/web/src/pages/Feed.test.tsx
@@ -12,7 +12,22 @@ vi.mock('../lib/api', () => ({
     workouts: { list: vi.fn() },
     programs: { get: vi.fn() },
     gyms: { programs: { list: vi.fn() } },
+    me: {
+      personalProgram: {
+        get: vi.fn(),
+        workouts: { list: vi.fn(), create: vi.fn() },
+      },
+    },
+    namedWorkouts: { list: vi.fn() },
+    movements: { detect: vi.fn() },
   },
+  TYPE_ABBR: {
+    AMRAP: 'A', FOR_TIME: 'F', METCON: 'M', WARMUP: 'W',
+  },
+}))
+
+vi.mock('../context/MovementsContext.tsx', () => ({
+  useMovements: () => [] as { id: string; name: string; parentId: string | null }[],
 }))
 
 vi.mock('../context/GymContext.tsx', () => ({
@@ -113,9 +128,17 @@ function renderFeed() {
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
+// Most existing specs don't care about the personal-program upsert; default
+// it to a rejection so the page renders the same as before (add button stays
+// hidden). The personal-program-specific specs further down override this.
+beforeEach(() => {
+  vi.mocked(api.me.personalProgram.get).mockRejectedValue(new Error('not seeded'))
+})
+
 describe('Feed — programIds filter (slice 2)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(api.me.personalProgram.get).mockRejectedValue(new Error('not seeded'))
     vi.mocked(api.workouts.list).mockResolvedValue([] as never)
     mockFilter.selected = []
     mockFilter.available = [
@@ -164,6 +187,7 @@ describe('Feed — programIds filter (slice 2)', () => {
 describe('Feed — workout-type tokens', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(api.me.personalProgram.get).mockRejectedValue(new Error('not seeded'))
     mockFilter.selected = []
     mockFilter.available = []
   })
@@ -207,6 +231,7 @@ describe('Feed — workout-type tokens', () => {
 describe('Feed — empty-day tiles', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(api.me.personalProgram.get).mockRejectedValue(new Error('not seeded'))
     mockFilter.selected = []
     mockFilter.available = []
   })
@@ -265,6 +290,7 @@ describe('Feed — empty-day tiles', () => {
 describe('Feed — tile result badges', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(api.me.personalProgram.get).mockRejectedValue(new Error('not seeded'))
     mockFilter.selected = []
     mockFilter.available = []
   })
@@ -328,5 +354,79 @@ describe('Feed — tile result badges', () => {
     // The count "1" still appears (it counts the viewer too) — the design choice
     // is to always render N when N > 0 so the tile reflects the leaderboard size.
     expect(screen.getByText('1')).toBeInTheDocument()
+  })
+})
+
+describe('Feed — personal program', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFilter.selected = []
+    mockFilter.available = []
+    vi.mocked(api.me.personalProgram.get).mockResolvedValue({
+      id: 'pp-1',
+      name: 'Personal Program',
+      description: null,
+      startDate: '2026-05-01T00:00:00.000Z',
+      endDate: null,
+      coverColor: null,
+      visibility: 'PRIVATE',
+      ownerUserId: 'u-1',
+      createdAt: '2026-05-01T00:00:00.000Z',
+      updatedAt: '2026-05-01T00:00:00.000Z',
+      _count: { workouts: 1 },
+    })
+    vi.mocked(api.namedWorkouts.list).mockResolvedValue([] as never)
+    vi.mocked(api.movements.detect).mockResolvedValue([] as never)
+  })
+
+  it('shows the "+" add-personal-workout button on each day-header row', async () => {
+    vi.mocked(api.workouts.list).mockResolvedValue([] as never)
+    renderFeed()
+    // Wait for personalProgram to resolve so the button is rendered.
+    const buttons = await screen.findAllByRole('button', { name: /Add personal workout/i })
+    // At least one for TODAY; the feed renders a row per day in the visible window.
+    expect(buttons.length).toBeGreaterThan(0)
+  })
+
+  it('hides the "+" button when the personal-program upsert fails', async () => {
+    vi.mocked(api.me.personalProgram.get).mockRejectedValue(new Error('boom'))
+    vi.mocked(api.workouts.list).mockResolvedValue([] as never)
+    renderFeed()
+    expect(await screen.findByText('TODAY')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Add personal workout/i })).not.toBeInTheDocument()
+  })
+
+  it('sorts personal-program workouts after gym workouts and renders an "Extra work" divider', async () => {
+    const today = new Date()
+    today.setHours(12, 0, 0, 0)
+    const gymWorkout = {
+      ...makeWorkout('AMRAP', 0),
+      id: 'w-gym',
+      title: 'Class WOD',
+      programId: 'gym-prog-99',
+    }
+    const personalWorkout = {
+      ...makeWorkout('METCON', 0),
+      id: 'w-personal',
+      title: 'My extra row',
+      programId: 'pp-1',
+    }
+    vi.mocked(api.workouts.list).mockResolvedValue([gymWorkout, personalWorkout] as never)
+    renderFeed()
+
+    // Both tiles render
+    const classTile = await screen.findByRole('button', { name: /Class WOD/i })
+    const personalTile = await screen.findByRole('button', { name: /My extra row/i })
+    expect(classTile).toBeInTheDocument()
+    expect(personalTile).toBeInTheDocument()
+
+    // Personal tile renders AFTER the gym tile in DOM order.
+    const order = classTile.compareDocumentPosition(personalTile)
+    expect(order & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    // The "Extra work" divider only appears when both gym and personal tiles
+    // are present on the same day — this assertion is the load-bearing check
+    // that a personal tile is recognized as such.
+    expect(await screen.findByText(/Extra work/i)).toBeInTheDocument()
   })
 })

--- a/apps/web/src/pages/Feed.tsx
+++ b/apps/web/src/pages/Feed.tsx
@@ -1,12 +1,15 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { api, type Workout } from '../lib/api.ts'
+import { api, type PersonalProgram, type Workout } from '../lib/api.ts'
 import { WORKOUT_TYPE_STYLES } from '../lib/workoutTypeStyles.ts'
 import { useGym } from '../context/GymContext.tsx'
 import { useProgramFilter } from '../context/ProgramFilterContext.tsx'
+import { makePersonalProgramScope } from '../lib/personalProgramScope.ts'
 import Skeleton from '../components/ui/Skeleton.tsx'
 import BarbellIcon from '../components/icons/BarbellIcon.tsx'
 import UsersIcon from '../components/icons/UsersIcon.tsx'
+import PersonalProgramIcon from '../components/icons/PersonalProgramIcon.tsx'
+import WorkoutDrawer from '../components/WorkoutDrawer.tsx'
 
 const INITIAL_FUTURE_DAYS = 30
 const INITIAL_PAST_DAYS = 30
@@ -72,9 +75,17 @@ export default function Feed() {
   const [loading, setLoading] = useState(false)
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Personal program is upserted on first feed load so the day-header "+"
+  // button can open WorkoutDrawer with the personal scope without an extra
+  // round-trip on click. Failure is non-fatal — the button just stays hidden.
+  const [personalProgram, setPersonalProgram] = useState<PersonalProgram | null>(null)
+  // dateKey the drawer is open for (null = closed). Adding from the feed
+  // always targets the personal program; the date is inherited from the row.
+  const [addingForDate, setAddingForDate] = useState<string | null>(null)
   // Refs let loadMore read current values without needing them in its dep array,
   // so the IntersectionObserver doesn't reconnect on every page load.
   const fetchStartRef = useRef<Date | null>(null)
+  const fetchEndRef = useRef<Date | null>(null)
   const loadingMoreRef = useRef(false)
   const sentinelRef = useRef<HTMLDivElement>(null)
   const navigate = useNavigate()
@@ -90,6 +101,7 @@ export default function Feed() {
     setFetchStart(null)
     setFetchEnd(null)
     fetchStartRef.current = null
+    fetchEndRef.current = null
     loadingMoreRef.current = false
     const today = new Date()
     const from = addDays(today, -INITIAL_PAST_DAYS)
@@ -106,6 +118,7 @@ export default function Feed() {
         if (!cancelled) {
           setWorkouts(data.filter((w) => w.status === 'PUBLISHED'))
           fetchStartRef.current = from
+          fetchEndRef.current = to
           setFetchStart(from)
           setFetchEnd(to)
         }
@@ -113,6 +126,39 @@ export default function Feed() {
       .catch((e) => { if (!cancelled) setError((e as Error).message) })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
+  }, [gymId, programIdsKey])  // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Upsert the personal program once per session. Independent of the gym /
+  // program-filter loop above so the "+" button is available even before the
+  // workouts list resolves.
+  useEffect(() => {
+    let cancelled = false
+    api.me.personalProgram.get()
+      .then((p) => { if (!cancelled) setPersonalProgram(p) })
+      .catch(() => { /* non-fatal — add button stays hidden */ })
+    return () => { cancelled = true }
+  }, [])
+
+  const personalScope = useMemo(
+    () => personalProgram ? makePersonalProgramScope({ program: personalProgram }) : null,
+    [personalProgram],
+  )
+
+  // Re-query the visible window after a personal-program save so the new tile
+  // appears in its day group without a full page reload.
+  const reloadVisibleWindow = useCallback(async () => {
+    if (!gymId || !fetchStartRef.current || !fetchEndRef.current) return
+    try {
+      const data = await api.workouts.list(
+        gymId,
+        fetchStartRef.current.toISOString(),
+        fetchEndRef.current.toISOString(),
+        programIds.length ? { programIds } : undefined,
+      )
+      setWorkouts(data.filter((w) => w.status === 'PUBLISHED'))
+    } catch (e) {
+      setError((e as Error).message)
+    }
   }, [gymId, programIdsKey])  // eslint-disable-line react-hooks/exhaustive-deps
 
   const loadMore = useCallback(() => {
@@ -179,6 +225,14 @@ export default function Feed() {
     ? available.find(({ program }) => program.id === programIds[0])?.program ?? null
     : null
 
+  // Workouts on the day the drawer is open for — fed to the drawer's
+  // "today's workouts" nav so the user can hop between siblings.
+  const drawerWorkoutsOnDay = addingForDate
+    ? (dayBlocks.find((b) => b.dateKey === addingForDate)?.workouts ?? []).filter(
+        (w) => personalProgram && w.programId === personalProgram.id,
+      )
+    : []
+
   return (
     <div className="max-w-2xl mx-auto">
       {programIds.length > 0 && (
@@ -220,55 +274,148 @@ export default function Feed() {
       {loading && <Skeleton variant="feed-row" count={4} />}
 
       <div className="space-y-8">
-        {dayBlocks.map(({ dateKey, workouts: dayWorkouts }) => (
-          <div key={dateKey}>
-            <div className="flex items-center gap-3 mb-3">
-              <span className="text-xs font-semibold tracking-widest text-gray-400">
-                {formatDayLabel(dateKey, todayKey)}
-              </span>
-              <hr className="flex-1 border-gray-800" />
-            </div>
-
-            {dayWorkouts.length === 0 ? (
-              <p className="text-sm text-gray-500 pl-1">No workouts planned</p>
-            ) : (
-              <div className="space-y-2">
-                {dayWorkouts.map((workout) => {
-                  const styles = WORKOUT_TYPE_STYLES[workout.type]
-                  return (
-                    <button
-                      key={workout.id}
-                      onClick={() => navigate(`/workouts/${workout.id}`)}
-                      className={`w-full flex items-start gap-3 px-4 py-3 rounded-lg bg-gray-900 hover:bg-gray-800 transition-colors text-left group border-l-4 ${styles.accentBar}`}
-                    >
-                      <span className={`shrink-0 mt-0.5 w-7 h-6 flex items-center justify-center rounded text-xs font-bold ${styles.bg} ${styles.tint}`}>
-                        {styles.abbr}
-                      </span>
-                      <span className="flex-1 min-w-0">
-                        <span className="block text-sm font-medium text-white break-words">
-                          {workout.title}
-                        </span>
-                        {workout.namedWorkout && (
-                          <span className="text-xs text-indigo-400">● {workout.namedWorkout.name}</span>
-                        )}
-                        <FeedTileBadgeRow
-                          logged={Boolean(workout.myResultId)}
-                          resultCount={workout._count.results}
-                        />
-                      </span>
-                      <span className="shrink-0 mt-0.5 text-gray-400 group-hover:text-white transition-colors">›</span>
-                    </button>
-                  )
-                })}
+        {dayBlocks.map(({ dateKey, workouts: dayWorkouts }) => {
+          // Personal-program tiles always sort to the bottom of the day with
+          // a divider above them — readable as "your extra work, on top of
+          // the class programming". Detection is by program id (the personal
+          // program is upserted at mount and pinned to the user). Note:
+          // unaffiliated catalog workouts (e.g. CrossFit Mainsite) carry
+          // `programId !== null` but `!== personalProgramId`, so they stay
+          // grouped with the gym tiles — only the user's *own* program
+          // moves to the bottom.
+          const personalProgramId = personalProgram?.id ?? null
+          const gymTiles: Workout[] = []
+          const personalTiles: Workout[] = []
+          for (const w of dayWorkouts) {
+            if (personalProgramId !== null && w.programId === personalProgramId) {
+              personalTiles.push(w)
+            } else {
+              gymTiles.push(w)
+            }
+          }
+          return (
+            <div key={dateKey}>
+              <div className="flex items-center gap-3 mb-3">
+                <span className="text-xs font-semibold tracking-widest text-gray-400">
+                  {formatDayLabel(dateKey, todayKey)}
+                </span>
+                <hr className="flex-1 border-gray-800" />
+                {personalScope && (
+                  <button
+                    type="button"
+                    onClick={() => setAddingForDate(dateKey)}
+                    aria-label={`Add personal workout on ${formatDayLabel(dateKey, todayKey).toLowerCase()}`}
+                    title="Add personal workout"
+                    className="-my-1 -mr-1 w-7 h-7 inline-flex items-center justify-center rounded text-gray-400 hover:text-white hover:bg-gray-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
+                  >
+                    <span aria-hidden="true" className="text-base leading-none">+</span>
+                  </button>
+                )}
               </div>
-            )}
-          </div>
-        ))}
+
+              {gymTiles.length === 0 && personalTiles.length === 0 ? (
+                <p className="text-sm text-gray-500 pl-1">No workouts planned</p>
+              ) : (
+                <div className="space-y-2">
+                  {gymTiles.map((workout) => (
+                    <FeedTile key={workout.id} workout={workout} onClick={() => navigate(`/workouts/${workout.id}`)} />
+                  ))}
+
+                  {personalTiles.length > 0 && (
+                    <>
+                      {gymTiles.length > 0 && (
+                        <div
+                          className="flex items-center gap-2 pt-2 pb-0.5"
+                          aria-hidden="true"
+                        >
+                          <span className="h-px flex-1 bg-gray-800" />
+                          <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-widest text-gray-500">
+                            <PersonalProgramIcon size={12} />
+                            Extra work
+                          </span>
+                          <span className="h-px flex-1 bg-gray-800" />
+                        </div>
+                      )}
+                      {personalTiles.map((workout) => (
+                        <FeedTile
+                          key={workout.id}
+                          workout={workout}
+                          isPersonal
+                          onClick={() => navigate(`/workouts/${workout.id}`)}
+                        />
+                      ))}
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          )
+        })}
       </div>
 
       <div ref={sentinelRef} className="h-1" />
       {loadingMore && <Skeleton variant="feed-row" count={2} />}
+
+      {personalScope && (
+        <WorkoutDrawer
+          dateKey={addingForDate}
+          workout={undefined}
+          workoutsOnDay={drawerWorkoutsOnDay}
+          scope={personalScope}
+          // Personal-program drawer behaves like admin: one Save button, no
+          // DRAFT/PUBLISHED state, no inter-row reorder. Forced OWNER here is
+          // a no-op since canReorder also requires `kind === 'gym'` upstream.
+          userGymRole="OWNER"
+          defaultProgramId={personalProgram?.id}
+          onClose={() => setAddingForDate(null)}
+          onSaved={() => { setAddingForDate(null); reloadVisibleWindow() }}
+          onAutoSaved={reloadVisibleWindow}
+          onWorkoutSelect={() => { /* feed-add flow is single-row; no inter-day jump */ }}
+          onNewWorkout={() => { /* feed-add flow is single-row; no inter-day jump */ }}
+        />
+      )}
     </div>
+  )
+}
+
+interface FeedTileProps {
+  workout: Workout
+  isPersonal?: boolean
+  onClick: () => void
+}
+
+function FeedTile({ workout, isPersonal = false, onClick }: FeedTileProps) {
+  const styles = WORKOUT_TYPE_STYLES[workout.type]
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full flex items-start gap-3 px-4 py-3 rounded-lg bg-gray-900 hover:bg-gray-800 transition-colors text-left group border-l-4 ${styles.accentBar}`}
+    >
+      <span className={`shrink-0 mt-0.5 w-7 h-6 flex items-center justify-center rounded text-xs font-bold ${styles.bg} ${styles.tint}`}>
+        {styles.abbr}
+      </span>
+      <span className="flex-1 min-w-0">
+        <span className="block text-sm font-medium text-white break-words">
+          {isPersonal && (
+            <span
+              className="inline-flex items-center mr-1.5 text-indigo-400 align-text-bottom"
+              title="Personal Program — your own extra work"
+            >
+              <PersonalProgramIcon size={14} />
+            </span>
+          )}
+          {workout.title}
+        </span>
+        {workout.namedWorkout && (
+          <span className="text-xs text-indigo-400">● {workout.namedWorkout.name}</span>
+        )}
+        <FeedTileBadgeRow
+          logged={Boolean(workout.myResultId)}
+          resultCount={workout._count.results}
+        />
+      </span>
+      <span className="shrink-0 mt-0.5 text-gray-400 group-hover:text-white transition-colors">›</span>
+    </button>
   )
 }
 

--- a/apps/web/src/test/a11y.test.tsx
+++ b/apps/web/src/test/a11y.test.tsx
@@ -20,6 +20,12 @@ vi.mock('../lib/api', () => ({
     programs: { get: vi.fn() },
     namedWorkouts: { list: vi.fn() },
     movements: { list: vi.fn(), detect: vi.fn() },
+    me: {
+      personalProgram: {
+        get: vi.fn(),
+        workouts: { list: vi.fn(), create: vi.fn() },
+      },
+    },
   },
 }))
 
@@ -113,6 +119,7 @@ beforeEach(() => {
   vi.mocked(api.gyms.programs.list).mockResolvedValue([] as never)
   vi.mocked(api.namedWorkouts.list).mockResolvedValue([] as never)
   vi.mocked(api.movements.list).mockResolvedValue([] as never)
+  vi.mocked(api.me.personalProgram.get).mockRejectedValue(new Error('not seeded'))
 })
 
 // ─── Tests ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two pieces, both follow-ups to #210 / #183:

1. **Day-header rows now expose a right-aligned "+" button** that opens the shared `WorkoutDrawer` scoped to the user's personal program with the day's date pre-filled. Tapping the button on TODAY / TOMORROW / any past row spins up the same prescription editor the calendar uses, so the user can capture extra work without leaving the feed.

2. **Personal-program tiles segregate** within each day group. When a personal-program workout falls into a day that also has gym programming, the personal tiles sort to the bottom, separated from the gym tiles by a thin **"Extra work" divider** with a `PersonalProgramIcon` (single-person silhouette + "+" badge — pairs visually with `UsersIcon` on the leaderboard count). The personal tile's title is also prefixed with the same icon so the affordance is unambiguous on a day with only personal entries.

### Implementation notes

- Personal program is upserted on Feed mount via `api.me.personalProgram.get`. Failure is non-fatal — the "+" button stays hidden and the rest of the feed renders normally. Confirmed by the `hides the "+" button when the personal-program upsert fails` spec.
- The drawer's `personalScope` is built via the existing `makePersonalProgramScope` factory introduced in #210 — no new abstraction. After save, `reloadVisibleWindow` re-queries the active fetch range so the new tile appears in its day group without a full reload.
- `gymTiles` / `personalTiles` partition is null-safe: when no personal program is loaded, every workout (including unaffiliated CrossFit Mainsite catalog rows with `programId !== null`) flows through the gym-tile path. An earlier draft mis-bucketed `programId: null` workouts when `personalProgramId` was also null.

### Files

- `apps/web/src/components/icons/PersonalProgramIcon.tsx` (new) — single-person + "+" badge SVG, mirrors the shape of `UsersIcon` / `BarbellIcon`.
- `apps/web/src/pages/Feed.tsx` — drawer mount, "+" button on day headers, gym/personal partition + divider.
- `apps/web/src/pages/Feed.test.tsx` — 3 new specs covering the new behaviors.
- `apps/web/src/test/a11y.test.tsx` — extended the api mock to include `me.personalProgram` so the page-level axe check still mounts.

## Tests

**Unit** (`apps/web/src/pages/Feed.test.tsx` — 18 tests, all pass):

3 new specs in the `Feed — personal program` describe block:
- `shows the "+" add-personal-workout button on each day-header row` — asserts at least one `getByRole('button', { name: /Add personal workout/i })` after the personal-program upsert resolves.
- `hides the "+" button when the personal-program upsert fails` — when `api.me.personalProgram.get` rejects, no add button renders. The TODAY label still appears, confirming the rest of the feed is unaffected.
- `sorts personal-program workouts after gym workouts and renders an "Extra work" divider` — seeds a gym workout (`programId: 'gym-prog-99'`) and a personal workout (`programId: 'pp-1'`) on the same day; asserts both tiles render, the personal tile follows the gym tile in DOM order (`compareDocumentPosition & DOCUMENT_POSITION_FOLLOWING`), and the "Extra work" divider is present.

The 15 pre-existing Feed specs still pass — the `programId: null` partition fix above is what kept them green.

**Full vitest suite:** 202/202 passing across 27 files.

**Playwright E2E:** 40/42 — same two pre-existing flakes we've seen all session (`programs.spec.ts:277` Browse→Join strict-mode collision; `admin-programs.spec.ts:138` non-admin sidebar passes in isolation). Neither is caused by this PR.

**Mobile parity:** Mobile sibling tracked under #183 — the cross-app contract (route `/feed`, the `+` add affordance, the personal-tile sort order) is the shape mobile will mirror.

**Roles tested:** any authenticated user — the personal-program upsert isn't gym-role-gated. Confirmed unit-side that the button is hidden when the upsert fails (covers users without a personal program for any reason).

**Not automated / manual verification needed:**
- [ ] Visual check on the divider styling — verify the "Extra work" eyebrow is legible at the smallest text size against the gray-950 page background.

Part of #183