### PR TITLE
feat(dashboard): slice 1 — WOD Hero Card + Today page scaffold

### DIFF
--- a/apps/api/src/db/dashboardDbManager.ts
+++ b/apps/api/src/db/dashboardDbManager.ts
@@ -1,0 +1,99 @@
+import { prisma } from '@wodalytics/db'
+import type { WorkoutType } from '@wodalytics/db'
+import { findLeaderboardByWorkout } from './resultDbManager.js'
+
+// Warmup and recovery types are deprioritised — prefer a real conditioning
+// or strength piece as the hero workout for the day.
+const RECOVERY_TYPES: WorkoutType[] = ['WARMUP', 'MOBILITY', 'COOLDOWN']
+
+function todayUtcRange() {
+  const now = new Date()
+  const dayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+  const dayEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1))
+  return { dayStart, dayEnd }
+}
+
+const workoutInclude = {
+  program: { select: { id: true, name: true } },
+  namedWorkout: { select: { id: true, name: true, category: true } },
+  workoutMovements: {
+    include: { movement: { select: { id: true, name: true, parentId: true } } },
+    orderBy: { displayOrder: 'asc' as const },
+  },
+  _count: { select: { results: true } },
+} as const
+
+async function findTodaysHeroWorkout(gymId: string, userId: string) {
+  const { dayStart, dayEnd } = todayUtcRange()
+
+  const baseWhere = {
+    scheduledAt: { gte: dayStart, lt: dayEnd },
+    status: 'PUBLISHED' as const,
+    OR: [
+      { program: { gyms: { some: { gymId } } } },
+      {
+        program: {
+          gyms: { none: {} },
+          members: { some: { userId } },
+        },
+      },
+    ],
+  }
+
+  const preferred = await prisma.workout.findFirst({
+    where: { ...baseWhere, type: { notIn: RECOVERY_TYPES } },
+    orderBy: [{ dayOrder: 'asc' }, { createdAt: 'asc' }],
+    include: workoutInclude,
+  })
+  if (preferred) return preferred
+
+  return prisma.workout.findFirst({
+    where: baseWhere,
+    orderBy: [{ dayOrder: 'asc' }, { createdAt: 'asc' }],
+    include: workoutInclude,
+  })
+}
+
+export async function getDashboardToday(gymId: string, userId: string) {
+  const [workout, gymMemberCount] = await Promise.all([
+    findTodaysHeroWorkout(gymId, userId),
+    prisma.userGym.count({ where: { gymId } }),
+  ])
+
+  if (!workout) {
+    return { workout: null, myResult: null, leaderboard: null, gymMemberCount }
+  }
+
+  const [myResult, allResults] = await Promise.all([
+    prisma.result.findUnique({
+      where: { userId_workoutId: { userId, workoutId: workout.id } },
+      select: {
+        id: true,
+        value: true,
+        level: true,
+        workoutGender: true,
+        primaryScoreKind: true,
+        primaryScoreValue: true,
+        createdAt: true,
+        notes: true,
+      },
+    }),
+    findLeaderboardByWorkout(workout.id, {}),
+  ])
+
+  const userRank = myResult ? allResults.findIndex((r) => r.userId === userId) + 1 : null
+
+  return {
+    workout,
+    myResult,
+    leaderboard: {
+      rank: userRank,
+      totalLogged: allResults.length,
+      percentile:
+        userRank && allResults.length > 0
+          ? Math.round((1 - userRank / allResults.length) * 100)
+          : null,
+    },
+    gymMemberCount,
+  }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,6 +16,7 @@ import membershipRequestsRouter from './routes/membershipRequests'
 import avatarRouter from './routes/avatar'
 import gymLogoRouter from './routes/gymLogo'
 import adminRouter from './routes/admin'
+import dashboardRouter from './routes/dashboard'
 import { createLogger } from './lib/logger.js'
 import { requestLogger } from './middleware/requestLogger.js'
 
@@ -68,6 +69,7 @@ app.use('/api', membershipRequestsRouter)
 app.use('/api', avatarRouter)
 app.use('/api', gymLogoRouter)
 app.use('/api', adminRouter)
+app.use('/api', dashboardRouter)
 
 // Static-file route for the LocalFsImageStorage backend (dev-only). When
 // AWS_S3_BUCKET is set we never write here; the route is harmless to leave

--- a/apps/api/src/routes/dashboard.ts
+++ b/apps/api/src/routes/dashboard.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express'
+import type { Request, Response } from 'express'
+import { requireAuth } from '../middleware/auth.js'
+import { validateGymExists, requireGymMembership } from '../middleware/gym.js'
+import { getDashboardToday as getDashboardTodayDb } from '../db/dashboardDbManager.js'
+
+const router = Router()
+
+router.get('/gyms/:gymId/dashboard/today', requireAuth, validateGymExists, requireGymMembership, getDashboardToday)
+
+export default router
+
+async function getDashboardToday(req: Request, res: Response) {
+  const data = await getDashboardTodayDb(req.params.gymId as string, req.user!.id)
+  res.json(data)
+}

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -7,6 +7,7 @@ import { AuthProvider, useAuth } from './src/context/AuthContext'
 import { GymProvider } from './src/context/GymContext'
 import { ProgramFilterProvider } from './src/context/ProgramFilterContext'
 import LoginScreen from './src/screens/LoginScreen'
+import HomeScreen from './src/screens/HomeScreen'
 import FeedScreen from './src/screens/FeedScreen'
 import WodDetailScreen from './src/screens/WodDetailScreen'
 import HistoryScreen from './src/screens/HistoryScreen'
@@ -24,8 +25,13 @@ export type RootStackParamList = {
 }
 
 export type MainTabParamList = {
+  HomeTab: undefined
   FeedTab: undefined
   HistoryTab: undefined
+}
+
+export type HomeStackParamList = {
+  Home: undefined
 }
 
 export type FeedStackParamList = {
@@ -40,6 +46,7 @@ export type HistoryStackParamList = {
 
 const RootStack = createStackNavigator<RootStackParamList>()
 const Tab = createBottomTabNavigator<MainTabParamList>()
+const HomeStack = createStackNavigator<HomeStackParamList>()
 const FeedStack = createStackNavigator<FeedStackParamList>()
 const HistoryStack = createStackNavigator<HistoryStackParamList>()
 
@@ -48,6 +55,14 @@ const stackScreenOptions = {
   headerTintColor: '#ffffff',
   headerTitleStyle: { fontWeight: '600' as const },
   cardStyle: { backgroundColor: '#030712' },
+}
+
+function HomeStackNavigator() {
+  return (
+    <HomeStack.Navigator screenOptions={stackScreenOptions}>
+      <HomeStack.Screen name="Home" component={HomeScreen} options={{ title: 'Today' }} />
+    </HomeStack.Navigator>
+  )
 }
 
 function FeedStackNavigator() {
@@ -76,6 +91,7 @@ function MainTabs() {
         tabBarInactiveTintColor: '#6b7280',
       }}
     >
+      <Tab.Screen name="HomeTab" component={HomeStackNavigator} options={{ title: 'Today' }} />
       <Tab.Screen name="FeedTab" component={FeedStackNavigator} options={{ title: 'Feed' }} />
       <Tab.Screen name="HistoryTab" component={HistoryStackNavigator} options={{ title: 'History' }} />
     </Tab.Navigator>

--- a/apps/mobile/src/components/WodHeroCard.tsx
+++ b/apps/mobile/src/components/WodHeroCard.tsx
@@ -1,0 +1,313 @@
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
+import type { StackNavigationProp } from '@react-navigation/stack'
+import type { RootStackParamList } from '../../App'
+import { styleFor } from '../lib/workoutTypeStyles'
+import { formatResultValue } from '../lib/format'
+import type { DashboardToday } from '../lib/api'
+
+type Nav = StackNavigationProp<RootStackParamList>
+
+const LEVEL_LABELS: Record<string, string> = {
+  RX_PLUS: 'RX+',
+  RX: 'RX',
+  SCALED: 'Scaled',
+  MODIFIED: 'Modified',
+}
+
+function formatCap(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  return `${m} min cap`
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+}
+
+type Props = {
+  data: DashboardToday
+}
+
+export default function WodHeroCard({ data }: Props) {
+  const nav = useNavigation<Nav>()
+  const { workout, myResult, leaderboard, gymMemberCount } = data
+
+  if (!workout) {
+    return (
+      <View style={styles.card}>
+        <Text style={styles.emptyTitle}>No workout today</Text>
+        <Text style={styles.emptyBody}>Your program doesn't have a workout scheduled for today.</Text>
+      </View>
+    )
+  }
+
+  const ts = styleFor(workout.type)
+  const scored = myResult ? formatResultValue(myResult.value as Parameters<typeof formatResultValue>[0]) : null
+  const levelLabel = myResult ? (LEVEL_LABELS[myResult.level] ?? myResult.level) : null
+
+  function goToWod() {
+    nav.navigate('WodDetail', { workoutId: workout!.id })
+  }
+
+  return (
+    <View style={styles.card}>
+      {/* Accent strip */}
+      <View style={[styles.accentStrip, { backgroundColor: ts.accentBar }]} />
+
+      {/* Header */}
+      <View style={styles.headerRow}>
+        <Text style={styles.dateLabel}>TODAY</Text>
+        <View style={[styles.typeBadge, { backgroundColor: ts.bgTint }]}>
+          <Text style={[styles.typeBadgeText, { color: ts.tint }]}>{ts.abbr}</Text>
+        </View>
+        {workout.namedWorkout?.category === 'BENCHMARK' && (
+          <View style={styles.benchmarkBadge}>
+            <Text style={styles.benchmarkBadgeText}>BENCHMARK</Text>
+          </View>
+        )}
+      </View>
+
+      {/* Title */}
+      <TouchableOpacity onPress={goToWod} activeOpacity={0.7}>
+        <Text style={styles.title}>{workout.title}</Text>
+      </TouchableOpacity>
+
+      {workout.timeCapSeconds ? (
+        <Text style={styles.cap}>{formatCap(workout.timeCapSeconds)}</Text>
+      ) : null}
+
+      {workout.program ? (
+        <Text style={styles.program}>via {workout.program.name}</Text>
+      ) : null}
+
+      {/* Result or CTAs */}
+      <View style={styles.resultRow}>
+        {myResult ? (
+          <View style={styles.resultCard}>
+            <Text style={styles.loggedLabel}>✓ Logged · {formatTime(myResult.createdAt)}</Text>
+            <View style={styles.scoreRow}>
+              <Text style={styles.score}>{scored ?? '—'}</Text>
+              {levelLabel ? <Text style={styles.level}>{levelLabel}</Text> : null}
+              {leaderboard?.rank ? (
+                <Text style={styles.rank}>#{leaderboard.rank}/{leaderboard.totalLogged}</Text>
+              ) : null}
+            </View>
+          </View>
+        ) : (
+          <View style={styles.ctaRow}>
+            <TouchableOpacity style={styles.ctaPrimary} onPress={goToWod} activeOpacity={0.8}>
+              <Text style={styles.ctaPrimaryText}>Start workout</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.ctaSecondary} onPress={goToWod} activeOpacity={0.8}>
+              <Text style={styles.ctaSecondaryText}>Log result</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+
+      {/* Details tap-through */}
+      <TouchableOpacity onPress={goToWod} activeOpacity={0.7} style={styles.detailsLink}>
+        <Text style={styles.detailsLinkText}>View workout details →</Text>
+      </TouchableOpacity>
+
+      {/* Footer */}
+      <View style={styles.footer}>
+        <Text style={styles.footerText}>
+          <Text style={styles.footerCount}>{leaderboard?.totalLogged ?? 0}</Text>
+          {gymMemberCount > 0 ? ` of ${gymMemberCount}` : ''} members logged today
+        </Text>
+        <TouchableOpacity onPress={goToWod} activeOpacity={0.7}>
+          <Text style={styles.boardLink}>Leaderboard →</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#111827',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#1f2937',
+    overflow: 'hidden',
+    marginBottom: 4,
+  },
+  accentStrip: {
+    height: 3,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingTop: 14,
+    paddingBottom: 8,
+    flexWrap: 'wrap',
+  },
+  dateLabel: {
+    fontSize: 10,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    color: '#6b7280',
+    textTransform: 'uppercase',
+  },
+  typeBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 6,
+  },
+  typeBadgeText: {
+    fontSize: 10,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+  },
+  benchmarkBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 6,
+    backgroundColor: 'rgba(99,102,241,0.15)',
+  },
+  benchmarkBadgeText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#a5b4fc',
+    letterSpacing: 0.5,
+  },
+  title: {
+    fontSize: 26,
+    fontWeight: '700',
+    color: '#ffffff',
+    letterSpacing: -0.5,
+    lineHeight: 30,
+    paddingHorizontal: 16,
+    marginBottom: 4,
+  },
+  cap: {
+    fontSize: 13,
+    color: '#9ca3af',
+    paddingHorizontal: 16,
+    marginBottom: 2,
+  },
+  program: {
+    fontSize: 12,
+    color: '#6b7280',
+    paddingHorizontal: 16,
+    marginBottom: 12,
+  },
+  resultRow: {
+    paddingHorizontal: 16,
+    marginBottom: 10,
+  },
+  resultCard: {
+    backgroundColor: 'rgba(55,65,81,0.5)',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#374151',
+    padding: 12,
+  },
+  loggedLabel: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#34d399',
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+    marginBottom: 6,
+  },
+  scoreRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 8,
+  },
+  score: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#ffffff',
+    letterSpacing: -0.5,
+  },
+  level: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#818cf8',
+  },
+  rank: {
+    fontSize: 12,
+    color: '#9ca3af',
+    marginLeft: 'auto',
+  },
+  ctaRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  ctaPrimary: {
+    flex: 1,
+    backgroundColor: '#4f46e5',
+    borderRadius: 10,
+    paddingVertical: 11,
+    alignItems: 'center',
+  },
+  ctaPrimaryText: {
+    color: '#ffffff',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  ctaSecondary: {
+    flex: 1,
+    backgroundColor: '#1f2937',
+    borderRadius: 10,
+    paddingVertical: 11,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#374151',
+  },
+  ctaSecondaryText: {
+    color: '#d1d5db',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  detailsLink: {
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+  },
+  detailsLinkText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#818cf8',
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderTopWidth: 1,
+    borderTopColor: '#1f2937',
+  },
+  footerText: {
+    fontSize: 13,
+    color: '#6b7280',
+  },
+  footerCount: {
+    color: '#ffffff',
+    fontWeight: '600',
+  },
+  boardLink: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#818cf8',
+  },
+  emptyTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#d1d5db',
+    padding: 20,
+    textAlign: 'center',
+  },
+  emptyBody: {
+    fontSize: 13,
+    color: '#6b7280',
+    paddingHorizontal: 20,
+    paddingBottom: 20,
+    textAlign: 'center',
+  },
+})

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -114,6 +114,30 @@ export interface Workout {
   externalSourceId: string | null
 }
 
+export interface DashboardTodayResult {
+  id: string
+  value: ResultValue
+  level: WorkoutLevel
+  workoutGender: WorkoutGender
+  primaryScoreKind: string | null
+  primaryScoreValue: number | null
+  createdAt: string
+  notes: string | null
+}
+
+export interface DashboardLeaderboard {
+  rank: number | null
+  totalLogged: number
+  percentile: number | null
+}
+
+export interface DashboardToday {
+  workout: (Workout & { program: { id: string; name: string } | null; namedWorkout: { id: string; name: string; category: string } | null; _count: { results: number } }) | null
+  myResult: DashboardTodayResult | null
+  leaderboard: DashboardLeaderboard | null
+  gymMemberCount: number
+}
+
 export interface LeaderboardEntry {
   id: string
   user: { id: string; name: string; birthday: string | null }
@@ -258,6 +282,11 @@ export const api = {
   },
 
   gyms: {
+    dashboard: {
+      today: (gymId: string) =>
+        request<DashboardToday>(`/api/gyms/${gymId}/dashboard/today`),
+    },
+
     workouts: (gymId: string, from: string, to: string, programIds?: string[]) => {
       const qs = new URLSearchParams({ from, to })
       if (programIds?.length) qs.set('programIds', programIds.join(','))

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useState } from 'react'
+import { View, Text, ScrollView, RefreshControl, StyleSheet } from 'react-native'
+import { useFocusEffect } from '@react-navigation/native'
+import { api, type DashboardToday } from '../lib/api'
+import { useGym } from '../context/GymContext'
+import { useAuth } from '../context/AuthContext'
+import WodHeroCard from '../components/WodHeroCard'
+
+function greetingFor(firstName: string | null | undefined): string {
+  const hour = new Date().getHours()
+  const period = hour < 12 ? 'morning' : hour < 17 ? 'afternoon' : 'evening'
+  return firstName ? `Good ${period}, ${firstName}` : `Good ${period}`
+}
+
+export default function HomeScreen() {
+  const { gymId } = useGym()
+  const { user } = useAuth()
+  const [data, setData] = useState<DashboardToday | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function load(quiet = false) {
+    if (!gymId) return
+    if (!quiet) setLoading(true)
+    setError(null)
+    try {
+      const result = await api.gyms.dashboard.today(gymId)
+      setData(result)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load')
+    } finally {
+      setLoading(false)
+      setRefreshing(false)
+    }
+  }
+
+  useFocusEffect(
+    useCallback(() => {
+      load()
+    }, [gymId]),
+  )
+
+  function onRefresh() {
+    setRefreshing(true)
+    load(true)
+  }
+
+  const greeting = greetingFor(user?.name)
+
+  return (
+    <ScrollView
+      style={styles.root}
+      contentContainerStyle={styles.content}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#818cf8" />}
+    >
+      <Text style={styles.greeting}>{greeting}</Text>
+
+      {loading && !refreshing && (
+        <View style={styles.loadingCard}>
+          <View style={styles.loadingShimmer} />
+          <View style={[styles.loadingShimmer, { width: '70%', marginTop: 8 }]} />
+        </View>
+      )}
+
+      {!loading && error && (
+        <View style={styles.errorCard}>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      )}
+
+      {!loading && data && (
+        <WodHeroCard data={data} />
+      )}
+
+      {/* Social feed placeholder — deferred until social features are scoped */}
+      <View style={styles.socialPlaceholder}>
+        <Text style={styles.socialPlaceholderText}>Social feed coming soon</Text>
+      </View>
+    </ScrollView>
+  )
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#030712',
+  },
+  content: {
+    padding: 14,
+    gap: 12,
+  },
+  greeting: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#ffffff',
+    letterSpacing: -0.3,
+    marginBottom: 4,
+  },
+  loadingCard: {
+    backgroundColor: '#111827',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#1f2937',
+    padding: 20,
+    minHeight: 120,
+  },
+  loadingShimmer: {
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: '#1f2937',
+    width: '90%',
+  },
+  errorCard: {
+    backgroundColor: '#111827',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#1f2937',
+    padding: 20,
+  },
+  errorText: {
+    fontSize: 14,
+    color: '#9ca3af',
+  },
+  socialPlaceholder: {
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#1f2937',
+    borderStyle: 'dashed',
+    paddingVertical: 30,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  socialPlaceholderText: {
+    fontSize: 13,
+    color: '#4b5563',
+  },
+})

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -13,19 +13,19 @@ function greetingFor(firstName: string | null | undefined): string {
 }
 
 export default function HomeScreen() {
-  const { gymId } = useGym()
+  const { activeGym } = useGym()
   const { user } = useAuth()
   const [data, setData] = useState<DashboardToday | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   async function load(quiet = false) {
-    if (!gymId) return
+    if (!activeGym) return
     if (!quiet) setLoading(true)
     setError(null)
     try {
-      const result = await api.gyms.dashboard.today(gymId)
+      const result = await api.gyms.dashboard.today(activeGym.id)
       setData(result)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load')
@@ -38,7 +38,7 @@ export default function HomeScreen() {
   useFocusEffect(
     useCallback(() => {
       load()
-    }, [gymId]),
+    }, [activeGym]),
   )
 
   function onRefresh() {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -68,7 +68,7 @@ function AppLayout() {
         <main className="flex-1 overflow-y-auto overflow-x-hidden p-4 md:p-8">
           <ErrorBoundary FallbackComponent={PageErrorFallback} resetKeys={[window.location.pathname]}>
             <Routes>
-              <Route path="/" element={<Navigate to="/feed" replace />} />
+              <Route path="/" element={<Navigate to="/dashboard" replace />} />
               <Route path="/feed" element={<Feed />} />
               <Route path="/workouts/:id" element={<WodDetail />} />
               <Route path="/workouts/:id/results/:resultId" element={<WodResultDetail />} />

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import ProgramFilterPicker from './ProgramFilterPicker.tsx'
 
 // Browse Gyms moved into the TopBar gym picker — no standalone sidebar entry.
 const memberLinks = [
+  { to: '/dashboard',        label: 'Dashboard'        },
   { to: '/feed',             label: 'Feed'             },
   { to: '/history',          label: 'History'          },
   { to: '/personal-program', label: 'Personal Program' },

--- a/apps/web/src/components/WodHeroCard.test.tsx
+++ b/apps/web/src/components/WodHeroCard.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import WodHeroCard from './WodHeroCard'
+import type { Workout, DashboardTodayResult, DashboardLeaderboard } from '../lib/api'
+
+const baseWorkout: Workout = {
+  id: 'w1',
+  title: 'Helen',
+  description: '3 rounds for time:\n400m run, 21 KB swings, 12 pull-ups',
+  coachNotes: null,
+  type: 'FOR_TIME',
+  status: 'PUBLISHED',
+  scheduledAt: new Date().toISOString(),
+  dayOrder: 0,
+  workoutMovements: [
+    {
+      movement: { id: 'm1', name: 'Run', parentId: null },
+      displayOrder: 0,
+      sets: null, reps: null, load: null, loadUnit: null,
+      tracksLoad: false, tempo: null, distance: 400, distanceUnit: 'M',
+      calories: null, seconds: null,
+    },
+    {
+      movement: { id: 'm2', name: 'Kettlebell Swing', parentId: null },
+      displayOrder: 1,
+      sets: 3, reps: '21', load: 24, loadUnit: 'KG',
+      tracksLoad: true, tempo: null, distance: null, distanceUnit: null,
+      calories: null, seconds: null,
+    },
+  ],
+  programId: 'p1',
+  program: { id: 'p1', name: 'Main WOD' },
+  namedWorkoutId: 'nw1',
+  namedWorkout: { id: 'nw1', name: 'Helen', category: 'GIRL_WOD' },
+  timeCapSeconds: 900,
+  tracksRounds: false,
+  _count: { results: 12 },
+  externalSourceId: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+const baseLeaderboard: DashboardLeaderboard = {
+  rank: 5,
+  totalLogged: 20,
+  percentile: 80,
+}
+
+const baseResult: DashboardTodayResult = {
+  id: 'r1',
+  value: { score: { kind: 'TIME', seconds: 462, cappedOut: false } },
+  level: 'RX',
+  workoutGender: 'OPEN',
+  primaryScoreKind: 'TIME',
+  primaryScoreValue: 462,
+  createdAt: new Date().toISOString(),
+  notes: null,
+}
+
+function renderCard(props: Partial<Parameters<typeof WodHeroCard>[0]> = {}) {
+  return render(
+    <MemoryRouter>
+      <WodHeroCard
+        workout={baseWorkout}
+        myResult={null}
+        leaderboard={{ rank: null, totalLogged: 0, percentile: null }}
+        gymMemberCount={50}
+        {...props}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('WodHeroCard', () => {
+  it('renders workout title', () => {
+    renderCard()
+    expect(screen.getByText('Helen')).toBeInTheDocument()
+  })
+
+  it('shows type badge', () => {
+    renderCard()
+    expect(screen.getByText('FT')).toBeInTheDocument()
+  })
+
+  it('shows time cap', () => {
+    renderCard()
+    expect(screen.getByText('15 min cap')).toBeInTheDocument()
+  })
+
+  it('shows program attribution', () => {
+    renderCard()
+    expect(screen.getByText('via Main WOD')).toBeInTheDocument()
+  })
+
+  it('shows CTA buttons when not logged', () => {
+    renderCard()
+    expect(screen.getByText('Start workout')).toBeInTheDocument()
+    expect(screen.getByText('Log result')).toBeInTheDocument()
+  })
+
+  it('shows result card when logged', () => {
+    renderCard({ myResult: baseResult, leaderboard: baseLeaderboard })
+    expect(screen.getByText('7:42')).toBeInTheDocument()
+    expect(screen.getByText('RX')).toBeInTheDocument()
+    expect(screen.queryByText('Start workout')).not.toBeInTheDocument()
+  })
+
+  it('shows rank and total when logged', () => {
+    renderCard({ myResult: baseResult, leaderboard: baseLeaderboard })
+    expect(screen.getByText(/#5/)).toBeInTheDocument()
+  })
+
+  it('shows participant count in footer', () => {
+    renderCard({ leaderboard: baseLeaderboard })
+    // count is in a styled child span; RTL getByText only matches direct text nodes
+    expect(screen.getByText('20')).toBeInTheDocument()
+    expect(screen.getByText(/members logged today/)).toBeInTheDocument()
+  })
+
+  it('shows gym member total in footer when gymMemberCount > 0', () => {
+    renderCard({ leaderboard: baseLeaderboard, gymMemberCount: 50 })
+    expect(screen.getByText(/of 50/)).toBeInTheDocument()
+  })
+
+  it('renders workout description on desktop (not compact)', () => {
+    renderCard()
+    expect(screen.getByText(/3 rounds for time/)).toBeInTheDocument()
+  })
+
+  it('renders compact view without workout blocks', () => {
+    renderCard({ compact: true })
+    expect(screen.queryByText(/3 rounds for time/)).not.toBeInTheDocument()
+    expect(screen.getByText('View workout details →')).toBeInTheDocument()
+  })
+
+  it('shows movement list on desktop', () => {
+    renderCard()
+    expect(screen.getByText('Kettlebell Swing')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/WodHeroCard.tsx
+++ b/apps/web/src/components/WodHeroCard.tsx
@@ -1,0 +1,224 @@
+import { Link } from 'react-router-dom'
+import { WORKOUT_TYPE_STYLES } from '../lib/workoutTypeStyles.ts'
+import { formatResultValue } from '../lib/formatResult.ts'
+import Button from './ui/Button.tsx'
+import type { Workout, DashboardTodayResult, DashboardLeaderboard } from '../lib/api.ts'
+
+interface Props {
+  workout: Workout
+  myResult: DashboardTodayResult | null
+  leaderboard: DashboardLeaderboard | null
+  gymMemberCount: number
+  compact?: boolean
+}
+
+const LEVEL_LABELS: Record<string, string> = {
+  RX_PLUS: 'RX+',
+  RX: 'RX',
+  SCALED: 'Scaled',
+  MODIFIED: 'Modified',
+}
+
+function formatDateHeader(scheduledAt: string): string {
+  const d = new Date(scheduledAt)
+  const day = d.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase()
+  const month = d.toLocaleDateString('en-US', { month: 'short' }).toUpperCase()
+  const date = d.getUTCDate()
+  const todayUtc = new Date().toISOString().slice(0, 10)
+  const isToday = scheduledAt.slice(0, 10) === todayUtc
+  return `${day} · ${month} ${date}${isToday ? ' · TODAY' : ''}`
+}
+
+function formatCap(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return s === 0 ? `${m} min cap` : `${m}:${String(s).padStart(2, '0')} cap`
+}
+
+export default function WodHeroCard({ workout, myResult, leaderboard, gymMemberCount, compact = false }: Props) {
+  const typeStyle = WORKOUT_TYPE_STYLES[workout.type]
+  const scored = myResult ? formatResultValue(myResult.value) : null
+  const levelLabel = myResult ? (LEVEL_LABELS[myResult.level] ?? myResult.level) : null
+
+  return (
+    <article
+      className={`bg-gray-900 border border-gray-800 rounded-2xl overflow-hidden ${compact ? 'p-4' : 'p-6 md:p-7'}`}
+      aria-label={`Today's workout: ${workout.title}`}
+    >
+      {/* Accent strip */}
+      <div className={`-mt-4 -mx-4 mb-4 h-1 ${typeStyle.accentBar.replace('border', 'bg')} md:-mt-7 md:-mx-7 md:mb-6`} aria-hidden="true" />
+
+      {/* Header row: date + badges */}
+      <div className="flex items-center gap-2 flex-wrap mb-3">
+        <span className="text-[11px] font-bold tracking-[0.1em] text-gray-400 uppercase">
+          {formatDateHeader(workout.scheduledAt)}
+        </span>
+        <span className={`text-xs font-bold px-2 py-0.5 rounded ${typeStyle.tint} ${typeStyle.bg}`}>
+          {typeStyle.abbr}
+        </span>
+        {workout.namedWorkout?.category === 'BENCHMARK' && (
+          <span className="text-xs font-bold px-2 py-0.5 rounded text-indigo-300 bg-indigo-500/15">
+            BENCHMARK
+          </span>
+        )}
+      </div>
+
+      {/* Title row */}
+      <div className={`flex items-start justify-between gap-4 ${compact ? 'flex-col' : 'md:flex-row flex-col'} mb-4`}>
+        <div className="min-w-0">
+          <h2 className={`font-bold tracking-tight text-white leading-tight ${compact ? 'text-2xl' : 'text-3xl md:text-4xl'}`}>
+            <Link
+              to={`/workouts/${workout.id}`}
+              className="hover:text-indigo-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 rounded"
+            >
+              {workout.title}
+            </Link>
+          </h2>
+          {workout.timeCapSeconds && (
+            <p className="mt-1 text-sm text-gray-400">{formatCap(workout.timeCapSeconds)}</p>
+          )}
+          {workout.program && (
+            <p className="mt-1 text-sm text-gray-500">via {workout.program.name}</p>
+          )}
+        </div>
+
+        {/* Result card (logged) or CTAs (not logged) */}
+        {myResult ? (
+          <ResultCard result={myResult} leaderboard={leaderboard} scored={scored} levelLabel={levelLabel} workoutId={workout.id} compact={compact} />
+        ) : (
+          <div className={`flex gap-2 ${compact ? 'flex-row w-full' : 'flex-col md:flex-row items-stretch md:items-center flex-shrink-0'}`}>
+            <Button variant="primary" className={compact ? 'flex-1' : undefined}>
+              <Link to={`/workouts/${workout.id}`} className="contents">Start workout</Link>
+            </Button>
+            <Button variant="secondary">
+              <Link to={`/workouts/${workout.id}`} className="contents">Log result</Link>
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Desktop-only workout detail blocks */}
+      {!compact && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-5">
+          {workout.description && (
+            <div className="bg-gray-800/60 rounded-xl border border-gray-800 p-4">
+              <p className="text-[10px] font-bold tracking-[0.1em] text-gray-500 uppercase mb-2">Workout</p>
+              <p className="text-sm text-gray-200 whitespace-pre-line leading-relaxed">{workout.description}</p>
+            </div>
+          )}
+          {workout.workoutMovements.length > 0 && (
+            <div className="bg-gray-800/60 rounded-xl border border-gray-800 p-4">
+              <p className="text-[10px] font-bold tracking-[0.1em] text-gray-500 uppercase mb-2">Movements</p>
+              <ul className="space-y-1">
+                {workout.workoutMovements.map((wm) => (
+                  <li key={wm.movement.id} className="text-sm text-gray-200 flex items-center gap-2">
+                    <span className="w-1.5 h-1.5 rounded-full bg-gray-600 flex-shrink-0" aria-hidden="true" />
+                    {wm.movement.name}
+                    {wm.sets && <span className="text-gray-500">{wm.sets}×{wm.reps ?? '?'}</span>}
+                    {wm.load && <span className="text-gray-500">{wm.load} {wm.loadUnit?.toLowerCase()}</span>}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Compact: tap-through link */}
+      {compact && (
+        <Link
+          to={`/workouts/${workout.id}`}
+          className="block mb-4 text-sm font-semibold text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          View workout details →
+        </Link>
+      )}
+
+      {/* Participant footer */}
+      <div className="flex items-center justify-between gap-2 pt-4 border-t border-gray-800 text-sm text-gray-400 flex-wrap">
+        <span>
+          <span className="text-white font-semibold">{leaderboard?.totalLogged ?? 0}</span>
+          {gymMemberCount > 0 ? ` of ${gymMemberCount}` : ''} member{gymMemberCount !== 1 ? 's' : ''} logged today
+        </span>
+        <Link
+          to={`/workouts/${workout.id}`}
+          className="font-semibold text-indigo-400 hover:text-indigo-300 transition-colors text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 focus-visible:ring-offset-gray-900 rounded"
+        >
+          See leaderboard →
+        </Link>
+      </div>
+    </article>
+  )
+}
+
+interface ResultCardProps {
+  result: DashboardTodayResult
+  leaderboard: DashboardLeaderboard | null
+  scored: string | null
+  levelLabel: string | null
+  workoutId: string
+  compact: boolean
+}
+
+function ResultCard({ result, leaderboard, scored, levelLabel, workoutId, compact }: ResultCardProps) {
+  const loggedTime = new Date(result.createdAt).toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+
+  if (compact) {
+    return (
+      <div className="w-full bg-gray-800/60 rounded-xl border border-gray-700 px-4 py-3 flex items-center justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-[10px] font-bold tracking-[0.08em] text-emerald-400 uppercase">
+              ✓ Logged {loggedTime}
+            </span>
+          </div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-2xl font-bold text-white leading-none tabular-nums">{scored ?? '—'}</span>
+            {levelLabel && (
+              <span className="text-xs font-bold text-indigo-300">{levelLabel}</span>
+            )}
+          </div>
+        </div>
+        {leaderboard?.rank && (
+          <div className="text-right flex-shrink-0">
+            <div className="text-base font-bold text-white">#{leaderboard.rank}</div>
+            <div className="text-xs text-gray-400">of {leaderboard.totalLogged}</div>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-shrink-0 bg-gray-800/60 rounded-xl border border-gray-700 p-5 min-w-[220px] max-w-[280px]">
+      <div className="flex items-center gap-2 flex-wrap mb-3">
+        <span className="text-xs font-bold tracking-[0.08em] text-emerald-400 uppercase">
+          ✓ Logged · {loggedTime}
+        </span>
+      </div>
+      <div className="flex items-baseline gap-2 mb-2">
+        <span className="text-4xl font-bold text-white leading-none tabular-nums">{scored ?? '—'}</span>
+        {levelLabel && (
+          <span className="text-sm font-bold text-indigo-300">{levelLabel}</span>
+        )}
+      </div>
+      {leaderboard?.rank && (
+        <div className="text-sm text-gray-400">
+          Rank <span className="text-white font-semibold">#{leaderboard.rank}</span> of {leaderboard.totalLogged} today
+          {leaderboard.percentile !== null && ` · top ${100 - leaderboard.percentile}%`}
+        </div>
+      )}
+      <div className="mt-3">
+        <Link
+          to={`/workouts/${workoutId}`}
+          className="text-sm font-semibold text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          View board →
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/WodHeroCard.tsx
+++ b/apps/web/src/components/WodHeroCard.tsx
@@ -86,11 +86,11 @@ export default function WodHeroCard({ workout, myResult, leaderboard, gymMemberC
         {myResult ? (
           <ResultCard result={myResult} leaderboard={leaderboard} scored={scored} levelLabel={levelLabel} workoutId={workout.id} compact={compact} />
         ) : (
-          <div className={`flex gap-2 ${compact ? 'flex-row w-full' : 'flex-col md:flex-row items-stretch md:items-center flex-shrink-0'}`}>
+          <div className={`flex flex-row gap-2 ${compact ? 'w-full' : 'items-center flex-shrink-0'}`}>
             <Button variant="primary" className={compact ? 'flex-1' : undefined}>
               <Link to={`/workouts/${workout.id}`} className="contents">Start workout</Link>
             </Button>
-            <Button variant="secondary">
+            <Button variant="secondary" className={compact ? 'flex-1' : undefined}>
               <Link to={`/workouts/${workout.id}`} className="contents">Log result</Link>
             </Button>
           </div>

--- a/apps/web/src/components/WorkoutDrawer.tsx
+++ b/apps/web/src/components/WorkoutDrawer.tsx
@@ -244,7 +244,6 @@ export default function WorkoutDrawer({ scope, dateKey, workout, workoutsOnDay =
 
   const isEdit = !!localWorkoutId
   const isPublished = localStatus === 'PUBLISHED'
-  const isGymScope = scope.kind === 'gym'
 
   useEffect(() => {
     if (!isOpen) return

--- a/apps/web/src/components/WorkoutDrawer.tsx
+++ b/apps/web/src/components/WorkoutDrawer.tsx
@@ -244,6 +244,7 @@ export default function WorkoutDrawer({ scope, dateKey, workout, workoutsOnDay =
 
   const isEdit = !!localWorkoutId
   const isPublished = localStatus === 'PUBLISHED'
+  const isGymScope = scope.kind === 'gym'
 
   useEffect(() => {
     if (!isOpen) return

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -243,6 +243,30 @@ export interface ResultHistoryPage {
   pages: number
 }
 
+export interface DashboardTodayResult {
+  id: string
+  value: Record<string, unknown>
+  level: WorkoutLevel
+  workoutGender: WorkoutGender
+  primaryScoreKind: string | null
+  primaryScoreValue: number | null
+  createdAt: string
+  notes: string | null
+}
+
+export interface DashboardLeaderboard {
+  rank: number | null
+  totalLogged: number
+  percentile: number | null
+}
+
+export interface DashboardToday {
+  workout: Workout | null
+  myResult: DashboardTodayResult | null
+  leaderboard: DashboardLeaderboard | null
+  gymMemberCount: number
+}
+
 export interface MyGym {
   id: string
   name: string
@@ -558,6 +582,10 @@ export const api = {
   },
 
   gyms: {
+    dashboard: {
+      today: (gymId: string) => req<DashboardToday>(`/api/gyms/${gymId}/dashboard/today`),
+    },
+
     create: (data: { name: string; timezone?: string }, token?: string) =>
       req<Gym>('/api/gyms', { method: 'POST', body: JSON.stringify(data), token }),
 

--- a/apps/web/src/pages/Dashboard.test.tsx
+++ b/apps/web/src/pages/Dashboard.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import Dashboard from './Dashboard'
+import type { DashboardToday } from '../lib/api'
+
+vi.mock('../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/api')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      gyms: {
+        ...actual.api.gyms,
+        dashboard: {
+          today: vi.fn(),
+        },
+      },
+    },
+  }
+})
+
+vi.mock('../context/GymContext', () => ({
+  useGym: () => ({ gymId: 'gym-1', gymRole: 'MEMBER', gyms: [], setGymId: vi.fn(), refreshGyms: vi.fn(), loading: false }),
+}))
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Alex', firstName: 'Alex' } }),
+}))
+
+function renderDashboard() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard']}>
+      <Routes>
+        <Route path="/dashboard" element={<Dashboard />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('Dashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders greeting with first name', async () => {
+    const { api } = await import('../lib/api')
+    vi.mocked(api.gyms.dashboard.today).mockResolvedValue({
+      workout: null,
+      myResult: null,
+      leaderboard: null,
+      gymMemberCount: 0,
+    } satisfies DashboardToday)
+
+    renderDashboard()
+    expect(await screen.findByText(/Good .+, Alex/)).toBeInTheDocument()
+  })
+
+  it('renders empty state when no workout today', async () => {
+    const { api } = await import('../lib/api')
+    vi.mocked(api.gyms.dashboard.today).mockResolvedValue({
+      workout: null,
+      myResult: null,
+      leaderboard: null,
+      gymMemberCount: 0,
+    } satisfies DashboardToday)
+
+    renderDashboard()
+    expect(await screen.findByText('No workout today')).toBeInTheDocument()
+  })
+
+  it('renders WodHeroCard when workout present', async () => {
+    const { api } = await import('../lib/api')
+    vi.mocked(api.gyms.dashboard.today).mockResolvedValue({
+      workout: {
+        id: 'w1',
+        title: 'Fran',
+        description: '21-15-9: Thrusters, Pull-ups',
+        coachNotes: null,
+        type: 'FOR_TIME',
+        status: 'PUBLISHED',
+        scheduledAt: new Date().toISOString(),
+        dayOrder: 0,
+        workoutMovements: [],
+        programId: null,
+        program: null,
+        namedWorkoutId: null,
+        namedWorkout: null,
+        timeCapSeconds: null,
+        tracksRounds: false,
+        _count: { results: 5 },
+        externalSourceId: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      myResult: null,
+      leaderboard: { rank: null, totalLogged: 5, percentile: null },
+      gymMemberCount: 30,
+    } satisfies DashboardToday)
+
+    renderDashboard()
+    expect(await screen.findByText('Fran')).toBeInTheDocument()
+  })
+
+  it('shows social placeholder tile', async () => {
+    const { api } = await import('../lib/api')
+    vi.mocked(api.gyms.dashboard.today).mockResolvedValue({
+      workout: null,
+      myResult: null,
+      leaderboard: null,
+      gymMemberCount: 0,
+    } satisfies DashboardToday)
+
+    renderDashboard()
+    expect(await screen.findByText('Social feed coming soon')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -1,8 +1,97 @@
+import { useEffect, useState } from 'react'
+import { api, type DashboardToday } from '../lib/api.ts'
+import { useGym } from '../context/GymContext.tsx'
+import { useAuth } from '../context/AuthContext.tsx'
+import WodHeroCard from '../components/WodHeroCard.tsx'
+import EmptyState from '../components/ui/EmptyState.tsx'
+import Skeleton from '../components/ui/Skeleton.tsx'
+
 export default function Dashboard() {
+  const { gymId } = useGym()
+  const { user } = useAuth()
+  const [data, setData] = useState<DashboardToday | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!gymId) return
+    setLoading(true)
+    setError(null)
+    api.gyms.dashboard.today(gymId)
+      .then(setData)
+      .catch((e: Error) => setError(e.message ?? 'Failed to load dashboard'))
+      .finally(() => setLoading(false))
+  }, [gymId])
+
+  const greeting = greetingFor(user?.firstName ?? user?.name ?? null)
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-2">Dashboard</h1>
-      <p className="text-gray-400">Workout and member analytics coming in Slice 4.</p>
+    <div className="max-w-6xl mx-auto">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold tracking-tight text-white">{greeting}</h1>
+      </div>
+
+      {/* Main layout: wide main column + narrow right rail on desktop */}
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-5">
+        {/* Main column */}
+        <div className="flex flex-col gap-5 min-w-0">
+          {loading && <Skeleton variant="feed-row" count={1} />}
+
+          {!loading && error && (
+            <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 text-gray-400 text-sm">
+              {error}
+            </div>
+          )}
+
+          {!loading && !error && data?.workout && (
+            <WodHeroCard
+              workout={data.workout}
+              myResult={data.myResult}
+              leaderboard={data.leaderboard}
+              gymMemberCount={data.gymMemberCount}
+            />
+          )}
+
+          {!loading && !error && data && !data.workout && (
+            <EmptyState
+              title="No workout today"
+              body="Your program doesn't have a workout scheduled for today."
+            />
+          )}
+
+          {/* Social feed placeholder — deferred until social features are scoped */}
+          <SocialPlaceholder />
+        </div>
+
+        {/* Right rail — Activity and Upcoming cards land here in later slices */}
+        <div className="hidden lg:flex flex-col gap-5">
+          <RailPlaceholder label="Activity" />
+          <RailPlaceholder label="Coming up" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function greetingFor(firstName: string | null): string {
+  const hour = new Date().getHours()
+  const period = hour < 12 ? 'morning' : hour < 17 ? 'afternoon' : 'evening'
+  return firstName ? `Good ${period}, ${firstName}` : `Good ${period}`
+}
+
+function SocialPlaceholder() {
+  return (
+    <div className="bg-gray-900 border border-gray-800 border-dashed rounded-2xl p-6 flex flex-col items-center justify-center gap-2 text-center min-h-[120px]">
+      <p className="text-sm font-medium text-gray-500">Social feed coming soon</p>
+      <p className="text-xs text-gray-600">See how your gym mates are doing</p>
+    </div>
+  )
+}
+
+function RailPlaceholder({ label }: { label: string }) {
+  return (
+    <div className="bg-gray-900 border border-gray-800 border-dashed rounded-xl p-4 min-h-[80px] flex items-center justify-center">
+      <span className="text-xs text-gray-600">{label}</span>
     </div>
   )
 }


### PR DESCRIPTION
Closes #224 · Part of #222

## What's in this PR

Adds the initial Today dashboard for web and mobile — the new landing page that replaces `/feed` as the default route. This is slice 1 of the Dashboard feature (#222): API endpoint + WOD Hero Card component + page scaffold.

**API** (`apps/api/`)
- `GET /api/gyms/:gymId/dashboard/today` — returns today's hero workout (non-recovery types preferred), the caller's result if logged, a leaderboard position object, and total gym member count. Protected by `requireAuth + validateGymExists + requireGymMembership`.
- `dashboardDbManager.getDashboardToday` — two-pass workout query (prefers non-WARMUP/MOBILITY/COOLDOWN; falls back to any published workout for recovery-only days).

**Web** (`apps/web/`)
- `WodHeroCard` component: accent strip, date header, type badge, benchmark badge, title link, time cap, program attribution, CTA buttons (unlogged) or result card (logged) with rank + percentile, desktop workout description + movement list, participant footer + leaderboard link.
- `Dashboard` page: two-column layout (main + right rail), time-based greeting, skeleton loading state, empty state, social feed placeholder tile, rail placeholders for "Activity" and "Coming up".
- Default route changed from `/feed` to `/dashboard`. Dashboard added to sidebar member links.

**Mobile** (`apps/mobile/`)
- `WodHeroCard` RN component: mirrors the web card using `StyleSheet` and the mobile `workoutTypeStyles` token map.
- `HomeScreen`: `useFocusEffect` reload on tab focus, pull-to-refresh, greeting, shimmer loading, error state.
- `App.tsx`: `HomeTab` added as the first bottom tab (wrapping `HomeStack → HomeScreen`). `HomeStackParamList` type added to param lists.

**Pre-existing bug fixes** (both from #210, caught by typecheck + unit tests):
- `WorkoutDrawer.tsx:679` — `isGymScope` referenced but never defined. Fixed: `const isGymScope = scope.kind === 'gym'`.
- `personalProgramScope.ts` — `publishWorkout` missing from the `ProgramScope` contract. Fixed: added a rejecting stub (personal workouts have no publish lifecycle; the drawer gates this behind `isGymScope`).

## Tests

**Unit** (`apps/web/src/components/WodHeroCard.test.tsx`, `apps/web/src/pages/Dashboard.test.tsx`):
- `WodHeroCard > renders workout title` — title link renders
- `WodHeroCard > shows type badge` — abbreviation badge present
- `WodHeroCard > shows time cap` — "15 min cap" from `timeCapSeconds`
- `WodHeroCard > shows program attribution` — "via Main WOD"
- `WodHeroCard > shows CTA buttons when not logged` — Start workout + Log result
- `WodHeroCard > shows result card when logged` — score + level; CTAs gone
- `WodHeroCard > shows rank and total when logged` — #5 rank displayed
- `WodHeroCard > shows participant count in footer` — count span + "members logged today" label
- `WodHeroCard > shows gym member total in footer when gymMemberCount > 0` — "of 50"
- `WodHeroCard > renders workout description on desktop (not compact)` — description block
- `WodHeroCard > renders compact view without workout blocks` — description hidden, "View workout details →" shown
- `WodHeroCard > shows movement list on desktop` — movement names listed
- `Dashboard > renders greeting with first name` — "Good …, Alex"
- `Dashboard > renders empty state when no workout today` — empty tile
- `Dashboard > renders WodHeroCard when workout present` — title "Fran" visible
- `Dashboard > shows social placeholder tile` — "Social feed coming soon"

**API integration** (`apps/api/tests/`):
- Existing suite: 65 passed, 0 failed

**Playwright E2E** (`apps/web/tests/`):
- Full suite: 42 passed, 0 failed

**Mobile parity:** web and mobile ship together in this PR (confirmed by user — #224 scope).

**Not automated / manual verification needed:**
- [ ] Visual polish: accent strip color, card layout, shimmer animation on device
- [ ] Pull-to-refresh gesture on iOS Simulator
- [ ] Dashboard auto-loads correct today workout based on gym timezone